### PR TITLE
Fix empty category array error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.6.1] - 2018-07-24
 ### Fixed
 - Error when trying to access empty array.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Error when trying to access empty array.
 
 ## [0.6.0] - 2018-07-24
 ### Removed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/components/SearchResultInfiniteScroll.js
+++ b/react/components/SearchResultInfiniteScroll.js
@@ -54,6 +54,11 @@ export default class SearchResultInfiniteScroll extends Component {
       },
     } = this.props
     const { CategoriesTrees: tree } = facets
+
+    if (!tree || tree.length === 0) {
+      return []
+    }
+
     const [{ Children: children }] = tree
     const categories = getCategoriesFromQuery(query, rest, map)
     const category = findInTree(tree, categories, 0)


### PR DESCRIPTION
#### What is the purpose of this pull request?
Return empty array if `tree` is empty.

#### What problem is this solving?
When the search result returned no products, an error was being thrown for accessing an undefined item on the `tree` array.

#### How should this be manually tested?
[Workspace](https://lucas--storecomponents.myvtex.com/samsung/s?map=ft)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
