### PR TITLE
Update to show custom query only outside search context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Only show custom query schema if not inside search context.
 
 ## [2.3.0] - 2018-11-06
 ### Added

--- a/react/index.js
+++ b/react/index.js
@@ -47,51 +47,48 @@ export default class SearchResultQueryLoader extends Component {
 }
 
 SearchResultQueryLoader.getSchema = props => {
-  const queryProperties = props.querySchema && props.querySchema.enableCustomQuery
+  const querySchema = !props.searchQuery
     ? {
-      maxItemsPerPage: {
-        title: 'editor.search-result.query.maxItemsPerPage',
-        type: 'number',
-        default: DEFAULT_MAX_ITEMS_PER_PAGE,
-      },
-      queryField: {
-        title: 'Query',
-        type: 'string',
-      },
-      mapField: {
-        title: 'Map',
-        type: 'string',
-      },
-      restField: {
-        title: 'Other Query Strings',
-        type: 'string',
-      },
-      orderByField: {
-        title: 'Order by field',
-        type: 'string',
-        default: SORT_OPTIONS[1].value,
-        enum: SORT_OPTIONS.map(opt => opt.value),
-        enumNames: SORT_OPTIONS.map(opt => opt.label),
-      },
-    }
-    : {}
-  return {
-    title: 'editor.search-result.title',
-    description: 'editor.search-result.description',
-    type: 'object',
-    properties: {
       querySchema: {
         title: 'editor.search-result.query',
         description: 'editor.search-result.query.description',
         type: 'object',
         properties: {
-          enableCustomQuery: {
-            title: 'editor.search-result.query.enableCustomQuery',
-            type: 'boolean',
+          maxItemsPerPage: {
+            title: 'editor.search-result.query.maxItemsPerPage',
+            type: 'number',
+            default: DEFAULT_MAX_ITEMS_PER_PAGE,
           },
-          ...queryProperties,
+          queryField: {
+            title: 'Query',
+            type: 'string',
+          },
+          mapField: {
+            title: 'Map',
+            type: 'string',
+          },
+          restField: {
+            title: 'Other Query Strings',
+            type: 'string',
+          },
+          orderByField: {
+            title: 'Order by field',
+            type: 'string',
+            default: SORT_OPTIONS[1].value,
+            enum: SORT_OPTIONS.map(opt => opt.value),
+            enumNames: SORT_OPTIONS.map(opt => opt.label),
+          },
         },
       },
+    }
+    : {}
+
+  return {
+    title: 'editor.search-result.title',
+    description: 'editor.search-result.description',
+    type: 'object',
+    properties: {
+      ...querySchema,
       hiddenFacets: {
         title: 'editor.search-result.hiddenFacets',
         type: 'object',


### PR DESCRIPTION
#### What is the purpose of this pull request?
Update to only show the schema for the custom query if the component is outside a search context.

#### What problem is this solving?
The user could be confused whether they should change inside the search result schema or on the search context, when inside a page with the search context.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
