### PR TITLE
return null if contextProperties are unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.4.2] - 2018-12-11
+
 ## [2.4.1] - 2018-11-22
 ### Changed
 - Changes to search scroll the window to the top of the search result

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/components/Popup.js
+++ b/react/components/Popup.js
@@ -86,6 +86,10 @@ export default class Popup extends Component {
     return (
       <Consumer>
         {contextProps => {
+          if (!contextProps) {
+            return null;
+          }
+
           const { isOpen, onToggle } = contextProps
           const open = isOpen(id)
 


### PR DESCRIPTION
Prevent bug with undefined contextProperties.
For `brastemp` project