### PR TITLE
Bar appearing on scroll up and disappearing on scroll down - mobile view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Makes the search options bar disappear on scroll down and appear on scroll up.
 
 ## [3.10.2] - 2019-01-29
 ### Fixed

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -241,7 +241,7 @@ class SearchResult extends Component {
 
     const showLoading = loading && !fetchMoreLoading
     const showContentLoader = showLoading && !showLoadingAsOverlay
-    const searchOptionsBarClasses = classNames({ 'flex justify-center flex-auto fixed z-1 w-100 bg-base bb bw1 b--light-gray pr4': mobile })
+    const searchOptionsBarClasses = classNames({ 'flex justify-center flex-auto fixed z-1 w-100 mw9 bg-base bb bw1 b--light-gray': mobile })
 
     return (
       <LoadingOverlay loading={showLoading && showLoadingAsOverlay}>

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -1,18 +1,17 @@
 import React, { Component } from 'react'
 import { Spinner } from 'vtex.styleguide'
 import { ExtensionPoint, withRuntimeContext } from 'vtex.render-runtime'
-
+import classNames from 'classnames'
 import LoadingOverlay from './LoadingOverlay'
 import { searchResultPropTypes } from '../constants/propTypes'
 import LayoutModeSwitcher, { LAYOUT_MODE } from './LayoutModeSwitcher'
 
 import searchResult from '../searchResult.css'
 
-const HEADER_SIZE = 36
-const CONVERSION_MARGIN_VALUE = 0.08
-const MARGIN_TOP = "-2.4rem"
+const MARGIN_TOP_VISIBLE_SEARCH_BAR_OPTIONS = "0rem"
+const MARGIN_TOP_INVISIBLE_SEARCH_BAR_OPTIONS = "-5.5rem"
 const FADE_DURATION = "500ms" // It should be passed via props in the future
-const FADE_DELAY = "0ms" // Same as above
+const FADE_DELAY = "80ms" // Same as above
 
 /**
  * Search Result Component.
@@ -123,29 +122,26 @@ class SearchResult extends Component {
     if (typeof scroll !== 'number' || !mobile) return
 
     if (scroll > this.state.scrollValue) this.handleScrollDown()
-    else if (scroll < this.state.scrollValue) this.handleScrollUp(scroll)
+    else if (scroll < this.state.scrollValue) this.handleScrollUp()
 
     this.setState({scrollValue: scroll})
   }
 
-  handleScrollUp = scrollValue => {
-    const marginValue = scrollValue * CONVERSION_MARGIN_VALUE
+  handleScrollUp = () => {
+    this.changeSearchOptionsBarVisibility('ease-out', FADE_DURATION, FADE_DELAY, MARGIN_TOP_VISIBLE_SEARCH_BAR_OPTIONS)
 
-    const searchOptionsBarElement = this.searchOptionsBar.current
-    if (searchOptionsBarElement) {
-      searchOptionsBarElement.style.transition = `opacity ${FADE_DURATION} ${FADE_DELAY}`
-      searchOptionsBarElement.style.opacity = 1
-
-      if (scrollValue < HEADER_SIZE) searchOptionsBarElement.style.marginTop = `-${marginValue}rem`
-      else searchOptionsBarElement.style.marginTop = MARGIN_TOP
-    }
   }
 
   handleScrollDown = () => {
+    this.changeSearchOptionsBarVisibility('ease-in', FADE_DURATION, FADE_DELAY, MARGIN_TOP_INVISIBLE_SEARCH_BAR_OPTIONS)
+  }
+
+  changeSearchOptionsBarVisibility = (transition, fadeDuration, fadeDelay, marginTop) => {
     const searchOptionsBarElement = this.searchOptionsBar.current
+
     if (searchOptionsBarElement) {
-      searchOptionsBarElement.style.opacity = 0
-      searchOptionsBarElement.style.transition = `opacity ${FADE_DURATION} ${FADE_DELAY}`
+      searchOptionsBarElement.style.transition = `${transition} ${fadeDuration} ${fadeDelay}`
+      searchOptionsBarElement.style.marginTop = marginTop
     }
   }
 
@@ -247,7 +243,7 @@ class SearchResult extends Component {
 
     const showLoading = loading && !fetchMoreLoading
     const showContentLoader = showLoading && !showLoadingAsOverlay
-    const searchOptionsBarClasses = classNames({ 'flex justify-center flex-auto fixed z-1 bg-base bb bw1 b--light-gray': mobile })
+    const searchOptionsBarClasses = classNames({ 'flex justify-center flex-auto fixed w-100 z-1 bg-base bb bw1 b--light-gray nl3': mobile })
 
     return (
       <LoadingOverlay loading={showLoading && showLoadingAsOverlay}>
@@ -255,20 +251,17 @@ class SearchResult extends Component {
           <div className={`${searchResult.breadcrumb} db-ns dn-s`}>
             <ExtensionPoint id="breadcrumb" {...breadcrumbsProps} />
           </div>
-          <div className={`${searchResult.totalProducts} pv5 bn-ns bt-s b--muted-4 tc-s tl`}>
-            <FormattedMessage
-              id="search.total-products"
-              values={{ recordsFiltered }}
-            >
-              {txt => <span className="ph4 c-muted-2">{txt}</span>}
-            </FormattedMessage>
-          </div>
+          <ExtensionPoint id="total-products"
+              recordsFiltered={recordsFiltered}
+          />
           {mobile ? (
-            <div ref={this.searchOptionsBar} className={`${searchResult.searchOptionsBar} ${searchOptionsBarClasses}`}>
+            <div 
+              ref={this.searchOptionsBar} 
+              className={`${searchResult.searchOptionsBar} ${searchOptionsBarClasses}`}
+            >
               {this.getSearchOptionsBar()}
             </div> 
-          ): 
-            this.getSearchOptionsBar()
+          ) : (this.getSearchOptionsBar())
           }
           <div className={searchResult.resultGallery}>
             {showContentLoader ? (
@@ -293,5 +286,4 @@ class SearchResult extends Component {
     )
   }
 }
-
 export default withRuntimeContext(SearchResult)

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, Fragment } from 'react'
 import { Spinner } from 'vtex.styleguide'
 import { ExtensionPoint, withRuntimeContext } from 'vtex.render-runtime'
 import classNames from 'classnames'
@@ -156,7 +156,7 @@ class SearchResult extends Component {
     const hideFacets = !map || !map.length
 
     return (
-      <React.Fragment>
+      <Fragment>
         {!hideFacets && (
             <ExtensionPoint
               id="filter-navigator"
@@ -175,7 +175,7 @@ class SearchResult extends Component {
             />
         )}
         {mobile && <div className={`${searchResult.border} bg-muted-5 h-50 self-center`} />}
-          <ExtensionPoint id="order-by" className={searchResult.orderBy}
+          <ExtensionPoint id="order-by"
             orderBy={orderBy}
             getLinkProps={getLinkProps}
           />
@@ -188,7 +188,7 @@ class SearchResult extends Component {
               />
             </div>
           </div>}
-      </React.Fragment>
+      </Fragment>
     )
   }
 

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -104,18 +104,21 @@ class SearchResult extends Component {
       })
     }
 
-    document.addEventListener('scroll', this.handleScroll)
+    const {runtime: { hints: { mobile } }} = this.props
+
+    if (mobile) document.addEventListener('scroll', this.handleScroll)
   }
 
   componentWillUnmount() {
-    document.removeEventListener('scroll', this.handleScroll)
+    const {runtime: { hints: { mobile } }} = this.props
+
+    if(mobile) document.removeEventListener('scroll', this.handleScroll)
   }
 
   handleScroll = () => {
     const scroll = this.props.leanMode ? Infinity : window.scrollY
-    const {runtime: { hints: { mobile } }} = this.props
     
-    if (typeof scroll !== 'number' || !mobile) return
+    if (typeof scroll !== 'number') return
 
     scroll > this.state.scrollValue ? this.handleScrollDown() : this.handleScrollUp()
 

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -10,9 +10,9 @@ import searchResult from '../searchResult.css'
 
 const HEADER_SIZE = 36
 const CONVERSION_MARGIN_VALUE = 0.08
-const MARGIN_TOP = -2.4 //rem
-const FADE_DURATION = 500 //ms - It should be passed via props in the future
-const FADE_DELAY = 0 //ms - Same as above
+const MARGIN_TOP = "-2.4rem"
+const FADE_DURATION = "500ms" // It should be passed via props in the future
+const FADE_DELAY = "0ms" // Same as above
 
 /**
  * Search Result Component.
@@ -133,11 +133,11 @@ class SearchResult extends Component {
 
     const searchOptionsBarElement = this.searchOptionsBar.current
     if (searchOptionsBarElement) {
-      searchOptionsBarElement.style.transition = `opacity ${FADE_DURATION}ms ${FADE_DELAY}ms`
+      searchOptionsBarElement.style.transition = `opacity ${FADE_DURATION} ${FADE_DELAY}`
       searchOptionsBarElement.style.opacity = 1
 
       if (scrollValue < HEADER_SIZE) searchOptionsBarElement.style.marginTop = `-${marginValue}rem`
-      else searchOptionsBarElement.style.marginTop = `${MARGIN_TOP}rem`
+      else searchOptionsBarElement.style.marginTop = MARGIN_TOP
     }
   }
 
@@ -145,7 +145,7 @@ class SearchResult extends Component {
     const searchOptionsBarElement = this.searchOptionsBar.current
     if (searchOptionsBarElement) {
       searchOptionsBarElement.style.opacity = 0
-      searchOptionsBarElement.style.transition = `opacity ${FADE_DURATION}ms ${FADE_DELAY}ms`
+      searchOptionsBarElement.style.transition = `opacity ${FADE_DURATION} ${FADE_DELAY}`
     }
   }
 

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -37,7 +37,10 @@ class SearchResult extends Component {
     specificationFilters: this.props.specificationFilters,
     tree: this.props.tree,
     hiddenFacets: this.props.hiddenFacets,
+    scrollValue: 0
   }
+
+  searchOptionsBar = React.createRef()
 
   handleLayoutChange = e => {
     e.preventDefault()
@@ -99,6 +102,42 @@ class SearchResult extends Component {
         showLoadingAsOverlay: true,
       })
     }
+
+    document.addEventListener('scroll', this.handleScroll)
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('scroll', this.handleScroll)
+  }
+
+  handleScroll = () => {
+    // If it's in leanMode, pretend it's scrolled all the way to the bottom,
+    // in order to make it look compressed
+    const scroll = this.props.leanMode ? Infinity : window.scrollY
+    
+    if (typeof scroll !== 'number') return
+
+    this.setState({scrollValue: scroll})
+
+    console.log(scroll)
+    
+    if (scroll > this.state.scrollValue) this.handleScrollDown()
+    else if (scroll < this.state.scrollValue) this.handleScrollUp()
+    else return
+  }
+
+  handleScrollUp = () => {
+    const searchOptionsBarElement = this.searchOptionsBar.current
+    if (searchOptionsBarElement) {
+      searchOptionsBarElement.style.opacity = 1
+    }
+  }
+
+  handleScrollDown = () => {
+    const searchOptionsBarElement = this.searchOptionsBar.current
+    if (searchOptionsBarElement) {
+      searchOptionsBarElement.style.opacity = 0
+    }
   }
 
   componentDidUpdate(prevProps) {
@@ -151,7 +190,7 @@ class SearchResult extends Component {
     const showContentLoader = showLoading && !showLoadingAsOverlay
     return (
       <LoadingOverlay loading={showLoading && showLoadingAsOverlay}>
-        <div className={`${searchResult.container} w-100 mw9`}>
+        <div className={`${searchResult.container} w-100 mw9 relative`}>
           <div className={`${searchResult.breadcrumb} db-ns dn-s`}>
             <ExtensionPoint id="breadcrumb" {...breadcrumbsProps} />
           </div>

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -128,12 +128,16 @@ class SearchResult extends Component {
   }
 
   handleScrollUp = () => {
+    const marginValue = this.state.scrollValue * -0.085 - 3.4
+
+    console.log(marginValue)
+
     const searchOptionsBarElement = this.searchOptionsBar.current
     if (searchOptionsBarElement) {
       searchOptionsBarElement.style.opacity = 1
 
       if (this.state.scrollValue < 40) searchOptionsBarElement.style.marginTop = 0
-      else searchOptionsBarElement.style.marginTop = "-3.4rem"
+      else searchOptionsBarElement.style.marginTop = `-3.4rem`
     }
     console.log("up")
   }

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -18,9 +18,7 @@ class SearchResult extends Component {
     hiddenFacets: {
       layoutMode1: LAYOUT_MODE[0].value,
       layoutMode2: LAYOUT_MODE[1].value,
-    },
-    easeDuration: '500ms',
-    easeDelay: '80ms'
+    }
   }
 
   state = {

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -117,20 +117,25 @@ class SearchResult extends Component {
     
     if (typeof scroll !== 'number') return
 
-    this.setState({scrollValue: scroll})
-
+    
     console.log(scroll)
+    console.log(this.state.scrollValue)
     
     if (scroll > this.state.scrollValue) this.handleScrollDown()
     else if (scroll < this.state.scrollValue) this.handleScrollUp()
-    else return
+
+    this.setState({scrollValue: scroll})
   }
 
   handleScrollUp = () => {
     const searchOptionsBarElement = this.searchOptionsBar.current
     if (searchOptionsBarElement) {
       searchOptionsBarElement.style.opacity = 1
+
+      if (this.state.scrollValue < 40) searchOptionsBarElement.style.marginTop = 0
+      else searchOptionsBarElement.style.marginTop = "-3.4rem"
     }
+    console.log("up")
   }
 
   handleScrollDown = () => {
@@ -138,6 +143,8 @@ class SearchResult extends Component {
     if (searchOptionsBarElement) {
       searchOptionsBarElement.style.opacity = 0
     }
+
+    console.log("down")
   }
 
   componentDidUpdate(prevProps) {
@@ -188,6 +195,7 @@ class SearchResult extends Component {
     const hideFacets = !map || !map.length
     const showLoading = loading && !fetchMoreLoading
     const showContentLoader = showLoading && !showLoadingAsOverlay
+    
     return (
       <LoadingOverlay loading={showLoading && showLoadingAsOverlay}>
         <div className={`${searchResult.container} w-100 mw9 relative`}>

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -10,8 +10,6 @@ import searchResult from '../searchResult.css'
 
 const MARGIN_TOP_VISIBLE_SEARCH_BAR_OPTIONS = "0rem"
 const MARGIN_TOP_INVISIBLE_SEARCH_BAR_OPTIONS = "-5.5rem"
-const FADE_DURATION = "500ms" // It should be passed via props in the future
-const FADE_DELAY = "80ms" // Same as above
 
 /**
  * Search Result Component.
@@ -24,6 +22,8 @@ class SearchResult extends Component {
       layoutMode1: LAYOUT_MODE[0].value,
       layoutMode2: LAYOUT_MODE[1].value,
     },
+    easeDuration: '500ms',
+    easeDelay: '80ms'
   }
 
   state = {
@@ -128,19 +128,19 @@ class SearchResult extends Component {
   }
 
   handleScrollUp = () => {
-    this.changeSearchOptionsBarVisibility('ease-out', FADE_DURATION, FADE_DELAY, MARGIN_TOP_VISIBLE_SEARCH_BAR_OPTIONS)
+    this.changeSearchOptionsBarVisibility('ease-out', this.props.easeDuration, this.props.easeDelay, MARGIN_TOP_VISIBLE_SEARCH_BAR_OPTIONS)
 
   }
 
   handleScrollDown = () => {
-    this.changeSearchOptionsBarVisibility('ease-in', FADE_DURATION, FADE_DELAY, MARGIN_TOP_INVISIBLE_SEARCH_BAR_OPTIONS)
+    this.changeSearchOptionsBarVisibility('ease-in', this.props.easeDuration, this.props.easeDelay, MARGIN_TOP_INVISIBLE_SEARCH_BAR_OPTIONS)
   }
 
-  changeSearchOptionsBarVisibility = (transition, fadeDuration, fadeDelay, marginTop) => {
+  changeSearchOptionsBarVisibility = (transition, easeDuration, easeDelay, marginTop) => {
     const searchOptionsBarElement = this.searchOptionsBar.current
 
     if (searchOptionsBarElement) {
-      searchOptionsBarElement.style.transition = `${transition} ${fadeDuration} ${fadeDelay}`
+      searchOptionsBarElement.style.transition = `${transition} ${easeDuration} ${easeDelay}`
       searchOptionsBarElement.style.marginTop = marginTop
     }
   }

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -8,9 +8,6 @@ import LayoutModeSwitcher, { LAYOUT_MODE } from './LayoutModeSwitcher'
 
 import searchResult from '../searchResult.css'
 
-const MARGIN_TOP_VISIBLE_SEARCH_BAR_OPTIONS = "0rem"
-const MARGIN_TOP_INVISIBLE_SEARCH_BAR_OPTIONS = "-5.5rem"
-
 /**
  * Search Result Component.
  */
@@ -42,10 +39,9 @@ class SearchResult extends Component {
     specificationFilters: this.props.specificationFilters,
     tree: this.props.tree,
     hiddenFacets: this.props.hiddenFacets,
-    scrollValue: 0
+    scrollValue: 0,
+    scrollDirection: 'up'
   }
-
-  searchOptionsBar = React.createRef()
 
   handleLayoutChange = e => {
     e.preventDefault()
@@ -121,28 +117,17 @@ class SearchResult extends Component {
     
     if (typeof scroll !== 'number' || !mobile) return
 
-    if (scroll > this.state.scrollValue) this.handleScrollDown()
-    else if (scroll < this.state.scrollValue) this.handleScrollUp()
+    scroll > this.state.scrollValue ? this.handleScrollDown() : this.handleScrollUp()
 
     this.setState({scrollValue: scroll})
   }
 
   handleScrollUp = () => {
-    this.changeSearchOptionsBarVisibility('ease-out', this.props.easeDuration, this.props.easeDelay, MARGIN_TOP_VISIBLE_SEARCH_BAR_OPTIONS)
-
+    this.setState({scrollDirection: 'up'})
   }
 
   handleScrollDown = () => {
-    this.changeSearchOptionsBarVisibility('ease-in', this.props.easeDuration, this.props.easeDelay, MARGIN_TOP_INVISIBLE_SEARCH_BAR_OPTIONS)
-  }
-
-  changeSearchOptionsBarVisibility = (transition, easeDuration, easeDelay, marginTop) => {
-    const searchOptionsBarElement = this.searchOptionsBar.current
-
-    if (searchOptionsBarElement) {
-      searchOptionsBarElement.style.transition = `${transition} ${easeDuration} ${easeDelay}`
-      searchOptionsBarElement.style.marginTop = marginTop
-    }
+    this.setState({scrollDirection: 'down'})
   }
 
   getSearchOptionsBar = () => {
@@ -189,7 +174,7 @@ class SearchResult extends Component {
             />
         )}
         {mobile && <div className={`${searchResult.border} bg-muted-5 h-50 self-center`} />}
-          <ExtensionPoint id="order-by"
+          <ExtensionPoint id="order-by" className={searchResult.orderBy}
             orderBy={orderBy}
             getLinkProps={getLinkProps}
           />
@@ -227,9 +212,9 @@ class SearchResult extends Component {
       galleryLayoutMode,
       recordsFiltered,
       products,
-      map,
       params,
       showLoadingAsOverlay,
+      scrollDirection
     } = this.state
 
     const term = params && params.term
@@ -244,6 +229,7 @@ class SearchResult extends Component {
     const showLoading = loading && !fetchMoreLoading
     const showContentLoader = showLoading && !showLoadingAsOverlay
     const searchOptionsBarClasses = classNames({ 'flex justify-center flex-auto fixed w-100 z-1 bg-base bb bw1 b--light-gray nl3': mobile })
+    const searchOptionsBarVisibility = scrollDirection === 'up' ? 'animated fadeInDownBig faster' : 'animated fadeOutUpBig slower'
 
     return (
       <LoadingOverlay loading={showLoading && showLoadingAsOverlay}>
@@ -254,11 +240,9 @@ class SearchResult extends Component {
           <ExtensionPoint id="total-products"
               recordsFiltered={recordsFiltered}
           />
-          {mobile ? (
-            <div 
-              ref={this.searchOptionsBar} 
-              className={`${searchResult.searchOptionsBar} ${searchOptionsBarClasses}`}
-            >
+          {mobile ? 
+          (
+            <div className={`${searchResult.searchOptionsBar} ${searchOptionsBarClasses} ${searchOptionsBarVisibility}`}>
               {this.getSearchOptionsBar()}
             </div> 
           ) : (this.getSearchOptionsBar())

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -8,6 +8,12 @@ import LayoutModeSwitcher, { LAYOUT_MODE } from './LayoutModeSwitcher'
 
 import searchResult from '../searchResult.css'
 
+const HEADER_SIZE = 36
+const CONVERSION_MARGIN_VALUE = 0.08
+const MARGIN_TOP = -2.4 //rem
+const FADE_DURATION = 500 //ms - It should be passed via props in the future
+const FADE_DELAY = 0 //ms - Same as above
+
 /**
  * Search Result Component.
  */
@@ -111,8 +117,6 @@ class SearchResult extends Component {
   }
 
   handleScroll = () => {
-    // If it's in leanMode, pretend it's scrolled all the way to the bottom,
-    // in order to make it look compressed
     const scroll = this.props.leanMode ? Infinity : window.scrollY
     const {runtime: { hints: { mobile } }} = this.props
     
@@ -125,14 +129,15 @@ class SearchResult extends Component {
   }
 
   handleScrollUp = scrollValue => {
-    const marginValue = scrollValue * 0.08
+    const marginValue = scrollValue * CONVERSION_MARGIN_VALUE
 
     const searchOptionsBarElement = this.searchOptionsBar.current
     if (searchOptionsBarElement) {
+      searchOptionsBarElement.style.transition = `opacity ${FADE_DURATION}ms ${FADE_DELAY}ms`
       searchOptionsBarElement.style.opacity = 1
 
-      if (scrollValue < 36) searchOptionsBarElement.style.marginTop = `-${marginValue}rem`
-      else searchOptionsBarElement.style.marginTop = `-2.4rem`
+      if (scrollValue < HEADER_SIZE) searchOptionsBarElement.style.marginTop = `-${marginValue}rem`
+      else searchOptionsBarElement.style.marginTop = `${MARGIN_TOP}rem`
     }
   }
 
@@ -140,6 +145,7 @@ class SearchResult extends Component {
     const searchOptionsBarElement = this.searchOptionsBar.current
     if (searchOptionsBarElement) {
       searchOptionsBarElement.style.opacity = 0
+      searchOptionsBarElement.style.transition = `opacity ${FADE_DURATION}ms ${FADE_DELAY}ms`
     }
   }
 
@@ -241,7 +247,7 @@ class SearchResult extends Component {
 
     const showLoading = loading && !fetchMoreLoading
     const showContentLoader = showLoading && !showLoadingAsOverlay
-    const searchOptionsBarClasses = classNames({ 'flex justify-center flex-auto fixed z-1 w-100 mw9 bg-base bb bw1 b--light-gray': mobile })
+    const searchOptionsBarClasses = classNames({ 'flex justify-center flex-auto fixed z-1 bg-base bb bw1 b--light-gray': mobile })
 
     return (
       <LoadingOverlay loading={showLoading && showLoadingAsOverlay}>
@@ -257,9 +263,13 @@ class SearchResult extends Component {
               {txt => <span className="ph4 c-muted-2">{txt}</span>}
             </FormattedMessage>
           </div>
-          {mobile ? <div ref={this.searchOptionsBar} className={`${searchResult.searchOptionsBar} ${searchOptionsBarClasses}`}>
-            {this.getSearchOptionsBar()}
-          </div> : this.getSearchOptionsBar()}
+          {mobile ? (
+            <div ref={this.searchOptionsBar} className={`${searchResult.searchOptionsBar} ${searchOptionsBarClasses}`}>
+              {this.getSearchOptionsBar()}
+            </div> 
+          ): 
+            this.getSearchOptionsBar()
+          }
           <div className={searchResult.resultGallery}>
             {showContentLoader ? (
               <div className="w-100 flex justify-center">

--- a/react/searchResult.css
+++ b/react/searchResult.css
@@ -254,7 +254,8 @@
     -ms-grid-columns: 2fr 1px 1.5fr 1px 0.2fr;
     grid-template-columns: 2fr 1px 1.5fr 1px 0.2fr;
     grid-template-areas:
-      "orderby border filters borderseq switch"
+      "orderby border filters borderseq switch";
+    width: 96%
   }
 }
 

--- a/react/searchResult.css
+++ b/react/searchResult.css
@@ -148,6 +148,7 @@
   grid-row: quantity;
   justify-self: end;
   align-self: center;
+  padding-top: 3.5rem;
 }
 
 .orderBy {
@@ -157,6 +158,9 @@
   grid-row: orderby;
   align-self: center;
   justify-self: stretch;
+}
+.searchOptionsBar{
+
 }
 
 .accordionFilterItemHidden {}
@@ -223,7 +227,7 @@
     -ms-grid-columns: 2fr 1px 1.5fr 1px 0.2fr;
     grid-template-columns: 2fr 1px 1.5fr 1px 0.2fr;
     grid-template-areas:
-      "orderby border filters borderseq switch"
+      "searchoptionsbar searchoptionsbar searchoptionsbar searchoptionsbar searchoptionsbar"
       "quantity quantity quantity quantity quantity"
       "gallery gallery gallery gallery gallery";
   }
@@ -242,6 +246,15 @@
 
   .totalProducts {
     justify-self: stretch;
+  }
+
+  .searchOptionsBar{
+    display: grid;
+    display: -ms-grid;
+    -ms-grid-columns: 2fr 1px 1.5fr 1px 0.2fr;
+    grid-template-columns: 2fr 1px 1.5fr 1px 0.2fr;
+    grid-template-areas:
+      "orderby border filters borderseq switch"
   }
 }
 

--- a/react/searchResult.css
+++ b/react/searchResult.css
@@ -148,7 +148,6 @@
   grid-row: quantity;
   justify-self: end;
   align-self: center;
-  padding-top: 3.5rem;
 }
 
 .orderBy {
@@ -246,6 +245,7 @@
 
   .totalProducts {
     justify-self: stretch;
+    padding-top: 4.5rem;
   }
 
   .searchOptionsBar{

--- a/react/searchResult.css
+++ b/react/searchResult.css
@@ -255,7 +255,6 @@
     grid-template-columns: 2fr 1px 1.5fr 1px 0.2fr;
     grid-template-areas:
       "orderby border filters borderseq switch";
-    width: 96%
   }
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Makes the search options bar always visible on mobile view but also taking advantage of the whole screen.
<!--- Describe your changes in detail. -->

#### What problem is this solving?
The fact that the user may want to filter the products while he is seeing them, so instead of scroll all the way up, he may just scroll a little bit and have the options right there.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
[Workspace Link](https://searchresultoptionsbar--storecomponents.myvtex.com/clothing) in mobile view and scroll down to disappear and up to appear.

#### Screenshots or example usage
![captura de tela de 2019-01-28 09-48-00](https://user-images.githubusercontent.com/9946330/51837362-f252a800-22e1-11e9-92ec-c9f93ccbdfb8.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
