### PR TITLE
Add the possibility to hide the search-result facets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ node_modules/
 docs/_book/
 .tmp
 .idea
+.vscode
 npm-debug.log
 .build/
 lib

--- a/react/components/FiltersContainer.js
+++ b/react/components/FiltersContainer.js
@@ -69,6 +69,7 @@ export default class FiltersContainer extends Component {
     priceRanges: [],
     brands: [],
     loading: false,
+    hiddenFacets: {},
   }
 
   get availableCategories() {

--- a/react/components/FiltersContainer.js
+++ b/react/components/FiltersContainer.js
@@ -1,13 +1,17 @@
 /* global __RUNTIME__ */
 import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
-import { flatten } from 'ramda'
+import { flatten, identity } from 'ramda'
 import ContentLoader from 'react-content-loader'
 
 import SelectedFilters from './SelectedFilters'
 import AvailableFilters from './AvailableFilters'
 import AccordionFilterContainer from './AccordionFilterContainer'
-import { formatCategoriesTree, mountOptions, getMapByType } from '../constants/SearchHelpers'
+import {
+  formatCategoriesTree,
+  mountOptions,
+  getMapByType,
+} from '../constants/SearchHelpers'
 import { facetOptionShape, paramShape } from '../constants/propTypes'
 
 export const CATEGORIES_TYPE = 'Categories'
@@ -34,10 +38,12 @@ export default class FiltersContainer extends Component {
     /** List of brand filters (e.g. Samsung) */
     brands: PropTypes.arrayOf(facetOptionShape),
     /** List of specification filters (e.g. Android 7.0) */
-    specificationFilters: PropTypes.arrayOf(PropTypes.shape({
-      name: PropTypes.string.isRequired,
-      facets: PropTypes.arrayOf(facetOptionShape),
-    })),
+    specificationFilters: PropTypes.arrayOf(
+      PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        facets: PropTypes.arrayOf(facetOptionShape),
+      })
+    ),
     /** List of price ranges filters (e.g. from-0-to-100) */
     priceRanges: PropTypes.arrayOf(facetOptionShape),
     /** Current price range filter query parameter */
