### PR TITLE
Get switcher layout modes by schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Add new mobile design.
+### Added
+- Get switcher layout modes by schema
 
 ### Changed
 - Replace tachyons classes with design tokens.

--- a/react/components/LayoutModeSwitcher.js
+++ b/react/components/LayoutModeSwitcher.js
@@ -6,6 +6,20 @@ import Grid from '../images/Grid'
 import SingleItemGrid from '../images/SingleItemGrid'
 import InlineGrid from '../images/InlineGrid'
 
+export const LAYOUT_MODE = [
+  {
+    value: 'normal',
+    label: 'layoutModeSwitcher.normal',
+  },
+  {
+    value: 'small',
+    label: 'layoutModeSwitcher.small',
+  },
+  {
+    value: 'inline',
+    label: 'layoutModeSwitcher.inline',
+  },
+]
 
 export default function LayoutModeSwitcher({ activeMode, onChange }) {
 

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -8,7 +8,7 @@ import LoadingOverlay from './LoadingOverlay'
 import LayoutModeSwitcher from './LayoutModeSwitcher'
 import { searchResultPropTypes } from '../constants/propTypes'
 import OrderBy from './OrderBy'
-
+import { LAYOUT_MODE } from './LayoutModeSwitcher'
 
 /**
  * Search Result Component.
@@ -17,7 +17,7 @@ class SearchResult extends Component {
   static propTypes = searchResultPropTypes
 
   state = {
-    galleryLayoutMode: 'normal',
+    galleryLayoutMode: this.props.hiddenFacets.layoutMode1 || LAYOUT_MODE[0].value,
     showLoadingAsOverlay: false,
     // The definitions bellow are required because
     // on SSR the getDerivedStateFromProps isn't called
@@ -36,8 +36,9 @@ class SearchResult extends Component {
 
   handleLayoutChange = (e, mode) => {
     e.preventDefault()
-    const defaultModes = ['small', 'inline', 'normal']
-    const modeIndex = (defaultModes.indexOf(this.state.galleryLayoutMode) + 1) % 3
+    
+    const defaultModes = [this.props.hiddenFacets.layoutMode1, this.props.hiddenFacets.layoutMode2]
+    const modeIndex = (defaultModes.indexOf(this.state.galleryLayoutMode) + 1) % 2
     const currentMode = defaultModes[modeIndex]
 
     this.setState({
@@ -50,6 +51,11 @@ class SearchResult extends Component {
     // so we can show the previous products when the
     // overlay is on the screen
     if (!props.loading) {
+      if (!props.hiddenFacets.layoutMode1 && !props.hiddenFacets.layoutMode2) {
+        props.hiddenFacets.layoutMode1 = LAYOUT_MODE[0].value
+        props.hiddenFacets.layoutMode2 = LAYOUT_MODE[1].value
+      }
+
       const {
         products,
         recordsFiltered,
@@ -61,7 +67,7 @@ class SearchResult extends Component {
         rest,
         specificationFilters,
         tree,
-        hiddenFacets,
+        hiddenFacets
       } = props
 
       return {
@@ -75,7 +81,7 @@ class SearchResult extends Component {
         rest,
         specificationFilters,
         tree,
-        hiddenFacets,
+        hiddenFacets
       }
     }
 

--- a/react/index.js
+++ b/react/index.js
@@ -6,6 +6,7 @@ import ProductSummary from 'vtex.product-summary/index'
 import SearchResultContainer from './components/SearchResultContainer'
 import { SORT_OPTIONS } from './components/OrderBy'
 import LocalQuery from './components/LocalQuery'
+import { LAYOUT_MODE } from './components/LayoutModeSwitcher'
 
 const PAGINATION_TYPES = ['show-more', 'infinite-scroll']
 const DEFAULT_MAX_ITEMS_PER_PAGE = 10
@@ -18,9 +19,6 @@ export default class SearchResultQueryLoader extends Component {
   static defaultProps = {
     orderBy: SORT_OPTIONS[0].value,
     rest: '',
-    querySchema: {
-      maxItemsPerPage: DEFAULT_MAX_ITEMS_PER_PAGE,
-    },
   }
 
   static uiSchema = {
@@ -94,6 +92,22 @@ SearchResultQueryLoader.getSchema = props => {
         type: 'object',
         isLayout: true,
         properties: {
+          layoutMode1: {
+            title: 'Layout Mode Switcher 1',
+            type: 'string',
+            default: LAYOUT_MODE[0].value,
+            enum: LAYOUT_MODE.map(opt => opt.value),
+            enumNames: LAYOUT_MODE.map(opt => opt.label),
+            isLayout: true,
+          },
+          layoutMode2: {
+            title: 'Layout Mode Switcher 2',
+            type: 'string',
+            default: LAYOUT_MODE[1].value,
+            enum: LAYOUT_MODE.map(opt => opt.value),
+            enumNames: LAYOUT_MODE.map(opt => opt.label),
+            isLayout: true,
+          },
           brands: {
             title: 'editor.search-result.hiddenFacets.brands',
             type: 'boolean',

--- a/react/locales/en-US.json
+++ b/react/locales/en-US.json
@@ -42,5 +42,8 @@
   "editor.search-result.hiddenFacets.specificationFilters": "Hide Specifications filters",
   "editor.search-result.hiddenFacets.specificationFilters.hideAll": "Hide all the Specifications filters",
   "editor.search-result.hiddenFacets.specificationFilters.hiddenFilter": "Hidden Specification filter",
-  "editor.search-result.hiddenFacets.specificationFilters.hiddenFilter.name": "Hidden Specification filter name"
+  "editor.search-result.hiddenFacets.specificationFilters.hiddenFilter.name": "Hidden Specification filter name",
+  "layoutModeSwitcher.inline": "Line",
+  "layoutModeSwitcher.small": "Small",
+  "layoutModeSwitcher.normal": "Normal"
 }

--- a/react/locales/es-AR.json
+++ b/react/locales/es-AR.json
@@ -42,5 +42,8 @@
   "editor.search-result.hiddenFacets.specificationFilters": "Ocultar filtros de especificaciones",
   "editor.search-result.hiddenFacets.specificationFilters.hideAll": "Ocultar todos los filtros de especificaciones",
   "editor.search-result.hiddenFacets.specificationFilters.hiddenFilter": "Filtro de Especificaciones oculto",
-  "editor.search-result.hiddenFacets.specificationFilters.hiddenFilter.name": "Nombre del filtro de Especificaciones oculto"
+  "editor.search-result.hiddenFacets.specificationFilters.hiddenFilter.name": "Nombre del filtro de Especificaciones oculto",
+  "layoutModeSwitcher.inline": "En línea",
+  "layoutModeSwitcher.small": "Pequeño",
+  "layoutModeSwitcher.normal": "Normal"
 }

--- a/react/locales/pt-BR.json
+++ b/react/locales/pt-BR.json
@@ -42,5 +42,8 @@
   "editor.search-result.hiddenFacets.specificationFilters": "Ocultar filtros de Especificações",
   "editor.search-result.hiddenFacets.specificationFilters.hideAll": "Ocultar todos os filtros de Especificações",
   "editor.search-result.hiddenFacets.specificationFilters.hiddenFilter": "Filtro de Especificacões oculto",
-  "editor.search-result.hiddenFacets.specificationFilters.hiddenFilter.name": "Nome do filtro de Especificações oculto"
+  "editor.search-result.hiddenFacets.specificationFilters.hiddenFilter.name": "Nome do filtro de Especificações oculto",
+  "layoutModeSwitcher.inline": "Na linha",
+  "layoutModeSwitcher.small": "Pequeno",
+  "layoutModeSwitcher.normal": "Normal"
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Retrieve switcher layout modes by schema

#### What problem is this solving?

Get layout mode switcher values dynamically

#### How should this be manually tested?

[Access this workspace on mobile mode](https://theo--storecomponents.myvtex.com/eletronicos/d)
and [Access storefront](https://theo--storecomponents.myvtex.com/admin/cms/storefront) and change search result layout mode on pages

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
