### PR TITLE
Add a spinner to be shown when fetching more products.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Add the Infinite Scroll feature to the page.
+- Add a spinner to be shown when fetching more products.
 
 ### Fixed
 - Fix `SearchFilter` title internationalization.

--- a/react/SearchResult.js
+++ b/react/SearchResult.js
@@ -8,7 +8,7 @@ import { getQueryAndMap } from './constants/SearchHelpers'
 
 const DEFAULT_PAGE = 1
 const DEFAULT_MAX_ITEMS_PER_LINE = 5
-const DEFAULT_MAX_ITEMS_PER_PAGE = 10
+const DEFAULT_MAX_ITEMS_PER_PAGE = 3
 
 export default class SearchResult extends Component {
   static propTypes = {

--- a/react/SearchResult.js
+++ b/react/SearchResult.js
@@ -8,7 +8,7 @@ import { getQueryAndMap } from './constants/SearchHelpers'
 
 const DEFAULT_PAGE = 1
 const DEFAULT_MAX_ITEMS_PER_LINE = 5
-const DEFAULT_MAX_ITEMS_PER_PAGE = 3
+const DEFAULT_MAX_ITEMS_PER_PAGE = 10
 
 export default class SearchResult extends Component {
   static propTypes = {

--- a/react/components/SearchResultInfiniteScroll.js
+++ b/react/components/SearchResultInfiniteScroll.js
@@ -38,13 +38,6 @@ const MAP_SEPARATOR = ','
  * Search Result Component.
  */
 class SearchResultInfiniteScroll extends Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      currentPage: props.page,
-    }
-  }
-
   getLinkProps = ({ opt, variables, isSelected, type, pageNumber }) => {
     let { query, map, orderBy } = this.props.searchQuery.variables
     if (variables) {
@@ -186,7 +179,6 @@ class SearchResultInfiniteScroll extends Component {
 
   handleFetchMoreProducts = (prev, { fetchMoreResult }) => {
     if (!fetchMoreResult) return prev
-    this.setState({ currentPage: this.state.currentPage + 1 })
     return {
       ...prev,
       products: [...prev.products, ...fetchMoreResult.products],


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add a spinner to be shown when fetching more products.

#### What problem is this solving?

There was no feedback to the user to show that more products were being loaded.

#### How should this be manually tested?

[Access the workspace](https://estacio--storecomponents.myvtex.com/Eletronics/s?map=c&page=1)

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/15948386/41674803-5daac546-7497-11e8-8841-e74e27a44054.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
