### PR TITLE
Fix checkbox position in chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Checkbox position in chrome.
 
 ## [1.0.0] - 2018-08-24
 ### Changed

--- a/react/components/SelectedFilters.js
+++ b/react/components/SelectedFilters.js
@@ -57,7 +57,7 @@ class SelectedFilters extends Component {
                   <Check size={16} />
                 </div>
                 <input
-                  className="mr2 o-0"
+                  className="mr2 o-0 vtex-selected-filter__checkbox"
                   type="checkbox"
                   value=""
                   onChange={e => e.preventDefault()}

--- a/react/global.css
+++ b/react/global.css
@@ -103,6 +103,11 @@ body.vtex-filter-popup-open {
   transform: rotate(270deg);
 }
 
+.vtex-selected-filter__checkbox {
+  height: 1rem;
+  width: 1rem;
+}
+
 @media only screen and (max-width: 60em) {
   .vtex-search-result {
     grid-template-columns: 180px repeat(5, auto);


### PR DESCRIPTION
#### What is the purpose of this pull request?
Set a explicit width and height to the checkbox input (1rem).

#### What problem is this solving?
The checkbox on the selected filters looked weird in the chrome browser.

#### How should this be manually tested?
[Workspace](https://chromefix--storecomponents.myvtex.com/eletronicos/smartphones?map=c%2Cc%2CspecificationFilter_20&rest=Android%207.0). Don't think I need to mention that you need to access in chrome to see the fix, but here I am.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
