### PR TITLE
Add content loader on filter facets

### DIFF
--- a/.vtexignore
+++ b/.vtexignore
@@ -1,3 +1,4 @@
 react/__mocks__/
 react/__tests__/
+react/node_modules/
 react/test-setup.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Content loader on filter facets app.
 
 ## [1.1.0] - 2018-09-06
 ### Added

--- a/react/components/FiltersContainer.js
+++ b/react/components/FiltersContainer.js
@@ -2,6 +2,7 @@
 import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
 import { flatten } from 'ramda'
+import ContentLoader from 'react-content-loader'
 
 import SelectedFilters from './SelectedFilters'
 import AvailableFilters from './AvailableFilters'
@@ -45,6 +46,7 @@ export default class FiltersContainer extends Component {
     map: PropTypes.string.isRequired,
     /** Rest query parameter */
     rest: PropTypes.string.isRequired,
+    loading: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -52,6 +54,7 @@ export default class FiltersContainer extends Component {
     specificationFilters: [],
     priceRanges: [],
     brands: [],
+    loading: false,
   }
 
   get availableCategories() {
@@ -114,7 +117,44 @@ export default class FiltersContainer extends Component {
       map,
       rest,
       getLinkProps,
+      loading,
     } = this.props
+
+    if (loading) {
+      return (
+        <ContentLoader
+          style={{
+            width: '100%',
+            height: '100%',
+          }}
+          width="100%"
+          height="100%"
+          y="0"
+          x="0"
+        >
+          <rect
+            width="100%"
+            height="1em"
+          />
+          <rect
+            width="100%"
+            height="8em"
+            y="1.5em"
+          />
+          <rect
+            width="100%"
+            height="1em"
+            y="10.5em"
+          />
+          <rect
+            width="100%"
+            height="8em"
+            y="12em"
+          />
+        </ContentLoader>
+      )
+    }
+
     const categories = this.availableCategories
 
     const filters = [

--- a/react/components/SearchResultInfiniteScroll.js
+++ b/react/components/SearchResultInfiniteScroll.js
@@ -141,7 +141,7 @@ export default class SearchResultInfiniteScroll extends Component {
         } = {},
         products = [],
         recordsFiltered = 0,
-        loading: searchLoading,
+        loading,
         fetchMore,
       },
       orderBy,
@@ -154,7 +154,7 @@ export default class SearchResultInfiniteScroll extends Component {
       priceRange,
     } = this.props
 
-    const isLoading = searchLoading || this.props.loading
+    const isLoading = loading || this.props.loading
     const to = (page - 1) * maxItemsPerPage + products.length
 
     return (
@@ -199,6 +199,7 @@ export default class SearchResultInfiniteScroll extends Component {
                 rest={rest}
                 specificationFilters={SpecificationFilters}
                 tree={CategoriesTrees}
+                loading={isLoading && !this.state.fetchMoreLoading}
               />
             </div>
             <div className="vtex-search-result__border" />

--- a/react/package.json
+++ b/react/package.json
@@ -12,6 +12,7 @@
     "query-string": "^6.1.0",
     "ramda": "^0.25.0",
     "react-collapse": "^4.0.3",
+    "react-content-loader": "^3.1.2",
     "react-infinite-scroll-component": "^4.1.0",
     "react-motion": "^0.5.2"
   },

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -3421,6 +3421,10 @@ react-collapse@^4.0.3:
   dependencies:
     prop-types "^15.5.8"
 
+react-content-loader@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/react-content-loader/-/react-content-loader-3.1.2.tgz#98230b4604b4b744eaa2d3fc88917dd988df6766"
+
 react-dom@^16.3.1:
   version "16.4.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.0.tgz#099f067dd5827ce36a29eaf9a6cdc7cbf6216b1e"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add a content loader on the filter facets while the result of the search is loading.

#### What problem is this solving?
Fixes #34.

#### How should this be manually tested?
[Access the workspace](https://filterloader--storecomponents.myvtex.com/eletronicos/smartphones?map=c%2Cc).

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/10223856/45162508-8ce00c80-b1c4-11e8-9184-59ec01d4e0b7.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
