### PR TITLE
Fix slug of facet types other than brand being modified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix slug being modified for every type, instead of only brands.
 
 ## [2.1.0] - 2018-10-22
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.2.0] - 2018-10-31
 ### Fixed
 - Fix slug being modified for every type, instead of only brands.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/constants/SearchHelpers.js
+++ b/react/constants/SearchHelpers.js
@@ -247,7 +247,14 @@ export function mountOptions(options, type, map, rest) {
   const restMap = restMapped(rest, map)
 
   return options.reduce((acc, opt) => {
-    const slug = opt.Slug || (opt.normalizedName || opt.Name).replace(/[^\w\d]/g, '-')
+    let slug
+
+    if (opt.type === BRANDS_TYPE) {
+      slug = opt.Name.replace(/[^\w\d]/g, '-')
+    } else {
+      slug = opt.Slug || opt.normalizedName || opt.Name
+    }
+
     const optMap = type === SPECIFICATION_FILTERS_TYPE
       ? getSpecificationFilterFromLink(opt.Link, map.split(','))
       : getMapByType(type)


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove regex on slug and apply it only on brand slug's, e.g. `"Make B." -> "Make-B-"`

#### What problem is this solving?
The regex should only be applied on slugs of the brands facets, the name is fine for the other types.

#### How should this be manually tested?
Access the [workspace](https://fixslugs--storecomponents.myvtex.com/eletronicos/smartphones?map=c%2Cc) and select any filter under the "Operational System".

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
