### PR TITLE
Add loading overlay instead of content loaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update loading to use an overlay instead of content loader after initial mount.
 
 ## [2.4.0] - 2018-11-16
 ### Changed

--- a/react/components/LoadingOverlay.js
+++ b/react/components/LoadingOverlay.js
@@ -1,0 +1,62 @@
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+import { Spinner } from 'vtex.styleguide'
+
+export default class LoadingOverlay extends Component {
+  static propTypes = {
+    children: PropTypes.node,
+    loading: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    loading: false,
+  };
+
+  root_ = React.createRef();
+
+  handleClick = e => {
+    e.stopPropagation()
+  }
+
+  componentDidMount() {
+    if (this.props.loading)this.attachEvent()
+  }
+
+  attachEvent = () => {
+    if (this.root_.current) {
+      this.root_.current.addEventListener('click', this.handleClick, true)
+    }
+  }
+
+  dettachEvent = () => {
+    if (this.root_.current) {
+      this.root_.current.removeEventListener('click', this.handleClick, true)
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.loading) {
+      this.attachEvent()
+    } else if (prevProps.loading && !this.props.loading) {
+      this.dettachEvent()
+    }
+  }
+
+  render() {
+    const { children, loading } = this.props
+
+    return (
+      <div className="relative" ref={this.root_}>
+        {loading && (
+          <div className="absolute w-100 h-100 z-2" style={{ background: 'rgba(255, 255, 255, .6)' }}>
+            <div className="absolute top-0 bottom-0 left-0 right-0 flex justify-center pt11">
+              <Spinner />
+            </div>
+          </div>
+        )}
+        {children}
+      </div>
+    )
+  }
+}
+


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add a loading overlay when the search result component is already mounted.

#### What problem is this solving?
It wasn't a good user experience to click on a filter on the filter navigator and the whole component
turn to a content loader.

#### How should this be manually tested?
[Workspace](https://lucas--storecomponents.myvtex.com/eletronicos/d?map=c).

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/10223856/47582612-3755ef80-d92b-11e8-9944-c5cede62192c.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
