### PR TITLE
force initial state of collapse to be open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Improve performance at the dreamstore environment, changing the default behavior of the collapse component.
 
 ## [3.6.1] - 2019-01-11
 ### Changed

--- a/react/components/FilterOptionTemplate.js
+++ b/react/components/FilterOptionTemplate.js
@@ -1,8 +1,9 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { Collapse } from 'react-collapse'
+import { NoSSR } from 'render';
 import classNames from 'classnames'
-
+import { canUseDOM } from 'exenv'
 import Arrow from '../images/Arrow'
 
 /**
@@ -91,11 +92,15 @@ export default class FilterOptionTemplate extends Component {
           )}
           style={{ maxHeight: '200px' }}
         >
-          {collapsable ? (
-            <Collapse isOpened={open}>
-              {this.renderChildren()}
-            </Collapse>
-          ) : this.renderChildren()}
+          {canUseDOM && collapsable ?
+            <NoSSR>
+              <Collapse isOpened={open}>
+                {this.renderChildren()}
+              </Collapse>
+            </NoSSR>
+            :
+            this.renderChildren()
+          }
         </div>
       </div>
     )

--- a/react/package.json
+++ b/react/package.json
@@ -9,6 +9,7 @@
   "license": "ISC",
   "dependencies": {
     "classnames": "^2.2.6",
+    "exenv":"1.2.2",
     "query-string": "5",
     "ramda": "^0.25.0",
     "react-adopt": "^0.6.0",


### PR DESCRIPTION
#### What is the purpose of this pull request?
Improve performance at the dreamstore environment, changing the default behavior of the collapse component.

<!--- Describe your changes in detail. -->
`react-collapse` use to be rendered at the server side with initial state closed what forced the client side ( javascript at the browser ) to run a heavy task of processing the expand of the component making the store with a feeling of even more slow at page load.

#### What problem is this solving?
Dreamstore perfomance at page load

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
link the project at the category page of the dream store

#### Screenshots or example usage
![screen shot 2019-01-15 at 11 27 05](https://user-images.githubusercontent.com/13008014/51183534-a3a41780-18b8-11e9-90df-62b557cba2c2.png)


#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
