### PR TITLE
Fix filter content loader height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Update the `vtex.product-summary` version.
 
+### Fixed
+- Filter content loader height and width.
+
 ## [1.1.1] - 2018-09-06
 ### Added
 - Content loader on filter facets app.

--- a/react/components/FiltersContainer.js
+++ b/react/components/FiltersContainer.js
@@ -127,8 +127,8 @@ export default class FiltersContainer extends Component {
             width: '100%',
             height: '100%',
           }}
-          width="100%"
-          height="100%"
+          width="267"
+          height="320"
           y="0"
           x="0"
         >


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change the content loader svg height to actually match the defined loader.

#### What problem is this solving?
The content loader was truncated because the generated viewBox property was incorrect (`0 0 100% 100%`)

#### How should this be manually tested?
[Workspace](https://lucas--storecomponents.myvtex.com/eletronicos/d).

#### Screenshots or example usage
![screenshot from 2018-09-11 09-00-05](https://user-images.githubusercontent.com/10223856/45358839-1dda2d80-b5a1-11e8-9aec-aa5204993ed7.png)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
