### PR TITLE
Remove code dependency with the global runtime.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Remove code dependency with the global runtime.
 
 ## [0.5.0] - 2018-7-6
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.5.1] - 2018-07-19
 ### Fixed
 - Remove code dependency with the global runtime.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/components/SearchFilter.js
+++ b/react/components/SearchFilter.js
@@ -94,9 +94,7 @@ class SearchFilter extends Component {
                   {opt.Name}
                 </span>
               </div>
-              <span className="flex items-center f5">
-                ( {opt.Quantity} )
-              </span>
+              <span className="flex items-center f5">( {opt.Quantity} )</span>
             </div>
           </Link>
         )
@@ -130,9 +128,7 @@ class SearchFilter extends Component {
           </div>
         </div>
         <div style={{ overflowY: 'auto', maxHeight: '200px' }}>
-          <Collapse isOpened={opened}>
-            {this.renderOptions()}
-          </Collapse>
+          <Collapse isOpened={opened}>{this.renderOptions()}</Collapse>
         </div>
       </div>
     )

--- a/react/components/SearchResultContainer.js
+++ b/react/components/SearchResultContainer.js
@@ -34,7 +34,7 @@ export default class SearchResultContainer extends Component {
   static propTypes = searchResultPropTypes
 
   getLinkProps = ({ opt, type, isSelected, ordenation, pageNumber }) => {
-    const { path, rest, map, pagesPath } = this.props
+    const { path, rest, map, pagesPath, params } = this.props
     let {
       variables: { orderBy },
     } = this.props.searchQuery
@@ -45,6 +45,7 @@ export default class SearchResultContainer extends Component {
       rest,
       { map, orderBy, pageNumber },
       pagesPath,
+      params,
       isSelected
     )
   }

--- a/react/components/SearchResultInfiniteScroll.js
+++ b/react/components/SearchResultInfiniteScroll.js
@@ -32,7 +32,7 @@ export default class SearchResultInfiniteScroll extends Component {
   static propTypes = searchResultPropTypes
 
   getLinkProps = ({ opt, type, isSelected, ordenation, pageNumber }) => {
-    const { path, rest, map, pagesPath } = this.props
+    const { path, rest, map, pagesPath, params } = this.props
     let {
       variables: { orderBy },
     } = this.props.searchQuery
@@ -43,6 +43,7 @@ export default class SearchResultInfiniteScroll extends Component {
       rest,
       { map, orderBy, pageNumber },
       pagesPath,
+      params,
       isSelected
     )
   }

--- a/react/constants/SearchHelpers.js
+++ b/react/constants/SearchHelpers.js
@@ -1,5 +1,4 @@
 import QueryString from 'query-string'
-import * as RouteParser from 'route-parser'
 
 import SortOptions from './SortOptions'
 
@@ -58,37 +57,24 @@ export function stripPath(pathName) {
     .replace(/\/b$/i, '')
 }
 
-function getPathOfPage(pagesPath) {
-  return global.__RUNTIME__.pages[pagesPath].path
-}
-
-export function reversePagesPath(pagesPath, params) {
-  const Parser = RouteParser.default ? RouteParser.default : RouteParser
-  return new Parser(getPathOfPage(pagesPath)).reverse(params)
-}
-
-function matchPagesPath(pagesPath, pathName) {
-  const Parser = RouteParser.default ? RouteParser.default : RouteParser
-  return new Parser(pagesPath).match(pathName)
-}
-
 function getSpecificationFilterFromLink(link) {
   return `specificationFilter_${link.split('specificationFilter_')[1]}`
 }
 
 export function getPagesArgs(
   { name, type, link },
-  pathName,
+  path,
   rest,
   { map, orderBy, pageNumber = 1 },
   pagesPath,
+  params,
   isUnselectLink
 ) {
   const restValues = (rest && rest.split(',')) || []
   const mapValues = (map && map.split(',')) || []
   if (name) {
     if (isUnselectLink) {
-      const pathValuesLength = stripPath(pathName).split('/').length
+      const pathValuesLength = stripPath(path).split('/').length
       const index = restValues.findIndex(
         item => name.toLowerCase() === item.toLowerCase()
       )
@@ -120,6 +106,5 @@ export function getPagesArgs(
     order: orderBy === SortOptions[0].value ? undefined : orderBy,
     rest: restValues.join(',') || undefined,
   })
-  const params = matchPagesPath(getPathOfPage(pagesPath), pathName)
   return { page: pagesPath, params, queryString }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Remove code dependency with the global runtime.

#### What problem is this solving?

The app should not access the `global.__RUNTIME__`

#### How should this be manually tested?

[Access the workspace](https://estacio--storecomponents.myvtex.com/eletronics/d) and see the filters still working.

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
