### PR TITLE
Fix bug when lateral menu is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.0.5] - 2018-10-18
 ### Fixed
 - Fix bug when lateral menu was open.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix bug when lateral menu was open.
 
 ## [2.0.3] - 2018-10-15
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/components/Popup.js
+++ b/react/components/Popup.js
@@ -94,7 +94,7 @@ export default class Popup extends Component {
           })
 
           const contentClassName = classNames(
-            'vtex-filter-popup__content-container h-auto bg-white fixed dn w-100 left-0 bottom-0 z-999 ph3 overflow-y-auto flex-column',
+            'vtex-filter-popup__content-container h-auto bg-white fixed dn w-100 left-0 bottom-0 z-1 ph3 overflow-y-auto flex-column',
             {
               'vtex-filter-popup__content-container--open flex': open,
             }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix the bug that was mixing up the categories and filters when hamburger menu is open

#### What problem is this solving?
Resolve design issues

#### How should this be manually tested?
[Access this workspace](https://fixcategorymenu--storecomponents.myvtex.com/celular/s?map=ft), remember to reload the page after selecting mobile view in browser and search for something. Open the category menu while keeping the filter options open.

#### Screenshots or example usage
*Before*
![before](https://user-images.githubusercontent.com/4912690/47093666-117c6c80-d200-11e8-84a2-50dd22326e9b.PNG)
*After*
![after](https://user-images.githubusercontent.com/4912690/47093673-13dec680-d200-11e8-908a-146d165e5159.PNG)

#### Types of changes

* [X] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
