### PR TITLE
 Add order-by and total-products in search-result interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.10.0] - 2019-01-29
 ### Added
 - Add `order-by` and `total-products` on `search-result` interface.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `order-by` and `total-products` on `search-result` interface.
+
 ### Changed
 - Now, `filter-navigator` block is an allowed block.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Now, `filter-navigator` block is an allowed block.
 
 ## [3.9.1] - 2019-01-26
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "3.9.1",
+  "version": "3.10.0",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/OrderBy.js
+++ b/react/OrderBy.js
@@ -4,8 +4,8 @@ import { injectIntl, intlShape } from 'react-intl'
 import { Dropdown } from 'vtex.styleguide'
 import { withRuntimeContext } from 'vtex.render-runtime'
 
-import SelectionListOrderBy from './SelectionListOrderBy'
-import { HEADER_SCROLL_OFFSET } from '../constants/SearchHelpers'
+import SelectionListOrderBy from './components/SelectionListOrderBy'
+import { HEADER_SCROLL_OFFSET } from './constants/SearchHelpers'
 
 export const SORT_OPTIONS = [
   {

--- a/react/TotalProducts.js
+++ b/react/TotalProducts.js
@@ -1,0 +1,27 @@
+import { FormattedMessage } from 'react-intl'
+import React, { Fragment } from 'react'
+import PropTypes from 'prop-types'
+
+import searchResult from './searchResult.css'
+
+const TotalProducts = ({ recordsFiltered }) => {
+  return (
+    <Fragment>
+      <div className={`${searchResult.totalProducts} pv5 bn-ns bt-s b--muted-4 tc-s tl`}>
+        <FormattedMessage
+          id="search.total-products"
+          values={{ recordsFiltered }}
+        >
+          {txt => <span className="ph4 c-muted-2">{txt}</span>}
+        </FormattedMessage>
+      </div>
+    </Fragment>
+  )
+}
+
+TotalProducts.propTypes = {
+  /** Search term */
+  term: PropTypes.string.recordsFiltered,
+}
+
+export default TotalProducts

--- a/react/TotalProducts.js
+++ b/react/TotalProducts.js
@@ -20,8 +20,8 @@ const TotalProducts = ({ recordsFiltered }) => {
 }
 
 TotalProducts.propTypes = {
-  /** Search term */
-  term: PropTypes.string.recordsFiltered,
+  /** Total of records filtered */
+  recordsFiltered: PropTypes.string.recordsFiltered,
 }
 
 export default TotalProducts

--- a/react/TotalProducts.js
+++ b/react/TotalProducts.js
@@ -1,21 +1,16 @@
 import { FormattedMessage } from 'react-intl'
-import React, { Fragment } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 
 import searchResult from './searchResult.css'
 
 const TotalProducts = ({ recordsFiltered }) => {
   return (
-    <Fragment>
       <div className={`${searchResult.totalProducts} pv5 bn-ns bt-s b--muted-4 tc-s tl`}>
-        <FormattedMessage
-          id="search.total-products"
-          values={{ recordsFiltered }}
-        >
+        <FormattedMessage id="search.total-products" values={{ recordsFiltered }}>
           {txt => <span className="ph4 c-muted-2">{txt}</span>}
         </FormattedMessage>
       </div>
-    </Fragment>
   )
 }
 

--- a/react/components/LocalQuery.js
+++ b/react/components/LocalQuery.js
@@ -3,7 +3,7 @@ import { Query } from 'react-apollo'
 import { withRuntimeContext } from 'vtex.render-runtime'
 import { Queries } from 'vtex.store-resources'
 
-import { SORT_OPTIONS } from './OrderBy'
+import { SORT_OPTIONS } from '../OrderBy'
 
 const DEFAULT_PAGE = 1
 

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -1,11 +1,10 @@
 import React, { Component } from 'react'
 import { Spinner } from 'vtex.styleguide'
 import { ExtensionPoint, withRuntimeContext } from 'vtex.render-runtime'
-import { FormattedMessage } from 'react-intl'
+
 import classNames from 'classnames'
 import LoadingOverlay from './LoadingOverlay'
 import { searchResultPropTypes } from '../constants/propTypes'
-import OrderBy from './OrderBy'
 import LayoutModeSwitcher, { LAYOUT_MODE } from './LayoutModeSwitcher'
 
 import searchResult from '../searchResult.css'
@@ -158,14 +157,6 @@ class SearchResult extends Component {
           <div className={`${searchResult.breadcrumb} db-ns dn-s`}>
             <ExtensionPoint id="breadcrumb" {...breadcrumbsProps} />
           </div>
-          <div className={`${searchResult.totalProducts} pv5 bn-ns bt-s b--muted-4 tc-s tl`}>
-            <FormattedMessage
-              id="search.total-products"
-              values={{ recordsFiltered }}
-            >
-              {txt => <span className="ph4 c-muted-2">{txt}</span>}
-            </FormattedMessage>
-          </div>
           {!hideFacets && (
             <div className={searchResult.filters}>
               <div className={filterClasses}>
@@ -188,8 +179,11 @@ class SearchResult extends Component {
             </div>
           )}
           {mobile && <div className={`${searchResult.border} bg-muted-5 h-50 self-center`} />}
+          <ExtensionPoint id="total-products"
+              recordsFiltered={recordsFiltered}
+          />
           <div className={searchResult.orderBy}>
-            <OrderBy
+            <ExtensionPoint id="order-by"
               orderBy={orderBy}
               getLinkProps={getLinkProps}
             />

--- a/react/index.js
+++ b/react/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import ProductSummary from 'vtex.product-summary/index'
 
 import SearchResultContainer from './components/SearchResultContainer'
-import { SORT_OPTIONS } from './components/OrderBy'
+import { SORT_OPTIONS } from './OrderBy'
 import LocalQuery from './components/LocalQuery'
 import { LAYOUT_MODE } from './components/LayoutModeSwitcher'
 

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -9,7 +9,6 @@
     "inheritComponent": true
   },
   "filter-navigator": {
-    "blocks": [],
     "inheritComponent": true
   },
   "gallery": {
@@ -19,7 +18,6 @@
     "inheritComponent": true
   },
   "not-found": {
-    "blocks": [],
     "inheritComponent": true
   }
 }

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -4,7 +4,9 @@
       "filter-navigator",
       "gallery",
       "not-found",
-      "breadcrumb"
+      "breadcrumb",
+      "total-products",
+      "order-by"
     ],
     "inheritComponent": true
   },
