### PR TITLE
Fix breadcrumb being shown on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix breadcrumb being shown on mobile.
 
 ## [1.5.1] - 2018-09-20
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Fix breadcrumb being shown on mobile.
 
+### Removed
+- Content loader of filters on mobile.
+
 ## [1.5.1] - 2018-09-20
 ### Fixed
 - Fix breadcrumb padding to match the product details.

--- a/react/__tests__/components/FiltersContainer.test.js
+++ b/react/__tests__/components/FiltersContainer.test.js
@@ -20,6 +20,7 @@ describe('<FiltersContainer />', () => {
         params={{
           department: 'Eletronicos',
         }}
+        runtime={{ hints: { mobile: false } }}
       />
     )
 
@@ -73,6 +74,7 @@ describe('<FiltersContainer />', () => {
         params={{
           department: 'Livros',
         }}
+        runtime={{ hints: { mobile: false } }}
       />
     )
 
@@ -133,6 +135,7 @@ describe('<FiltersContainer />', () => {
         params={{
           department: 'livros',
         }}
+        runtime={{ hints: { mobile: false } }}
       />
     )
 

--- a/react/components/FiltersContainer.js
+++ b/react/components/FiltersContainer.js
@@ -1,8 +1,8 @@
-/* global __RUNTIME__ */
 import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
 import { flatten, path, identity, contains } from 'ramda'
 import ContentLoader from 'react-content-loader'
+import { withRuntimeContext } from 'render'
 
 import SelectedFilters from './SelectedFilters'
 import AvailableFilters from './AvailableFilters'
@@ -27,7 +27,7 @@ const PRICE_RANGES_TITLE = 'search.filter.title.price-ranges'
  * Wrapper around the filters (selected and available) as well
  * as the popup filters that appear on mobile devices
  */
-export default class FiltersContainer extends Component {
+class FiltersContainer extends Component {
   static propTypes = {
     /** Get the props to pass to render's Link */
     getLinkProps: PropTypes.func.isRequired,
@@ -54,7 +54,7 @@ export default class FiltersContainer extends Component {
     rest: PropTypes.string.isRequired,
     /** Loading indicator */
     loading: PropTypes.bool,
-    ...hiddenFacetsSchema
+    ...hiddenFacetsSchema,
   }
 
   static defaultProps = {
@@ -121,9 +121,8 @@ export default class FiltersContainer extends Component {
       getLinkProps,
       loading,
       hiddenFacets,
+      runtime: { hints: { mobile } },
     } = this.props
-
-    const mobile = __RUNTIME__.hints.mobile
 
     if (loading && !mobile) {
       return (
@@ -208,3 +207,5 @@ export default class FiltersContainer extends Component {
     )
   }
 }
+
+export default withRuntimeContext(FiltersContainer)

--- a/react/components/FiltersContainer.js
+++ b/react/components/FiltersContainer.js
@@ -123,7 +123,9 @@ export default class FiltersContainer extends Component {
       hiddenFacets,
     } = this.props
 
-    if (loading) {
+    const mobile = __RUNTIME__.hints.mobile
+
+    if (loading && !mobile) {
       return (
         <ContentLoader
           style={{
@@ -178,7 +180,7 @@ export default class FiltersContainer extends Component {
       },
     ].filter(identity)
 
-    if (__RUNTIME__.hints.mobile) {
+    if (mobile) {
       return (
         <AccordionFilterContainer
           filters={filters}

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -38,7 +38,7 @@ export default class SearchResult extends Component {
 
     return (
       <div className="vtex-search-result vtex-page-padding pv5 ph9-l ph7-m ph5-s">
-        <div className="vtex-search-result__breadcrumb">
+        <div className="vtex-search-result__breadcrumb db-m dn-s">
           <ExtensionPoint id="breadcrumb" {...breadcrumbsProps} />
         </div>
         <div className="vtex-search-result__total-products">

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -38,7 +38,7 @@ export default class SearchResult extends Component {
 
     return (
       <div className="vtex-search-result vtex-page-padding pv5 ph9-l ph7-m ph5-s">
-        <div className="vtex-search-result__breadcrumb db-m dn-s">
+        <div className="vtex-search-result__breadcrumb db-ns dn-s">
           <ExtensionPoint id="breadcrumb" {...breadcrumbsProps} />
         </div>
         <div className="vtex-search-result__total-products">

--- a/react/global.css
+++ b/react/global.css
@@ -151,10 +151,6 @@ body.vtex-filter-popup-open {
       "gallery gallery gallery";
   }
 
-  .vtex-search-result__breadcrumb {
-    justify-self: center;
-  }
-
   .vtex-search-result__total-products {
     justify-self: stretch;
     text-align: center;


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add `dn-s` class to breadcrumb wrapper so it's hidden on mobile, also remove the content loader of the filters on mobile.

#### What problem is this solving?
The breadcrumb isn't supposed to be displayed on mobile, and it was breaking the grid layout.

#### How should this be manually tested?
[Workspace](https://lucas--storecomponents.myvtex.com/Eletronicos/Smartphones), access with a espertofone or with mobile simulation.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
