### PR TITLE
Fix SearchFilter title internationalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix `SearchFilter` title internationalization.
 
 ## [0.3.0] - 2018-6-14
 ### Added

--- a/react/components/SearchFilter.js
+++ b/react/components/SearchFilter.js
@@ -56,7 +56,7 @@ class SearchFilter extends Component {
     const { type, options, getLinkProps } = this.props
     const title =
       this.props.title === CATEGORIES_FILTER_TITLE
-        ? this.props.intl.formatMessage({ id: title })
+        ? this.props.intl.formatMessage({ id: this.props.title })
         : this.props.title
     return (
       <div


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix SearchFilter title internationalization that is breaking the component.

#### What problem is this solving?

The component is not rendering

#### How should this be manually tested?

[Access the workspace](https://estacio--storecomponents.myvtex.com/eletronics/s)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/41621923-75aaaebc-73e4-11e8-99c9-54d3c64ede1a.png)


#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
