### PR TITLE
Add order by field to custom query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.3.0] - 2018-11-06
 ### Added
 - Add field `orderBy` to custom query schema.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add field `orderBy` to custom query schema.
 
 ## [2.2.0] - 2018-10-31
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/components/LocalQuery.js
+++ b/react/components/LocalQuery.js
@@ -6,37 +6,6 @@ import { Queries } from 'vtex.store'
 
 const DEFAULT_PAGE = 1
 
-const SORT_OPTIONS = [
-  {
-    value: 'OrderByTopSaleDESC',
-    label: 'ordenation.sales',
-  },
-  {
-    value: 'OrderByReleaseDateDESC',
-    label: 'ordenation.release.date',
-  },
-  {
-    value: 'OrderByBestDiscountDESC',
-    label: 'ordenation.discount',
-  },
-  {
-    value: 'OrderByPriceDESC',
-    label: 'ordenation.price.descending',
-  },
-  {
-    value: 'OrderByPriceASC',
-    label: 'ordenation.price.ascending',
-  },
-  {
-    value: 'OrderByNameASC',
-    label: 'ordenation.name.ascending',
-  },
-  {
-    value: 'OrderByNameDESC',
-    label: 'ordenation.name.descending',
-  },
-]
-
 function createInitialMap(params) {
   const map = [
     params.term && 'ft',
@@ -50,29 +19,6 @@ function createInitialMap(params) {
 }
 
 class LocalQuery extends Component {
-  static schema = {
-    title: 'editor.product-search.title',
-    type: 'object',
-    properties: {
-      maxItemsPerPage: {
-        title: 'editor.product-search.maxItemsPerPage',
-        type: 'number',
-      },
-      queryField: {
-        title: 'Query',
-        type: 'string',
-      },
-      mapField: {
-        title: 'Map',
-        type: 'string',
-      },
-      restField: {
-        title: 'Other Query Strings',
-        type: 'string',
-      },
-    },
-  }
-
   render() {
     const {
       nextTreePath,
@@ -81,8 +27,9 @@ class LocalQuery extends Component {
       queryField,
       mapField,
       restField,
+      orderByField,
       query: {
-        order: orderBy = SORT_OPTIONS[0].value,
+        order: orderBy = orderByField,
         page: pageQuery,
         map: mapQuery,
         rest = '',

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -47,8 +47,8 @@ export default class SearchResult extends Component {
       hiddenFacets,
     } = this.props
 
-    const term = params && params.term ?
-      decodeURIComponent(params.term) : undefined
+    const term = params && params.term
+      ? decodeURIComponent(params.term) : undefined
 
     return (
       <div className="vtex-search-result vtex-page-padding pv5 ph9-l ph7-m ph5-s">

--- a/react/index.js
+++ b/react/index.js
@@ -49,24 +49,31 @@ export default class SearchResultQueryLoader extends Component {
 SearchResultQueryLoader.getSchema = props => {
   const queryProperties = props.querySchema && props.querySchema.enableCustomQuery
     ? {
-        maxItemsPerPage: {
-          title: 'editor.search-result.query.maxItemsPerPage',
-          type: 'number',
-          default: DEFAULT_MAX_ITEMS_PER_PAGE,
-        },
-        queryField: {
-          title: 'Query',
-          type: 'string',
-        },
-        mapField: {
-          title: 'Map',
-          type: 'string',
-        },
-        restField: {
-          title: 'Other Query Strings',
-          type: 'string',
-        },
-      }
+      maxItemsPerPage: {
+        title: 'editor.search-result.query.maxItemsPerPage',
+        type: 'number',
+        default: DEFAULT_MAX_ITEMS_PER_PAGE,
+      },
+      queryField: {
+        title: 'Query',
+        type: 'string',
+      },
+      mapField: {
+        title: 'Map',
+        type: 'string',
+      },
+      restField: {
+        title: 'Other Query Strings',
+        type: 'string',
+      },
+      orderByField: {
+        title: 'Order by field',
+        type: 'string',
+        default: SORT_OPTIONS[1].value,
+        enum: SORT_OPTIONS.map(opt => opt.value),
+        enumNames: SORT_OPTIONS.map(opt => opt.label),
+      },
+    }
     : {}
   return {
     title: 'editor.search-result.title',


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add field `orderBy` to the custom query schema properties.

#### What problem is this solving?
You couldn't set the initial order of the products on the custom query before.

#### How should this be manually tested?
[Workspace](https://lucas--storecomponents.myvtex.com/eletronicos/d).

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
