### PR TITLE
Remove code dependency with the resolved page path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Remove code dependency with the resolved page path (e.g. `/eletronics/d`).
 
 ## [0.5.1] - 2018-07-19
 ### Fixed

--- a/react/__tests__/components/SearchResultInfiniteScroll.test.js
+++ b/react/__tests__/components/SearchResultInfiniteScroll.test.js
@@ -33,7 +33,9 @@ describe('<SearchResultInfiniteScroll /> component', () => {
         page: 1,
         map: 'c',
         rest: '',
-        path: 'eletronics',
+        params: {
+          department: 'eletronics',
+        },
         maxItemsPerPage: 10,
         searchQuery: searchQueryMock,
         facetsQuery: facetsQueryMock,

--- a/react/components/SearchResultContainer.js
+++ b/react/components/SearchResultContainer.js
@@ -5,7 +5,7 @@ import { Spinner } from 'vtex.styleguide'
 
 import VTEXClasses from '../constants/CSSClasses'
 import { searchResultPropTypes } from '../constants/propTypes'
-import { findInTree, getCategoriesFromQuery, getPagesArgs, stripPath } from '../constants/SearchHelpers'
+import { findInTree, getCategoriesFromQuery, getPagesArgs } from '../constants/SearchHelpers'
 import Gallery from './Gallery'
 import SearchFilter from './SearchFilter'
 import SearchFooter from './SearchFooter'
@@ -24,7 +24,6 @@ const CATEGORIES_FILTER_TYPE = 'Categories'
 const KEY_MAP_CATEGORY = 'c'
 const KEY_MAP_BRAND = 'b'
 const KEY_MAP_TEXT = 'ft'
-const PATH_SEPARATOR = '/'
 const MAP_SEPARATOR = ','
 
 /**
@@ -34,14 +33,13 @@ export default class SearchResultContainer extends Component {
   static propTypes = searchResultPropTypes
 
   getLinkProps = ({ opt, type, isSelected, ordenation, pageNumber }) => {
-    const { path, rest, map, pagesPath, params } = this.props
+    const { rest, map, pagesPath, params } = this.props
     let {
       variables: { orderBy },
     } = this.props.searchQuery
     orderBy = ordenation || orderBy
     return getPagesArgs(
       { name: opt && opt.Name, type, link: opt && opt.Link },
-      path,
       rest,
       { map, orderBy, pageNumber },
       pagesPath,
@@ -131,9 +129,11 @@ export default class SearchResultContainer extends Component {
   }
 
   getSelecteds() {
-    const { rest, path, map } = this.props
+    const { rest, params, map } = this.props
     const restValues = (rest && rest.split(MAP_SEPARATOR)) || []
-    const pathValues = stripPath(path).split(PATH_SEPARATOR)
+    const paramsValues = Object.keys(params).filter(
+      param => !param.startsWith('_')
+    )
     const mapValues = map.split(MAP_SEPARATOR)
     const selecteds = {
       Categories: [],
@@ -143,7 +143,7 @@ export default class SearchResultContainer extends Component {
     }
     restValues.map((term, index) => {
       const termDecoded = decodeURI(term.toUpperCase())
-      const mapValue = mapValues[pathValues.length + index]
+      const mapValue = mapValues[paramsValues.length + index]
 
       switch (mapValue) {
         case KEY_MAP_CATEGORY: {

--- a/react/components/SearchResultInfiniteScroll.js
+++ b/react/components/SearchResultInfiniteScroll.js
@@ -4,7 +4,7 @@ import { Spinner } from 'vtex.styleguide'
 
 import VTEXClasses from '../constants/CSSClasses'
 import { searchResultPropTypes } from '../constants/propTypes'
-import { findInTree, getCategoriesFromQuery, getPagesArgs, stripPath } from '../constants/SearchHelpers'
+import { findInTree, getCategoriesFromQuery, getPagesArgs } from '../constants/SearchHelpers'
 import Gallery from './Gallery'
 import SearchFilter from './SearchFilter'
 import SearchHeader from './SearchHeader'
@@ -22,7 +22,6 @@ const CATEGORIES_FILTER_TYPE = 'Categories'
 const KEY_MAP_CATEGORY = 'c'
 const KEY_MAP_BRAND = 'b'
 const KEY_MAP_TEXT = 'ft'
-const PATH_SEPARATOR = '/'
 const MAP_SEPARATOR = ','
 
 /**
@@ -32,14 +31,13 @@ export default class SearchResultInfiniteScroll extends Component {
   static propTypes = searchResultPropTypes
 
   getLinkProps = ({ opt, type, isSelected, ordenation, pageNumber }) => {
-    const { path, rest, map, pagesPath, params } = this.props
+    const { rest, map, pagesPath, params } = this.props
     let {
       variables: { orderBy },
     } = this.props.searchQuery
     orderBy = ordenation || orderBy
     return getPagesArgs(
       { name: opt && opt.Name, type, link: opt && opt.Link },
-      path,
       rest,
       { map, orderBy, pageNumber },
       pagesPath,
@@ -127,9 +125,11 @@ export default class SearchResultInfiniteScroll extends Component {
   }
 
   getSelecteds() {
-    const { rest, path, map } = this.props
+    const { rest, params, map } = this.props
     const restValues = (rest && rest.split(MAP_SEPARATOR)) || []
-    const pathValues = stripPath(path).split(PATH_SEPARATOR)
+    const paramsValues = Object.keys(params).filter(
+      param => !param.startsWith('_')
+    )
     const mapValues = map.split(MAP_SEPARATOR)
     const selecteds = {
       Categories: [],
@@ -139,7 +139,7 @@ export default class SearchResultInfiniteScroll extends Component {
     }
     restValues.map((term, index) => {
       const termDecoded = decodeURI(term.toUpperCase())
-      const mapValue = mapValues[pathValues.length + index]
+      const mapValue = mapValues[paramsValues.length + index]
 
       switch (mapValue) {
         case KEY_MAP_CATEGORY: {

--- a/react/constants/SearchHelpers.js
+++ b/react/constants/SearchHelpers.js
@@ -2,12 +2,6 @@ import QueryString from 'query-string'
 
 import SortOptions from './SortOptions'
 
-export function joinPathWithRest(path, rest) {
-  let pathValues = stripPath(path).split('/')
-  pathValues = pathValues.concat((rest && rest.split(',')) || [])
-  return pathValues.join('/')
-}
-
 export function getCategoriesFromQuery(query, map) {
   return getValuesByMap(query, map, 'c')
 }
@@ -37,33 +31,12 @@ export function findInTree(tree, values, index) {
   return tree[0]
 }
 
-export function createMap(pathName, rest, isBrand) {
-  let pathValues = stripPath(pathName).split('/')
-  if (rest) pathValues = pathValues.concat(rest.split(','))
-  const map =
-    Array(pathValues.length - 1)
-      .fill('c')
-      .join(',') +
-    (pathValues.length > 1 ? ',' : '') +
-    (isBrand ? 'b' : 'c')
-  return map
-}
-
-export function stripPath(pathName) {
-  return pathName
-    .replace(/^\//i, '')
-    .replace(/\/s$/i, '')
-    .replace(/\/d$/i, '')
-    .replace(/\/b$/i, '')
-}
-
 function getSpecificationFilterFromLink(link) {
   return `specificationFilter_${link.split('specificationFilter_')[1]}`
 }
 
 export function getPagesArgs(
   { name, type, link },
-  path,
   rest,
   { map, orderBy, pageNumber = 1 },
   pagesPath,
@@ -74,13 +47,15 @@ export function getPagesArgs(
   const mapValues = (map && map.split(',')) || []
   if (name) {
     if (isUnselectLink) {
-      const pathValuesLength = stripPath(path).split('/').length
+      const paramsLength = Object.keys(params).filter(
+        param => !param.startsWith('_')
+      ).length
       const index = restValues.findIndex(
         item => name.toLowerCase() === item.toLowerCase()
       )
       if (index !== -1) {
         restValues.splice(index, 1)
-        mapValues.splice(pathValuesLength + index, 1)
+        mapValues.splice(paramsLength + index, 1)
       }
     } else {
       switch (type) {

--- a/react/constants/propTypes.js
+++ b/react/constants/propTypes.js
@@ -125,8 +125,6 @@ export const schemaPropsTypes = {
 export const searchResultPropTypes = {
   /** Internal route path. e.g: 'store/search' */
   pagesPath: PropTypes.string,
-  /** Path param. e.g: eletronics/smartphones */
-  path: PropTypes.string,
   /** Map param. e.g: c,c */
   map: mapType.isRequired,
   /** Rest param. e.g: Android,Samsung */


### PR DESCRIPTION
#### What is the purpose of this pull request?

Remove code dependency with the resolved page path (e.g. /eletronics/d).

#### What problem is this solving?

The app doesn't need to see the resolved path. It can use the params to evaluate things.

#### How should this be manually tested?

[Access the workspace](https://estacio--storecomponents.myvtex.com/eletronics/d?map=c) and see everything working normally

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/42961931-ae3c29c4-8b66-11e8-9fda-cadd0234d5af.png)


#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
