### PR TITLE
Fix SearchResult loading state to show products with the right length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Fix `setContextVariables` function call.
+- Fix SearchResult loading state to not trigger the `fetchMore` function in the first query.
 
 ## [0.4.0] - 2018-6-20
 ### Added

--- a/react/__tests__/components/SearchResultInfiniteScroll.test.js
+++ b/react/__tests__/components/SearchResultInfiniteScroll.test.js
@@ -37,6 +37,9 @@ describe('<SearchResultInfiniteScroll /> component', () => {
         maxItemsPerPage: 10,
         searchQuery: searchQueryMock,
         facetsQuery: facetsQueryMock,
+        state: {
+          loading: false,
+        },
       }
     ) =>
       mount(

--- a/react/components/SearchResultContainer.js
+++ b/react/components/SearchResultContainer.js
@@ -203,7 +203,7 @@ export default class SearchResultContainer extends Component {
     const from = (page - 1) * maxItemsPerPage + 1
     const to = (page - 1) * maxItemsPerPage + products.length
     const selecteds = this.getSelecteds()
-    const isLoading = searchLoading || facetsLoading
+    const isLoading = searchLoading || facetsLoading || this.state.loading
     const recordsFiltered = this.getRecordsFiltered()
 
     return (

--- a/react/components/SearchResultInfiniteScroll.js
+++ b/react/components/SearchResultInfiniteScroll.js
@@ -205,7 +205,8 @@ export default class SearchResultInfiniteScroll extends Component {
       page,
       summary,
     } = this.props
-    const isLoading = searchLoading || facetsLoading
+
+    const isLoading = searchLoading || facetsLoading || this.props.state.loading
     const products = searchedProducts || []
     const from = (page - 1) * maxItemsPerPage + 1
     const to = (page - 1) * maxItemsPerPage + products.length


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix SearchResult loading state to not trigger the fetchMore function in the first query.

#### What problem is this solving?

InfiniteScroll was triggered in the first query result, but this hadn't the right length.

#### How should this be manually tested?

[Access the workspace](https://estacio--storecomponents.myvtex.com/eletronics/d)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/42340240-e39315e4-8065-11e8-949c-2a23710b42a6.png)
![image](https://user-images.githubusercontent.com/15948386/42340256-e8e86ac6-8065-11e8-939a-bb920af2389d.png)


#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
