### PR TITLE
 Add viewmode selector for product summary on mobile 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Fixed
-- Fix breadcrumb being shown on mobile.
 
 ## [1.5.2] - 2018-09-28
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix breadcrumb being shown on mobile.
 
 ## [1.5.2] - 2018-09-28
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.6.0] - 2018-10-02
 ### Added
 - Different viewmode of the result on mobile.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Different viewmode of the result on mobile.
 
 ## [1.5.2] - 2018-09-28
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/components/Gallery.js
+++ b/react/components/Gallery.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { PropTypes } from 'prop-types'
+import classNames from 'classnames'
 
 import { productShape } from '../constants/propTypes'
 import GalleryItem from './GalleryItem'
@@ -7,18 +8,24 @@ import GalleryItem from './GalleryItem'
 /**
  * Canonical gallery that displays a list of given products.
  */
-const Gallery = props => {
-  const { products, summary } = props
+const Gallery = ({ products, summary, layoutMode }) => {
+  const classes = classNames('vtex-gallery pa3 bn-ns bt-s b--muted-4', {
+    'vtex-gallery--two-columns': layoutMode === 'small',
+  })
 
   return (
-    <div className="vtex-gallery pa3">
+    <div className={classes}>
       {products.map(item => {
         return (
           <div
             key={item.productId}
             className="vtex-gallery__item mv2 pa1"
           >
-            <GalleryItem item={item} summary={summary} />
+            <GalleryItem
+              item={item}
+              summary={summary}
+              displayMode={layoutMode}
+            />
           </div>
         )
       })}
@@ -27,12 +34,12 @@ const Gallery = props => {
 }
 
 Gallery.propTypes = {
-  /** Maximum number of items per page. */
-  maxItemsPerPage: PropTypes.number.isRequired,
   /** Products to be displayed. */
   products: PropTypes.arrayOf(productShape),
   /** ProductSummary props. */
   summary: PropTypes.any,
+  /** Layout mode of the gallery */
+  layoutMode: PropTypes.string,
 }
 
 Gallery.defaultProps = {

--- a/react/components/GalleryItem.js
+++ b/react/components/GalleryItem.js
@@ -13,6 +13,8 @@ export default class GalleryItem extends Component {
     item: productShape,
     /** ProductSummary props.  */
     summary: PropTypes.any,
+    /** Display mode of the product summary */
+    displayMode: PropTypes.string,
   }
 
   normalizeProductSummary(product) {
@@ -39,6 +41,7 @@ export default class GalleryItem extends Component {
       <ProductSummary
         {...this.props.summary}
         product={this.normalizeProductSummary(this.props.item)}
+        displayMode={this.props.displayMode}
       />
     )
   }

--- a/react/components/LayoutModeSwitcher.js
+++ b/react/components/LayoutModeSwitcher.js
@@ -1,0 +1,50 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Button } from 'vtex.styleguide'
+
+import Grid from '../images/Grid'
+import SingleItemGrid from '../images/SingleItemGrid'
+import InlineGrid from '../images/InlineGrid'
+
+const onChangeHandler = (type, onChange) => e => onChange(e, type)
+
+export default function LayoutModeSwitcher({ activeMode, onChange }) {
+  return (
+    <div className="vtex-layout-switcher flex justify-between pv2">
+      <div className="flex justify-center flex-auto br b--muted-4">
+        <Button
+          variation="tertiary"
+          size="small"
+          onClick={onChangeHandler('small', onChange)}
+        >
+          <Grid active={activeMode === 'small'} />
+        </Button>
+      </div>
+      <div className="flex justify-center flex-auto br b--muted-4">
+        <Button
+          variation="tertiary"
+          size="small"
+          onClick={onChangeHandler('inline', onChange)}
+        >
+          <InlineGrid active={activeMode === 'inline'} />
+        </Button>
+      </div>
+      <div className="flex justify-center flex-auto">
+        <Button
+          variation="tertiary"
+          size="small"
+          onClick={onChangeHandler('normal', onChange)}
+        >
+          <SingleItemGrid active={activeMode === 'normal'} />
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+LayoutModeSwitcher.propTypes = {
+  /** Current active mode */
+  activeMode: PropTypes.string.isRequired,
+  /** On change callback */
+  onChange: PropTypes.func.isRequired,
+}

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -3,6 +3,7 @@ import { Spinner } from 'vtex.styleguide'
 import { ExtensionPoint } from 'render'
 import { FormattedMessage } from 'react-intl'
 
+import LayoutModeSwitcher from './LayoutModeSwitcher'
 import FiltersContainer from './FiltersContainer'
 import { searchResultPropTypes } from '../constants/propTypes'
 import OrderBy from './OrderBy'
@@ -13,6 +14,18 @@ import Gallery from './Gallery'
  */
 export default class SearchResult extends Component {
   static propTypes = searchResultPropTypes
+
+  state = {
+    galleryLayoutMode: 'normal',
+  }
+
+  handleLayoutChange = (e, mode) => {
+    e.preventDefault()
+
+    this.setState({
+      galleryLayoutMode: mode,
+    })
+  }
 
   render() {
     const {
@@ -41,12 +54,12 @@ export default class SearchResult extends Component {
         <div className="vtex-search-result__breadcrumb db-ns dn-s">
           <ExtensionPoint id="breadcrumb" {...breadcrumbsProps} />
         </div>
-        <div className="vtex-search-result__total-products">
+        <div className="vtex-search-result__total-products bn-ns bb-s b--muted-4 tc-s tl">
           <FormattedMessage
             id="search.total-products"
             values={{ recordsFiltered }}
           >
-            {txt => <span className="ph4 black-50">{txt}</span>}
+            {txt => <span className="ph4 c-muted-2">{txt}</span>}
           </FormattedMessage>
         </div>
         <div className="vtex-search-result__filters">
@@ -64,7 +77,7 @@ export default class SearchResult extends Component {
             loading={loading && !fetchMoreLoading}
           />
         </div>
-        <div className="vtex-search-result__border" />
+        <div className="vtex-search-result__border bg-muted-4 h-75 self-center" />
         <div className="vtex-search-result__order-by">
           <OrderBy
             orderBy={orderBy}
@@ -72,6 +85,12 @@ export default class SearchResult extends Component {
           />
         </div>
         <div className="vtex-search-result__gallery">
+          <div className="dn-ns db-s bt b--muted-4">
+            <LayoutModeSwitcher
+              activeMode={this.state.galleryLayoutMode}
+              onChange={this.handleLayoutChange}
+            />
+          </div>
           {loading && !fetchMoreLoading ? (
             <div className="w-100 flex justify-center">
               <div className="w3 ma0">
@@ -82,6 +101,7 @@ export default class SearchResult extends Component {
             <Gallery
               products={products}
               summary={summary}
+              layoutMode={this.state.galleryLayoutMode}
             />
           )}
           {children}

--- a/react/global.css
+++ b/react/global.css
@@ -68,9 +68,6 @@
 .vtex-search-result__border {
   grid-column: border;
   grid-row: border;
-  height: 80%;
-  background-color: #c4c4c4;
-  align-self: center;
 }
 
 .vtex-search-result a {
@@ -153,9 +150,7 @@ body.vtex-filter-popup-open {
 
   .vtex-search-result__total-products {
     justify-self: stretch;
-    text-align: center;
     padding-bottom: 0.375rem;
-    border-bottom: 1px solid #c4c4c4;
   }
 
   .vtex-search-result__filter-title {
@@ -163,6 +158,10 @@ body.vtex-filter-popup-open {
   }
 
   .vtex-gallery {
-    border-top: 1px solid #c4c4c4;
+    grid-template-columns: 1fr;
+  }
+
+  .vtex-gallery--two-columns {
+    grid-template-columns: repeat(2, 1fr);
   }
 }

--- a/react/images/Grid.js
+++ b/react/images/Grid.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+export default function Grid({ active }) {
+  const color = active ? '#828282' : '#ececec'
+
+  return (
+    <svg width="16" height="19" viewBox="0 0 16 19" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect width="6.73684" height="7" fill={color} />
+      <rect x="9.2627" width="6.73684" height="7" fill={color} />
+      <rect width="6.73684" height="1" transform="matrix(1 0 0 -1 9.2627 9)" fill={color} />
+      <rect width="6.73684" height="1" transform="matrix(1 0 0 -1 0 9)" fill={color} />
+      <rect y="10" width="6.73684" height="7" fill={color} />
+      <rect x="9.2627" y="10" width="6.73684" height="7" fill={color} />
+      <rect width="6.73684" height="1" transform="matrix(1 0 0 -1 9.2627 19)" fill={color} />
+      <rect width="6.73684" height="1" transform="matrix(1 0 0 -1 0 19)" fill={color} />
+    </svg>
+  )
+}
+
+Grid.propTypes = {
+  /** Whether the icon is active */
+  active: PropTypes.bool,
+}

--- a/react/images/InlineGrid.js
+++ b/react/images/InlineGrid.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+export default function InlineGrid({ active }) {
+  const color = active ? '#828282' : '#ececec'
+
+  return (
+    <svg width="19" height="19" viewBox="0 0 19 19" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect y="14" width="5" height="5" fill={color} />
+      <rect y="7" width="5" height="5" fill={color} />
+      <rect width="5" height="5" fill={color} />
+      <rect x="7" width="12" height="2" fill={color} />
+      <rect x="7" y="3" width="12" height="2" fill={color} />
+      <rect x="7" y="7" width="12" height="2" fill={color} />
+      <rect x="7" y="10" width="12" height="2" fill={color} />
+      <rect x="7" y="14" width="12" height="2" fill={color} />
+      <rect x="7" y="17" width="12" height="2" fill={color} />
+    </svg>
+  )
+}
+
+InlineGrid.propTypes = {
+  /** Whether the icon is active */
+  active: PropTypes.bool,
+}

--- a/react/images/SingleItemGrid.js
+++ b/react/images/SingleItemGrid.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+export default function SingleItemGrid({ active }) {
+  const color = active ? '#828282' : '#ececec'
+
+  return (
+    <svg width="10" height="19" viewBox="0 0 10 19" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect width="10" height="14" fill={color} />
+      <rect y="16" width="10" height="3" fill={color} />
+    </svg>
+  )
+}
+
+SingleItemGrid.propTypes = {
+  /** Whether the icon is active */
+  active: PropTypes.bool,
+}


### PR DESCRIPTION
> This branch was based on the #45's branch

#### What is the purpose of this pull request?
Added the display mode selector for the product summary on mobile.

#### What problem is this solving?
New design on the search result.

#### How should this be manually tested?
[Workspace](https://lucas--storecomponents.myvtex.com/eletronicos/d?map=c), access on mobile device or simulator.

#### Screenshots or example usage
![screen shot 2018-09-26 at 15 52 35](https://user-images.githubusercontent.com/10223856/46102226-3bfc7c00-c1a4-11e8-8756-84a42f772a4c.png)
![screen shot 2018-09-26 at 15 52 43](https://user-images.githubusercontent.com/10223856/46102227-3dc63f80-c1a4-11e8-9438-ef2d66973180.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