@@ -18,6 +20,12 @@
     "inheritComponent": true
   },
   "not-found": {
+    "inheritComponent": true
+  },
+  "total-products": {
+    "inheritComponent": true
+  },
+  "order-by": {
     "inheritComponent": true
   }
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -3,7 +3,9 @@
     "allowed": [
       "not-found",
       "breadcrumb",
-      "filter-navigator"
+      "filter-navigator",
+      "total-products",
+      "order-by"
     ],
     "required": [
       "gallery"
@@ -24,5 +26,11 @@
       "shelf"
     ],
     "component": "NotFoundSearch"
+  },
+  "order-by": {
+    "component": "OrderBy"
+  },
+  "total-products": {
+    "component": "TotalProducts"
   }
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -2,21 +2,18 @@
   "search-result": {
     "allowed": [
       "not-found",
-      "breadcrumb"
+      "breadcrumb",
+      "filter-navigator"
     ],
     "required": [
-      "filter-navigator",
       "gallery"
     ],
     "component": "index"
   },
   "filter-navigator": {
-    "allowed": [],
-    "required": [],
     "component": "FilterNavigator"
   },
   "gallery": {
-    "allowed": [],
     "required": [
       "product-summary"
     ],
@@ -26,7 +23,6 @@
     "allowed": [
       "shelf"
     ],
-    "required": [],
     "component": "NotFoundSearch"
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Also, filter-navigator block is an allowed block

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage
https://search--storecomponents.myvtex.com/clothing

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
