### PR TITLE
Scroll to top of search result when there's any change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.4.1] - 2018-11-22
 ### Changed
 - Changes to search scroll the window to the top of the search result
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Changes to search scroll the window to the top of the search result
 
 ## [2.4.0] - 2018-11-16
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/components/AccordionFilterItem.js
+++ b/react/components/AccordionFilterItem.js
@@ -7,7 +7,7 @@ import { Link } from 'render'
 import Arrow from '../images/Arrow'
 import CheckTick from '../images/CheckTick'
 import { facetOptionShape } from '../constants/propTypes'
-import { getFilterTitle, formatFacetToLinkPropsParam } from '../constants/SearchHelpers'
+import { getFilterTitle, formatFacetToLinkPropsParam, HEADER_SCROLL_OFFSET } from '../constants/SearchHelpers'
 
 const AccordionFilterItem = ({
   title,
@@ -54,7 +54,7 @@ const AccordionFilterItem = ({
               params={pagesArgs.params}
               query={pagesArgs.queryString}
               onClick={onItemSelected}
-              scrollOptions={{ elementId: 'search-result-anchor' }}
+              scrollOptions={{ baseElementId: 'search-result-anchor', top: -HEADER_SCROLL_OFFSET }}
           >
               {opt.Name}
 

--- a/react/components/AccordionFilterItem.js
+++ b/react/components/AccordionFilterItem.js
@@ -54,8 +54,8 @@ const AccordionFilterItem = ({
               params={pagesArgs.params}
               query={pagesArgs.queryString}
               onClick={onItemSelected}
-              scrollOptions={false}
-            >
+              scrollOptions={{ elementId: 'search-result-anchor' }}
+          >
               {opt.Name}
 
               {false && (

--- a/react/components/OrderBy.js
+++ b/react/components/OrderBy.js
@@ -86,7 +86,7 @@ class OrderBy extends Component {
             params: pagesArgs.params,
             query: pagesArgs.queryString,
             fallbackToWindowLocation: false,
-            scrollOptions: false,
+            scrollOptions: {elementId: 'search-result-anchor'},
           })
         }}
       />

--- a/react/components/OrderBy.js
+++ b/react/components/OrderBy.js
@@ -6,6 +6,7 @@ import { Dropdown } from 'vtex.styleguide'
 import { withRuntimeContext } from 'render'
 
 import SelectionListOrderBy from './SelectionListOrderBy'
+import { HEADER_SCROLL_OFFSET } from '../constants/SearchHelpers'
 
 export const SORT_OPTIONS = [
   {
@@ -86,7 +87,7 @@ class OrderBy extends Component {
             params: pagesArgs.params,
             query: pagesArgs.queryString,
             fallbackToWindowLocation: false,
-            scrollOptions: {elementId: 'search-result-anchor'},
+            scrollOptions: { baseElementId: 'search-result-anchor', top: -HEADER_SCROLL_OFFSET },
           })
         }}
       />

--- a/react/components/PriceRange.js
+++ b/react/components/PriceRange.js
@@ -60,7 +60,7 @@ class PriceRange extends Component {
         page: linkProps.page,
         params: linkProps.params,
         query: linkProps.queryString,
-        scrollOptions: false,
+        scrollOptions: { elementId: 'search-result-anchor' },
       })
     }, DEBOUNCE_TIME)
   }

--- a/react/components/PriceRange.js
+++ b/react/components/PriceRange.js
@@ -5,7 +5,7 @@ import { injectIntl, intlShape } from 'react-intl'
 import { Slider } from 'vtex.styleguide'
 
 import { facetOptionShape } from '../constants/propTypes'
-import { getFilterTitle } from '../constants/SearchHelpers'
+import { getFilterTitle, HEADER_SCROLL_OFFSET } from '../constants/SearchHelpers'
 import FilterOptionTemplate from './FilterOptionTemplate'
 
 const DEBOUNCE_TIME = 500 // ms
@@ -60,7 +60,7 @@ class PriceRange extends Component {
         page: linkProps.page,
         params: linkProps.params,
         query: linkProps.queryString,
-        scrollOptions: { elementId: 'search-result-anchor' },
+        scrollOptions: { baseElementId: 'search-result-anchor', top: -HEADER_SCROLL_OFFSET },
       })
     }, DEBOUNCE_TIME)
   }

--- a/react/components/SearchFilter.js
+++ b/react/components/SearchFilter.js
@@ -5,7 +5,7 @@ import { Link } from 'render'
 
 import FilterOptionTemplate from './FilterOptionTemplate'
 import { facetOptionShape } from '../constants/propTypes'
-import { getFilterTitle, formatFacetToLinkPropsParam } from '../constants/SearchHelpers'
+import { getFilterTitle, formatFacetToLinkPropsParam, HEADER_SCROLL_OFFSET } from '../constants/SearchHelpers'
 
 const SELECTED_FILTER_COLOR = '#368DF7'
 
