### PR TITLE
Fix incorrect specification filter being removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.3.1] - 2018-09-14
 ### Fixed
 - Fix incorrect specification filter being removed with more than 1 in map.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix incorrect specification filter being removed with more than 1 in map.
 
 ## [1.3.0] - 2018-09-13
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/__tests__/constants/SearchHelpers.test.js
+++ b/react/__tests__/constants/SearchHelpers.test.js
@@ -344,8 +344,8 @@ describe('getPagesArgs', () => {
       link: '/eletrodomesticos/Geladeira---Refrigerador/Geladeira---Refrigerador/Branco?map=c,c,c,specificationFilter_14',
       pagesPath: 'store/subcategory',
       query: {
-        rest: ['Branco', '110V'],
-        map: ['c', 'c', 'c', 'specificationFilter_14', 'specificationFilter_692'],
+        rest: ['Outra categoria', 'Branco', '110V'],
+        map: ['c', 'c', 'c', 'c', 'specificationFilter_14', 'specificationFilter_692'],
       },
       params: {
         department: 'eletrodomesticos',
@@ -356,7 +356,7 @@ describe('getPagesArgs', () => {
 
     const { query: { map, rest } } = getPagesArgs(filterSpec)
 
-    expect(map).toEqual(['c', 'c', 'c', 'specificationFilter_692'])
-    expect(rest).toEqual(['110V'])
+    expect(map).toEqual(['c', 'c', 'c', 'c', 'specificationFilter_692'])
+    expect(rest).toEqual(['Outra categoria', '110V'])
   })
 })

--- a/react/__tests__/constants/SearchHelpers.test.js
+++ b/react/__tests__/constants/SearchHelpers.test.js
@@ -4,6 +4,7 @@ import {
   CATEGORIES_TYPE,
   BRANDS_TYPE,
   PRICE_RANGES_TYPE,
+  SPECIFICATION_FILTERS_TYPE,
 } from '../../components/FiltersContainer'
 
 describe('getSpecificationFilterFromLink', () => {
@@ -189,7 +190,7 @@ describe('getPagesArgs', () => {
       pagesPath: SUBCATEGORY_PAGE,
       query: {
         rest: ['Samsung', 'foo'],
-        map: ['c', 'b', 'c', 'c', 'c'],
+        map: ['c', 'c', 'c', 'c', 'b'],
       },
       params: {
         department: 'Eletronicos',
@@ -201,7 +202,7 @@ describe('getPagesArgs', () => {
 
     const { query: { map, rest } } = getPagesArgs(filterSpec)
 
-    expect(map).toEqual(['c', 'b', 'c', 'c'])
+    expect(map).toEqual(['c', 'c', 'c', 'b'])
     expect(rest).toEqual(['Samsung'])
   })
 
@@ -332,5 +333,30 @@ describe('getPagesArgs', () => {
     const { query: { priceRange } } = getPagesArgs(filterSpec)
 
     expect(priceRange).toBe('1000 TO 1999,99')
+  })
+
+  it('should remove correct specification filter map', () => {
+    const filterSpec = {
+      type: SPECIFICATION_FILTERS_TYPE,
+      isUnselectLink: true,
+      name: 'Branco',
+      slug: 'Branco',
+      link: '/eletrodomesticos/Geladeira---Refrigerador/Geladeira---Refrigerador/Branco?map=c,c,c,specificationFilter_14',
+      pagesPath: 'store/subcategory',
+      query: {
+        rest: ['Branco', '110V'],
+        map: ['c', 'c', 'c', 'specificationFilter_14', 'specificationFilter_692'],
+      },
+      params: {
+        department: 'eletrodomesticos',
+        category: 'geladeiras 1',
+        subcategory: 'geladeiras 2',
+      },
+    }
+
+    const { query: { map, rest } } = getPagesArgs(filterSpec)
+
+    expect(map).toEqual(['c', 'c', 'c', 'specificationFilter_692'])
+    expect(rest).toEqual(['110V'])
   })
 })

--- a/react/constants/SearchHelpers.js
+++ b/react/constants/SearchHelpers.js
@@ -101,7 +101,7 @@ function removeFilter(map, rest, { type, slug, pagesPath }) {
 
     if (symbol === categoryMapSymbol && skip > 0) {
       skip--
-    } else if (count === restIndex) {
+    } else if (count >= restIndex) {
       break
     } else {
       count++

--- a/react/constants/SearchHelpers.js
+++ b/react/constants/SearchHelpers.js
@@ -73,14 +73,14 @@ function restMapped(rest, map) {
 }
 
 function removeFilter(map, rest, { type, slug, pagesPath }) {
-  let skip = 0
+  let categoryCount = 0
 
   if (pagesPath === 'store/department') {
-    skip = 1
+    categoryCount = 1
   } else if (pagesPath === 'store/category') {
-    skip = 2
+    categoryCount = 2
   } else if (pagesPath === 'store/subcategory') {
-    skip = 3
+    categoryCount = 3
   }
 
   const categoryMapSymbol = getMapByType(CATEGORIES_TYPE)
@@ -93,25 +93,39 @@ function removeFilter(map, rest, { type, slug, pagesPath }) {
     return { map, rest }
   }
 
+  if (type !== CATEGORIES_TYPE) {
+    let categoriesFiltered = 0
+
+    const mapWithoutCategories = map.filter(s => {
+      if (categoriesFiltered === categoryCount) {
+        return true
+      }
+
+      categoriesFiltered++
+
+      return s !== categoryMapSymbol
+    }).filter((_, i) => i !== restIndex)
+
+    const lengthDifference = map.length - mapWithoutCategories.length - 1
+
+    return {
+      map: [...repeat(categoryMapSymbol, lengthDifference), ...mapWithoutCategories],
+      rest: rest.filter((_, i) => i !== restIndex),
+    }
+  }
+
   let mapIndex = -1
-  let count = skip - 1
+  let count = categoryCount - 1
 
   for (const symbol of map) {
     mapIndex++
 
-    if (symbol === categoryMapSymbol && skip > 0) {
-      skip--
+    if (symbol === categoryMapSymbol && categoryCount > 0) {
+      categoryCount--
     } else if (count >= restIndex) {
       break
     } else {
       count++
-    }
-  }
-
-  if (type !== CATEGORIES_TYPE) {
-    return {
-      map: map.filter((_, i) => i !== mapIndex),
-      rest: rest.filter((_, i) => i !== restIndex),
     }
   }
 

--- a/react/constants/SearchHelpers.js
+++ b/react/constants/SearchHelpers.js
@@ -96,14 +96,14 @@ function removeFilter(map, rest, { type, slug, pagesPath }) {
   if (type !== CATEGORIES_TYPE) {
     let categoriesFiltered = 0
 
-    const mapWithoutCategories = map.filter(s => {
+    const mapWithoutCategories = map.filter(symbol => {
       if (categoriesFiltered === categoryCount) {
         return true
       }
 
       categoriesFiltered++
 
-      return s !== categoryMapSymbol
+      return symbol !== categoryMapSymbol
     }).filter((_, i) => i !== restIndex)
 
     const lengthDifference = map.length - mapWithoutCategories.length - 1


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fixes condition in the break loop when removing the filter.

#### What problem is this solving?
Fixes inccorect specification filter being removed when there were more than one instance of it in the url.

#### How should this be manually tested?
[Workspace](https://lucas--storecomponents.myvtex.com/eletronicos/smartphones), select an specification filter then another, then remove the first one you selected.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
