### PR TITLE
Set search filters not to scroll when updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
 - Set search filters not to scroll page when edited
 
 ## [2.3.3] - 2018-11-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.3.4] - 2018-11-13
 ### Changed
 - Set search filters not to scroll page when edited
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Set search filters not to scroll page when edited
 
 ## [2.3.3] - 2018-11-08
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/components/AccordionFilterItem.js
+++ b/react/components/AccordionFilterItem.js
@@ -54,6 +54,7 @@ const AccordionFilterItem = ({
               params={pagesArgs.params}
               query={pagesArgs.queryString}
               onClick={onItemSelected}
+              scrollOptions={false}
             >
               {opt.Name}
 

--- a/react/components/OrderBy.js
+++ b/react/components/OrderBy.js
@@ -86,6 +86,7 @@ class OrderBy extends Component {
             params: pagesArgs.params,
             query: pagesArgs.queryString,
             fallbackToWindowLocation: false,
+            scrollOptions: false,
           })
         }}
       />

--- a/react/components/PriceRange.js
+++ b/react/components/PriceRange.js
@@ -60,6 +60,7 @@ class PriceRange extends Component {
         page: linkProps.page,
         params: linkProps.params,
         query: linkProps.queryString,
+        scrollOptions: false,
       })
     }, DEBOUNCE_TIME)
   }

--- a/react/components/SearchFilter.js
+++ b/react/components/SearchFilter.js
@@ -64,6 +64,7 @@ class SearchFilter extends Component {
               page={pagesArgs.page}
               params={pagesArgs.params}
               query={pagesArgs.queryString}
+              scrollOptions={false}
             >
               <span
                 className="f6 fw3 bb db"

--- a/react/components/SelectedFilters.js
+++ b/react/components/SelectedFilters.js
@@ -49,6 +49,7 @@ class SelectedFilters extends Component {
               page={pagesArgs.page}
               params={pagesArgs.params}
               query={pagesArgs.queryString}
+              scrollOptions={false}
             >
               <label className="w-100 flex items-center relative f7 fw3 mb2 pointer">
                 <div className="absolute top-0 left-0 bottom-0 z-1">


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix a bug where every modification to search filters cause a scroll to the top of the page.

#### What problem is this solving?

It shouldn't scroll. This is a problem [for boticario](https://www.boticario.com.br/malbec/b).

#### How should this be manually tested?

I've linked the changes [here](https://fixsearchscrolloptions--storecomponents.myvtex.com/eletronicos/videogames). Together, I've linked a version of `dreamstore` that adds a bunch of footer so that the effect of this change becomes noticeable.

To test it, visit the link and click on the filters. Check that the page doesn't scroll to top.

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)