### PR TITLE
Center using vtex-page-padding class instead of tachyons.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Center using vtex-page-padding class instead of tachyons.
 
 ## [2.2.0] - 2018-10-31
 ### Fixed

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -51,7 +51,7 @@ export default class SearchResult extends Component {
       decodeURIComponent(params.term) : undefined
 
     return (
-      <div className="vtex-search-result vtex-page-padding pv5 ph9-l ph7-m ph5-s">
+      <div className="vtex-search-result vtex-page-padding center pv5">
         <div className="vtex-search-result__breadcrumb db-ns dn-s">
           <ExtensionPoint id="breadcrumb" {...breadcrumbsProps} />
         </div>

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -66,7 +66,7 @@ export default class SearchResult extends Component {
             {txt => <span className="ph4 c-muted-2">{txt}</span>}
           </FormattedMessage>
         </div>
-        <div className="vtex-search-result__filters">
+        <div className="vtex-search-result__filters pl4">
           <ExtensionPoint
             id="filter-navigator"
             brands={brands}
@@ -83,7 +83,7 @@ export default class SearchResult extends Component {
           />
         </div>
         <div className="vtex-search-result__border bg-muted-4 h-75 self-center" />
-        <div className="vtex-search-result__order-by">
+        <div className="vtex-search-result__order-by pr4">
           <OrderBy
             orderBy={orderBy}
             getLinkProps={getLinkProps}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Addition of center tachyon along side vtex-page-padding.

#### What problem is this solving?
Due use of vtex-page-padding class, the center tachyon is required.

#### How should this be manually tested?
[Access this workspace](https://alignheader--storecomponents.myvtex.com/)

#### Screenshots or example usage
The search-result must be centralized and using vtex-page-padding as reference

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
