### PR TITLE
Fix breadcrumb props when has an accented letter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix props of breadcrumbs when it has an accented letter.
 
 ## [2.0.1] - 2018-10-02
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.0.3] - 2018-10-15
 ### Fixed
 - Fix props of breadcrumbs when it has an accented letter.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/index.js
+++ b/react/index.js
@@ -29,15 +29,15 @@ export default class SearchResultContainer extends Component {
     const categories = []
 
     if (department) {
-      categories.push(department)
+      categories.push(decodeURIComponent(department))
     }
 
     if (category) {
-      categories.push(`${department}/${category}/`)
+      categories.push(`${decodeURIComponent(department)}/${decodeURIComponent(category)}/`)
     }
 
     return {
-      term,
+      term: term ? decodeURIComponent(term) : term,
       categories,
     }
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix props of breadcrumb when you search a word with an accented letter

#### What problem is this solving?

Uncoded props when you access a route of search and the term, category or department has an accented letter

#### How should this be manually tested?
[Access this workspace](https://decodeuribreadcrumb--storecomponents.myvtex.com/T%C3%AAnis)
#### Screenshots or example usage
Before
![image](https://user-images.githubusercontent.com/8517023/46957305-aa2eb300-d06d-11e8-9544-d1c2bef256f9.png)
After
![image](https://user-images.githubusercontent.com/8517023/46957322-b0249400-d06d-11e8-8d26-3b71f00972a3.png)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