@@ -46,7 +52,15 @@ export default class FiltersContainer extends Component {
     map: PropTypes.string.isRequired,
     /** Rest query parameter */
     rest: PropTypes.string.isRequired,
+    /** Loading indicator */
     loading: PropTypes.bool,
+    /** Indicates which facets will be hidden */
+    hiddenFacets: PropTypes.shape({
+      brands: PropTypes.bool,
+      priceRange: PropTypes.bool,
+      specificationFilters: PropTypes.bool,
+      categories: PropTypes.bool,
+    }),
   }
 
   static defaultProps = {
@@ -63,8 +77,7 @@ export default class FiltersContainer extends Component {
 
     const categoriesCount = this.props.map
       .split(',')
-      .filter(m => m === getMapByType(CATEGORIES_TYPE))
-      .length
+      .filter(m => m === getMapByType(CATEGORIES_TYPE)).length
 
     const currentPath = [params.department, params.category, params.subcategory]
       .filter(v => v)
@@ -86,13 +99,7 @@ export default class FiltersContainer extends Component {
   }
 
   get selectedFilters() {
-    const {
-      brands,
-      specificationFilters,
-      priceRanges,
-      map,
-      rest,
-    } = this.props
+    const { brands, specificationFilters, priceRanges, map, rest } = this.props
 
     const categories = this.categories
 
@@ -118,6 +125,7 @@ export default class FiltersContainer extends Component {
       rest,
       getLinkProps,
       loading,
+      hiddenFacets,
     } = this.props
 
     if (loading) {
@@ -130,56 +138,44 @@ export default class FiltersContainer extends Component {
           width="100%"
           height="100%"
           y="0"
-          x="0"
-        >
-          <rect
-            width="100%"
-            height="1em"
-          />
-          <rect
-            width="100%"
-            height="8em"
-            y="1.5em"
-          />
-          <rect
-            width="100%"
-            height="1em"
-            y="10.5em"
-          />
-          <rect
-            width="100%"
-            height="8em"
-            y="12em"
-          />
+          x="0">
+          <rect width="100%" height="1em" />
+          <rect width="100%" height="8em" y="1.5em" />
+          <rect width="100%" height="1em" y="10.5em" />
+          <rect width="100%" height="8em" y="12em" />
         </ContentLoader>
       )
     }
 
     const categories = this.availableCategories
 
+    const mappedSpecificationFilters = !hiddenFacets.specificationFilters
+      ? specificationFilters.map(spec => ({
+          type: SPECIFICATION_FILTERS_TYPE,
+          title: spec.name,
+          options: spec.facets,
+        }))
+      : []
+
     const filters = [
-      {
+      !hiddenFacets.categories && {
         type: CATEGORIES_TYPE,
         title: CATEGORIES_TITLE,
         options: categories,
         oneSelectedCollapse: true,
       },
-      ...specificationFilters.map(spec => ({
-        type: SPECIFICATION_FILTERS_TYPE,
-        title: spec.name,
-        options: spec.facets,
-      })),
-      {
+      ...mappedSpecificationFilters,
+      !hiddenFacets.brands && {
         type: BRANDS_TYPE,
         title: BRANDS_TITLE,
         options: brands,
       },
-      {
+      !hiddenFacets.priceRange && {
         type: PRICE_RANGES_TYPE,
         title: PRICE_RANGES_TITLE,
         options: priceRanges,
       },
-    ]
+    ].filter(identity)
 
     if (__RUNTIME__.hints.mobile) {
       return (

--- a/react/components/FiltersContainer.js
+++ b/react/components/FiltersContainer.js
@@ -12,7 +12,7 @@ import {
   mountOptions,
   getMapByType,
 } from '../constants/SearchHelpers'
-import { facetOptionShape, paramShape } from '../constants/propTypes'
+import { facetOptionShape, paramShape, hiddenFacetsSchema } from '../constants/propTypes'
 
 export const CATEGORIES_TYPE = 'Categories'
 export const BRANDS_TYPE = 'Brands'
@@ -54,13 +54,7 @@ export default class FiltersContainer extends Component {
     rest: PropTypes.string.isRequired,
     /** Loading indicator */
     loading: PropTypes.bool,
-    /** Indicates which facets will be hidden */
-    hiddenFacets: PropTypes.shape({
-      brands: PropTypes.bool,
-      priceRange: PropTypes.bool,
-      specificationFilters: PropTypes.bool,
-      categories: PropTypes.bool,
-    }),
+    ...hiddenFacetsSchema
   }
 
   static defaultProps = {

--- a/react/components/FiltersContainer.js
+++ b/react/components/FiltersContainer.js
@@ -139,7 +139,8 @@ export default class FiltersContainer extends Component {
           width="100%"
           height="100%"
           y="0"
-          x="0">
+          x="0"
+        >
           <rect width="100%" height="1em" />
           <rect width="100%" height="8em" y="1.5em" />
           <rect width="100%" height="1em" y="10.5em" />

--- a/react/components/FiltersContainer.js
+++ b/react/components/FiltersContainer.js
@@ -1,7 +1,7 @@
 /* global __RUNTIME__ */
 import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
-import { flatten, identity } from 'ramda'
+import { flatten, path, identity, contains } from 'ramda'
 import ContentLoader from 'react-content-loader'
 
 import SelectedFilters from './SelectedFilters'
@@ -150,9 +150,14 @@ export default class FiltersContainer extends Component {
     }
 
     const categories = this.availableCategories
+    const hiddenFacetsNames = (
+        path(['specificationFilters', 'hiddenFilters'], hiddenFacets) || []
+      ).map(filter => filter.name)
 
-    const mappedSpecificationFilters = !hiddenFacets.specificationFilters
-      ? specificationFilters.map(spec => ({
+    const mappedSpecificationFilters = !path(['specificationFilters', 'hideAll'], hiddenFacets)
+      ? specificationFilters.filter(
+          spec => !contains(spec.name, hiddenFacetsNames)
+        ).map(spec => ({
           type: SPECIFICATION_FILTERS_TYPE,
           title: spec.name,
           options: spec.facets,

--- a/react/components/SearchResultInfiniteScroll.js
+++ b/react/components/SearchResultInfiniteScroll.js
@@ -158,20 +158,11 @@ export default class SearchResultInfiniteScroll extends Component {
       rest,
       params,
       priceRange,
-      hideBrands,
-      hideCategories,
-      hideRange,
-      hideSpecification,
+      hiddenFacets
     } = this.props
 
     const isLoading = loading || this.props.loading
     const to = (page - 1) * maxItemsPerPage + products.length
-    const hiddenFacets = {
-      brands: hideBrands,
-      priceRange: hideRange,
-      specificationFilters: hideSpecification,
-      categories: hideCategories,
-    }
 
     return (
       <PopupProvider>

--- a/react/components/SearchResultInfiniteScroll.js
+++ b/react/components/SearchResultInfiniteScroll.js
@@ -190,7 +190,8 @@ export default class SearchResultInfiniteScroll extends Component {
               updateQuery: this.handleFetchMoreProducts,
             })
           }}
-          hasMore={products.length < recordsFiltered}>
+          hasMore={products.length < recordsFiltered}
+        >
           <div className="vtex-search-result vtex-search-result--infinite-scroll pv5 ph9-l ph7-m ph5-s">
             <div className="vtex-search-result__breadcrumb">
               <ExtensionPoint id="breadcrumb" {...this.breadcrumbsProps} />
@@ -198,7 +199,8 @@ export default class SearchResultInfiniteScroll extends Component {
             <div className="vtex-search-result__total-products">
               <FormattedMessage
                 id="search.total-products"
-                values={{ recordsFiltered }}>
+                values={{ recordsFiltered }}
+              >
                 {txt => <span className="ph4 black-50">{txt}</span>}
               </FormattedMessage>
             </div>

--- a/react/components/SearchResultInfiniteScroll.js
+++ b/react/components/SearchResultInfiniteScroll.js
@@ -44,12 +44,7 @@ export default class SearchResultInfiniteScroll extends Component {
   }
 
   getLinkProps = (spec, useEmptyMapAndRest = false) => {
-    const {
-      rest,
-      map,
-      pagesPath,
-      params,
-    } = this.props
+    const { rest, map, pagesPath, params } = this.props
     const filters = Array.isArray(spec) ? spec : [spec]
 
     if (filters.length === 0) {
@@ -61,7 +56,16 @@ export default class SearchResultInfiniteScroll extends Component {
 
     const pageProps = filters.reduce(
       (linkProps, filter) => {
-        const { type, ordenation, pageNumber, isSelected, path, name, link, slug } = filter
+        const {
+          type,
+          ordenation,
+          pageNumber,
+          isSelected,
+          path,
+          name,
+          link,
+          slug,
+        } = filter
         const order = ordenation || linkProps.query.order
 
         return getPagesArgs({
@@ -86,7 +90,9 @@ export default class SearchResultInfiniteScroll extends Component {
         query: {
           order: this.props.orderBy,
           map: useEmptyMapAndRest
-            ? getBaseMap(map, rest).split(',').filter(x => x)
+            ? getBaseMap(map, rest)
+                .split(',')
+                .filter(x => x)
             : map.split(','),
           rest: useEmptyMapAndRest ? [] : rest.split(',').filter(x => x),
         },
@@ -152,10 +158,20 @@ export default class SearchResultInfiniteScroll extends Component {
       rest,
       params,
       priceRange,
+      hideBrands,
+      hideCategories,
+      hideRange,
+      hideSpecification,
     } = this.props
 
     const isLoading = loading || this.props.loading
     const to = (page - 1) * maxItemsPerPage + products.length
+    const hiddenFacets = {
+      brands: hideBrands,
+      priceRange: hideRange,
+      specificationFilters: hideSpecification,
+      categories: hideCategories,
+    }
 
     return (
       <PopupProvider>
@@ -174,8 +190,7 @@ export default class SearchResultInfiniteScroll extends Component {
               updateQuery: this.handleFetchMoreProducts,
             })
           }}
-          hasMore={products.length < recordsFiltered}
-        >
+          hasMore={products.length < recordsFiltered}>
           <div className="vtex-search-result vtex-search-result--infinite-scroll pv5 ph9-l ph7-m ph5-s">
             <div className="vtex-search-result__breadcrumb">
               <ExtensionPoint id="breadcrumb" {...this.breadcrumbsProps} />
@@ -183,8 +198,7 @@ export default class SearchResultInfiniteScroll extends Component {
             <div className="vtex-search-result__total-products">
               <FormattedMessage
                 id="search.total-products"
-                values={{ recordsFiltered }}
-              >
+                values={{ recordsFiltered }}>
                 {txt => <span className="ph4 black-50">{txt}</span>}
               </FormattedMessage>
             </div>
@@ -199,15 +213,13 @@ export default class SearchResultInfiniteScroll extends Component {
                 rest={rest}
                 specificationFilters={SpecificationFilters}
                 tree={CategoriesTrees}
+                hiddenFacets={hiddenFacets}
                 loading={isLoading && !this.state.fetchMoreLoading}
               />
             </div>
             <div className="vtex-search-result__border" />
             <div className="vtex-search-result__order-by">
-              <OrderBy
-                orderBy={orderBy}
-                getLinkProps={this.getLinkProps}
-              />
+              <OrderBy orderBy={orderBy} getLinkProps={this.getLinkProps} />
             </div>
             <div className="vtex-search-result__gallery">
               {isLoading && !this.state.fetchMoreLoading ? (

--- a/react/constants/propTypes.js
+++ b/react/constants/propTypes.js
@@ -133,11 +133,23 @@ export const mapType = PropTypes.string
 
 export const orderType = PropTypes.string
 
+export const schemaLayoutPropTypes = {
+  /** Determines if the brands facets will be hidden */
+  hideBrands: PropTypes.bool,
+  /** Determines if the categories facets will be hidden */
+  hideCategories: PropTypes.bool,
+  /** Determines if the price range will be hidden */
+  hideRange: PropTypes.bool,
+  /** Determines if the specification filters facets will be hidden */
+  hideSpecification: PropTypes.bool,
+}
+
 export const schemaPropsTypes = {
   /** Maximum number of items per page. */
   maxItemsPerPage: PropTypes.number,
   /** Product Summary's props */
   summary: PropTypes.any,
+  ...schemaLayoutPropTypes,
 }
 
 export const searchResultPropTypes = {

--- a/react/constants/propTypes.js
+++ b/react/constants/propTypes.js
@@ -134,6 +134,7 @@ export const mapType = PropTypes.string
 export const orderType = PropTypes.string
 
 export const hiddenFacetsSchema = {
+  /** Indicates which facets will be hidden */
   hiddenFacets: PropTypes.shape({
     /** Determines if the brands facets will be hidden */
     brands: PropTypes.bool,

--- a/react/constants/propTypes.js
+++ b/react/constants/propTypes.js
@@ -133,19 +133,35 @@ export const mapType = PropTypes.string
 
 export const orderType = PropTypes.string
 
+export const hiddenFacetsSchema = {
+  hiddenFacets: PropTypes.shape({
+    /** Determines if the brands facets will be hidden */
+    brands: PropTypes.bool,
+    /** Determines if the categories facets will be hidden */
+    categories: PropTypes.bool,
+    /** Determines if the price range will be hidden */
+    priceRange: PropTypes.bool,
+    /** Hidden specification filters facets configuration */
+    specificationFilters: PropTypes.shape({
+      /** Determines if all the specification filters facets will be hidden */
+      hideAll: PropTypes.bool,
+      /** Array of specific hidden filters */
+      hiddenFilters: PropTypes.arrayOf(
+        PropTypes.shape({
+          /** Name of the hidden filter */
+          name: PropTypes.string,
+        })
+      ),
+    }),
+  })
+}
+
 export const schemaPropsTypes = {
   /** Maximum number of items per page. */
   maxItemsPerPage: PropTypes.number,
   /** Product Summary's props */
   summary: PropTypes.any,
-  /** Determines if the brands facets will be hidden */
-  brands: PropTypes.bool,
-  /** Determines if the categories facets will be hidden */
-  categories: PropTypes.bool,
-  /** Determines if the price range will be hidden */
-  priceRange: PropTypes.bool,
-  /** Determines if the specification filters facets will be hidden */
-  specificationFilters: PropTypes.bool,
+  ...hiddenFacetsSchema,
 }
 
 export const searchResultPropTypes = {

--- a/react/constants/propTypes.js
+++ b/react/constants/propTypes.js
@@ -133,7 +133,11 @@ export const mapType = PropTypes.string
 
 export const orderType = PropTypes.string
 
-export const schemaLayoutPropTypes = {
+export const schemaPropsTypes = {
+  /** Maximum number of items per page. */
+  maxItemsPerPage: PropTypes.number,
+  /** Product Summary's props */
+  summary: PropTypes.any,
   /** Determines if the brands facets will be hidden */
   hideBrands: PropTypes.bool,
   /** Determines if the categories facets will be hidden */
@@ -142,14 +146,6 @@ export const schemaLayoutPropTypes = {
   hideRange: PropTypes.bool,
   /** Determines if the specification filters facets will be hidden */
   hideSpecification: PropTypes.bool,
-}
-
-export const schemaPropsTypes = {
-  /** Maximum number of items per page. */
-  maxItemsPerPage: PropTypes.number,
-  /** Product Summary's props */
-  summary: PropTypes.any,
-  ...schemaLayoutPropTypes,
 }
 
 export const searchResultPropTypes = {

--- a/react/constants/propTypes.js
+++ b/react/constants/propTypes.js
@@ -139,13 +139,13 @@ export const schemaPropsTypes = {
   /** Product Summary's props */
   summary: PropTypes.any,
   /** Determines if the brands facets will be hidden */
-  hideBrands: PropTypes.bool,
+  brands: PropTypes.bool,
   /** Determines if the categories facets will be hidden */
-  hideCategories: PropTypes.bool,
+  categories: PropTypes.bool,
   /** Determines if the price range will be hidden */
-  hideRange: PropTypes.bool,
+  priceRange: PropTypes.bool,
   /** Determines if the specification filters facets will be hidden */
-  hideSpecification: PropTypes.bool,
+  specificationFilters: PropTypes.bool,
 }
 
 export const searchResultPropTypes = {

--- a/react/index.js
+++ b/react/index.js
@@ -3,8 +3,8 @@ import './global.css'
 import React, { Component } from 'react'
 import ProductSummary from 'vtex.product-summary/index'
 
-import SearchResultInfiniteScroll from './components/SearchResultInfiniteScroll'
 import { SORT_OPTIONS } from './components/OrderBy'
+import SearchResultInfiniteScroll from './components/SearchResultInfiniteScroll'
 import { searchResultPropTypes } from './constants/propTypes'
 
 const DEFAULT_MAX_ITEMS_PER_PAGE = 10
@@ -47,6 +47,26 @@ export default class SearchResult extends Component {
           type: 'number',
           default: DEFAULT_MAX_ITEMS_PER_PAGE,
         },
+        hideBrands: {
+          title: 'editor.search-result.hideBrands',
+          type: 'boolean',
+          isLayout: true,
+        },
+        hideCategories: {
+          title: 'editor.search-result.hideCategories',
+          type: 'boolean',
+          isLayout: true,
+        },
+        hideRange: {
+          title: 'editor.search-result.hideRange',
+          type: 'boolean',
+          isLayout: true,
+        },
+        hideSpecification: {
+          title: 'editor.search-result.hideSpecification',
+          type: 'boolean',
+          isLayout: true,
+        },
         summary: {
           title: 'editor.search-result.summary.title',
           type: 'object',
@@ -57,10 +77,6 @@ export default class SearchResult extends Component {
   }
 
   render() {
-    return (
-      <SearchResultInfiniteScroll
-        {...this.props}
-      />
-    )
+    return <SearchResultInfiniteScroll {...this.props} />
   }
 }

--- a/react/index.js
+++ b/react/index.js
@@ -47,25 +47,32 @@ export default class SearchResult extends Component {
           type: 'number',
           default: DEFAULT_MAX_ITEMS_PER_PAGE,
         },
-        hideBrands: {
-          title: 'editor.search-result.hideBrands',
-          type: 'boolean',
+        hiddenFacets: {
+          title: 'editor.search-result.hiddenFacets',
+          type: 'object',
           isLayout: true,
-        },
-        hideCategories: {
-          title: 'editor.search-result.hideCategories',
-          type: 'boolean',
-          isLayout: true,
-        },
-        hideRange: {
-          title: 'editor.search-result.hideRange',
-          type: 'boolean',
-          isLayout: true,
-        },
-        hideSpecification: {
-          title: 'editor.search-result.hideSpecification',
-          type: 'boolean',
-          isLayout: true,
+          properties: {
+            brands: {
+              title: 'editor.search-result.hiddenFacets.brands',
+              type: 'boolean',
+              isLayout: true,
+            },
+            categories: {
+              title: 'editor.search-result.hiddenFacets.categories',
+              type: 'boolean',
+              isLayout: true,
+            },
+            priceRange: {
+              title: 'editor.search-result.hiddenFacets.priceRange',
+              type: 'boolean',
+              isLayout: true,
+            },
+            specificationFilters: {
+              title: 'editor.search-result.hiddenFacets.specificationFilters',
+              type: 'boolean',
+              isLayout: true,
+            },
+          },
         },
         summary: {
           title: 'editor.search-result.summary.title',

--- a/react/index.js
+++ b/react/index.js
@@ -69,8 +69,31 @@ export default class SearchResult extends Component {
             },
             specificationFilters: {
               title: 'editor.search-result.hiddenFacets.specificationFilters',
-              type: 'boolean',
+              type: 'object',
               isLayout: true,
+              properties: {
+                hideAll: {
+                  title: 'editor.search-result.hiddenFacets.specificationFilters.hideAll',
+                  type: 'boolean',
+                  isLayout: true,
+                },
+                hiddenFilters: {
+                  type: 'array',
+                  isLayout: true,
+                  items: {
+                    title: 'editor.search-result.hiddenFacets.specificationFilters.hiddenFilter',
+                    type: 'object',
+                    isLayout: true,
+                    properties: {
+                      name: {
+                        title: 'editor.search-result.hiddenFacets.specificationFilters.hiddenFilter.name',
+                        type: 'string',
+                        isLayout: true,
+                      },
+                    },
+                  },
+                },
+              },
             },
           },
         },

--- a/react/locales/en-US.json
+++ b/react/locales/en-US.json
@@ -17,9 +17,13 @@
   "ordenation.price.ascending": "Price: Low to High",
   "ordenation.name.ascending": "Name, ascending",
   "ordenation.name.descending": "Name, descending",
-  "editor.search-result.title" : "Search Result",
-  "editor.search-result.description" : "Search Result Wrapper",
-  "editor.search-result.maxItemsPerLine.title" : "Maximum number of items per line",
-  "editor.search-result.maxItemsPerPage.title" : "Maximum number of items per page",
-  "editor.search-result.summary.title" : "Product Summary"
+  "editor.search-result.title": "Search Result",
+  "editor.search-result.description": "Search Result Wrapper",
+  "editor.search-result.maxItemsPerLine.title": "Maximum number of items per line",
+  "editor.search-result.maxItemsPerPage.title": "Maximum number of items per page",
+  "editor.search-result.summary.title": "Product Summary",
+  "editor.search-result.hideBrands": "Hide Brands filter",
+  "editor.search-result.hideCategories": "Hide Categories filter",
+  "editor.search-result.hideRange": "Hide Price filter",
+  "editor.search-result.hideSpecification": "Hide Specifications filter"
 }

--- a/react/locales/en-US.json
+++ b/react/locales/en-US.json
@@ -26,5 +26,8 @@
   "editor.search-result.hiddenFacets.brands": "Hide Brands filter",
   "editor.search-result.hiddenFacets.categories": "Hide Categories filter",
   "editor.search-result.hiddenFacets.priceRange": "Hide Price filter",
-  "editor.search-result.hiddenFacets.specificationFilters": "Hide Specifications filters"
+  "editor.search-result.hiddenFacets.specificationFilters": "Hide Specifications filters",
+  "editor.search-result.hiddenFacets.specificationFilters.hideAll": "Hide all the Specifications filters",
+  "editor.search-result.hiddenFacets.specificationFilters.hiddenFilter": "Hidden Specification filter",
+  "editor.search-result.hiddenFacets.specificationFilters.hiddenFilter.name": "Hidden Specification filter name"
 }

--- a/react/locales/en-US.json
+++ b/react/locales/en-US.json
@@ -22,8 +22,9 @@
   "editor.search-result.maxItemsPerLine.title": "Maximum number of items per line",
   "editor.search-result.maxItemsPerPage.title": "Maximum number of items per page",
   "editor.search-result.summary.title": "Product Summary",
-  "editor.search-result.hideBrands": "Hide Brands filter",
-  "editor.search-result.hideCategories": "Hide Categories filter",
-  "editor.search-result.hideRange": "Hide Price filter",
-  "editor.search-result.hideSpecification": "Hide Specifications filter"
+  "editor.search-result.hiddenFacets": "Hidden Filters",
+  "editor.search-result.hiddenFacets.brands": "Hide Brands filter",
+  "editor.search-result.hiddenFacets.categories": "Hide Categories filter",
+  "editor.search-result.hiddenFacets.priceRange": "Hide Price filter",
+  "editor.search-result.hiddenFacets.specificationFilters": "Hide Specifications filters"
 }

--- a/react/locales/es-AR.json
+++ b/react/locales/es-AR.json
@@ -26,5 +26,8 @@
   "editor.search-result.hiddenFacets.brands": "Ocultar filtro de Marcas",
   "editor.search-result.hiddenFacets.categories": "Ocultar filtro de Categorías",
   "editor.search-result.hiddenFacets.priceRange": "Ocultar filtro de Precio",
-  "editor.search-result.hiddenFacets.specificationFilters": "Ocultar filtros de especificaciones"
+  "editor.search-result.hiddenFacets.specificationFilters": "Ocultar filtros de especificaciones",
+  "editor.search-result.hiddenFacets.specificationFilters.hideAll": "Ocultar todos los filtros de especificaciones",
+  "editor.search-result.hiddenFacets.specificationFilters.hiddenFilter": "Filtro de Especificaciones oculto",
+  "editor.search-result.hiddenFacets.specificationFilters.hiddenFilter.name": "Nombre del filtro de Especificaciones oculto"
 }

--- a/react/locales/es-AR.json
+++ b/react/locales/es-AR.json
@@ -17,9 +17,13 @@
   "ordenation.price.ascending": "Precios más bajo",
   "ordenation.name.ascending": "Nombre, creciente",
   "ordenation.name.descending": "Nombre, decreciente",
-  "editor.search-result.title" : "Resultado de búsqueda",
-  "editor.search-result.description" : "Contenedor de resultados de búsqueda",
-  "editor.search-result.maxItemsPerLine.title" : "Número máximo de elementos por línea",
-  "editor.search-result.maxItemsPerPage.title" : "Número máximo de elementos por página",
-  "editor.search-result.summary.title" : "Resumen del producto"
+  "editor.search-result.title": "Resultado de búsqueda",
+  "editor.search-result.description": "Contenedor de resultados de búsqueda",
+  "editor.search-result.maxItemsPerLine.title": "Número máximo de elementos por línea",
+  "editor.search-result.maxItemsPerPage.title": "Número máximo de elementos por página",
+  "editor.search-result.summary.title": "Resumen del producto",
+  "editor.search-result.hideBrands": "Ocultar filtro de Marcas",
+  "editor.search-result.hideCategories": "Ocultar filtro de Categorías",
+  "editor.search-result.hideRange": "Ocultar filtro de Precio",
+  "editor.search-result.hideSpecification": "Ocultar filtro de especificaciones"
 }

--- a/react/locales/es-AR.json
+++ b/react/locales/es-AR.json
@@ -22,8 +22,9 @@
   "editor.search-result.maxItemsPerLine.title": "Número máximo de elementos por línea",
   "editor.search-result.maxItemsPerPage.title": "Número máximo de elementos por página",
   "editor.search-result.summary.title": "Resumen del producto",
-  "editor.search-result.hideBrands": "Ocultar filtro de Marcas",
-  "editor.search-result.hideCategories": "Ocultar filtro de Categorías",
-  "editor.search-result.hideRange": "Ocultar filtro de Precio",
-  "editor.search-result.hideSpecification": "Ocultar filtro de especificaciones"
+  "editor.search-result.hiddenFacets": "Filtros Ocultados",
+  "editor.search-result.hiddenFacets.brands": "Ocultar filtro de Marcas",
+  "editor.search-result.hiddenFacets.categories": "Ocultar filtro de Categorías",
+  "editor.search-result.hiddenFacets.priceRange": "Ocultar filtro de Precio",
+  "editor.search-result.hiddenFacets.specificationFilters": "Ocultar filtros de especificaciones"
 }

--- a/react/locales/pt-BR.json
+++ b/react/locales/pt-BR.json
@@ -17,9 +17,13 @@
   "ordenation.price.ascending": "Menor preço",
   "ordenation.name.ascending": "Nome, crescente",
   "ordenation.name.descending": "Nome, decrescente",
-  "editor.search-result.title" : "Resultado da pesquisa",
-  "editor.search-result.description" : "Conteúdo do resultado da pesquisa",
-  "editor.search-result.maxItemsPerLine.title" : "Número máximo de elementos por linha",
-  "editor.search-result.maxItemsPerPage.title" : "Número máximo de elementos por página",
-  "editor.search-result.summary.title" : "Resumo do produto"
+  "editor.search-result.title": "Resultado da pesquisa",
+  "editor.search-result.description": "Conteúdo do resultado da pesquisa",
+  "editor.search-result.maxItemsPerLine.title": "Número máximo de elementos por linha",
+  "editor.search-result.maxItemsPerPage.title": "Número máximo de elementos por página",
+  "editor.search-result.summary.title": "Resumo do produto",
+  "editor.search-result.hideBrands": "Ocultar filtro de Marcas",
+  "editor.search-result.hideCategories": "Ocultar filtro de Categorias",
+  "editor.search-result.hideRange": "Ocultar filtro de Preço",
+  "editor.search-result.hideSpecification": "Ocultar filtro de Especificações"
 }

--- a/react/locales/pt-BR.json
+++ b/react/locales/pt-BR.json
@@ -26,5 +26,8 @@
   "editor.search-result.hiddenFacets.brands": "Ocultar filtro de Marcas",
   "editor.search-result.hiddenFacets.categories": "Ocultar filtro de Categorias",
   "editor.search-result.hiddenFacets.priceRange": "Ocultar filtro de Preço",
-  "editor.search-result.hiddenFacets.specificationFilters": "Ocultar filtros de Especificações"
+  "editor.search-result.hiddenFacets.specificationFilters": "Ocultar filtros de Especificações",
+  "editor.search-result.hiddenFacets.specificationFilters.hideAll": "Ocultar todos os filtros de Especificações",
+  "editor.search-result.hiddenFacets.specificationFilters.hiddenFilter": "Filtro de Especificacões oculto",
+  "editor.search-result.hiddenFacets.specificationFilters.hiddenFilter.name": "Nome do filtro de Especificações oculto"
 }

--- a/react/locales/pt-BR.json
+++ b/react/locales/pt-BR.json
@@ -22,8 +22,9 @@
   "editor.search-result.maxItemsPerLine.title": "Número máximo de elementos por linha",
   "editor.search-result.maxItemsPerPage.title": "Número máximo de elementos por página",
   "editor.search-result.summary.title": "Resumo do produto",
-  "editor.search-result.hideBrands": "Ocultar filtro de Marcas",
-  "editor.search-result.hideCategories": "Ocultar filtro de Categorias",
-  "editor.search-result.hideRange": "Ocultar filtro de Preço",
-  "editor.search-result.hideSpecification": "Ocultar filtro de Especificações"
+  "editor.search-result.hiddenFacets": "Filtros Ocultados",
+  "editor.search-result.hiddenFacets.brands": "Ocultar filtro de Marcas",
+  "editor.search-result.hiddenFacets.categories": "Ocultar filtro de Categorias",
+  "editor.search-result.hiddenFacets.priceRange": "Ocultar filtro de Preço",
+  "editor.search-result.hiddenFacets.specificationFilters": "Ocultar filtros de Especificações"
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add the possibility to hide the search-result facets

#### What problem is this solving?

No customizable facets

#### How should this be manually tested?

[Access the workspace](https://hiddenfacets--storecomponents.myvtex.com/admin/cms/storefront)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/45487195-05e6e300-b734-11e8-82e6-e4659ededa29.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
