### PR TITLE
Add reactive solution when querySchema is undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add default behavoir when `querySchema` comes undefined from server. 
+
 ### Added
 - Add new mobile design.
 - Not found page component.

--- a/react/components/OrderBy.js
+++ b/react/components/OrderBy.js
@@ -42,7 +42,7 @@ export const SORT_OPTIONS = [
 class OrderBy extends Component {
   static propTypes = {
     /** Which sorting option is selected. */
-    orderBy: PropTypes.string.isRequired,
+    orderBy: PropTypes.string,
     /** Returns the link props. */
     getLinkProps: PropTypes.func,
     /** Intl instance. */

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -15,6 +15,13 @@ import LayoutModeSwitcher, { LAYOUT_MODE } from './LayoutModeSwitcher'
 class SearchResult extends Component {
   static propTypes = searchResultPropTypes
 
+  static defaultProps = {
+    hiddenFacets: {
+      layoutMode1: LAYOUT_MODE[0].value, 
+      layoutMode2: LAYOUT_MODE[1].value, 
+    } 
+  }
+
   state = {
     galleryLayoutMode: this.props.hiddenFacets.layoutMode1 || LAYOUT_MODE[0].value,
     showLoadingAsOverlay: false,

--- a/react/index.js
+++ b/react/index.js
@@ -32,7 +32,7 @@ export default class SearchResultQueryLoader extends Component {
 
   render() {
     const { querySchema } = this.props
-    return !this.props.searchQuery || querySchema.enableCustomQuery ? (
+    return !this.props.searchQuery || (querySchema && querySchema.enableCustomQuery) ? (
       <LocalQuery
         {...this.props}
         {...querySchema}


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
When the `querySchema` props comes undefined the component breaks and make inaccessible the search content.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Add data in default props to feed de component

#### How should this be manually tested?
https://search3xresult--storecomponents.myvtex.com/shirt/s?map=ft

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