@@ -65,7 +65,7 @@ class SearchFilter extends Component {
               page={pagesArgs.page}
               params={pagesArgs.params}
               query={pagesArgs.queryString}
-              scrollOptions={{ elementId: 'search-result-anchor' }}
+              scrollOptions={{ baseElementId: 'search-result-anchor', top: -HEADER_SCROLL_OFFSET }}
             >
               <span
                 className="f6 fw3 bb db"

--- a/react/components/SearchFilter.js
+++ b/react/components/SearchFilter.js
@@ -65,7 +65,7 @@ class SearchFilter extends Component {
               page={pagesArgs.page}
               params={pagesArgs.params}
               query={pagesArgs.queryString}
-              scrollOptions={false}
+              scrollOptions={{ elementId: 'search-result-anchor' }}
             >
               <span
                 className="f6 fw3 bb db"

--- a/react/components/SearchFooter.js
+++ b/react/components/SearchFooter.js
@@ -30,6 +30,7 @@ class SearchFooter extends Component {
       page,
       params,
       query,
+      scrollOptions: { elementId: 'search-result-anchor' },
     })
   }
 

--- a/react/components/SearchFooter.js
+++ b/react/components/SearchFooter.js
@@ -4,6 +4,8 @@ import React, { Component, Fragment } from 'react'
 import { IconCaretLeft, IconCaretRight } from 'vtex.styleguide'
 import { withRuntimeContext } from 'render'
 
+import { HEADER_SCROLL_OFFSET } from '../constants/SearchHelpers'
+
 class SearchFooter extends Component {
   static propTypes = {
     /** Amount of products matched with the filters. */
@@ -30,7 +32,7 @@ class SearchFooter extends Component {
       page,
       params,
       query,
-      scrollOptions: { elementId: 'search-result-anchor' },
+      scrollOptions: { baseElementId: 'search-result-anchor', top: -HEADER_SCROLL_OFFSET },
     })
   }
 

--- a/react/components/SearchResultContainer.js
+++ b/react/components/SearchResultContainer.js
@@ -184,6 +184,7 @@ export default class SearchResultContainer extends Component {
 
     return (
       <PopupProvider>
+        <div id="search-result-anchor" className="relative" style={{ top: "-56px" }} />
         <ResultComponent
           {...this.props}
           breadcrumbsProps={this.breadcrumbsProps}

--- a/react/components/SearchResultContainer.js
+++ b/react/components/SearchResultContainer.js
@@ -184,7 +184,7 @@ export default class SearchResultContainer extends Component {
 
     return (
       <PopupProvider>
-        <div id="search-result-anchor" className="relative" style={{ top: "-56px" }} />
+        <div id="search-result-anchor" />
         <ResultComponent
           {...this.props}
           breadcrumbsProps={this.breadcrumbsProps}

--- a/react/components/SelectedFilters.js
+++ b/react/components/SelectedFilters.js
@@ -5,7 +5,7 @@ import { Link } from 'render'
 
 import FilterOptionTemplate from './FilterOptionTemplate'
 import Check from '../images/Check'
-import { formatFacetToLinkPropsParam } from '../constants/SearchHelpers'
+import { formatFacetToLinkPropsParam, HEADER_SCROLL_OFFSET } from '../constants/SearchHelpers'
 
 /**
  * Search Filter Component.
@@ -49,7 +49,7 @@ class SelectedFilters extends Component {
               page={pagesArgs.page}
               params={pagesArgs.params}
               query={pagesArgs.queryString}
-              scrollOptions={{ elementId: 'search-result-anchor' }}
+              scrollOptions={{ baseElementId: 'search-result-anchor', top: -HEADER_SCROLL_OFFSET }}
             >
               <label className="w-100 flex items-center relative f7 fw3 mb2 pointer">
                 <div className="absolute top-0 left-0 bottom-0 z-1">

--- a/react/components/SelectedFilters.js
+++ b/react/components/SelectedFilters.js
@@ -49,7 +49,7 @@ class SelectedFilters extends Component {
               page={pagesArgs.page}
               params={pagesArgs.params}
               query={pagesArgs.queryString}
-              scrollOptions={false}
+              scrollOptions={{ elementId: 'search-result-anchor' }}
             >
               <label className="w-100 flex items-center relative f7 fw3 mb2 pointer">
                 <div className="absolute top-0 left-0 bottom-0 z-1">

--- a/react/components/SelectionListOrderBy.js
+++ b/react/components/SelectionListOrderBy.js
@@ -32,6 +32,7 @@ class SelectionListOrderBy extends Component {
       page: linkProps.page,
       query: linkProps.queryString,
       params: linkProps.params,
+      scrollOptions: { elementId: 'search-result-anchor' },
     })
   }
 

--- a/react/components/SelectionListOrderBy.js
+++ b/react/components/SelectionListOrderBy.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import { injectIntl, intlShape } from 'react-intl'
 import classNames from 'classnames'
 
+import { HEADER_SCROLL_OFFSET } from '../constants/SearchHelpers'
 import CheckTick from '../images/CheckTick'
 import Popup from './Popup'
 
@@ -32,7 +33,7 @@ class SelectionListOrderBy extends Component {
       page: linkProps.page,
       query: linkProps.queryString,
       params: linkProps.params,
-      scrollOptions: { elementId: 'search-result-anchor' },
+      scrollOptions: { baseElementId: 'search-result-anchor', top: -HEADER_SCROLL_OFFSET },
     })
   }
 

--- a/react/constants/SearchHelpers.js
+++ b/react/constants/SearchHelpers.js
@@ -254,3 +254,5 @@ export function formatFacetToLinkPropsParam(type, option, oneSelectedCollapse = 
     type,
   }
 }
+
+export const HEADER_SCROLL_OFFSET = 90


### PR DESCRIPTION
#### What is the purpose of this pull request?
Scroll the window to the top of the search result whenever it changes.

#### What problem is this solving?
When search result shrinks user end up seeing only the footer of the page.