### PR TITLE
Fix Gallery Scroll and Query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.11.1] - 2019-01-31
 ### Fixed
 - Pass `scrollTop` param to list, fix `fetchMore` query and fix layout when more items are loaded.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Pass `scrollTop` param to list and set ``overscanRowCount` to 2.
 
 ## [3.11.0] - 2019-01-30
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Pass `scrollTop` param to list and set `overscanRowCount` to 2.
+- Pass `scrollTop` param to list, fix `fetchMore` query and fix layout when more items are loaded.
 
 ## [3.11.0] - 2019-01-30
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Pass `scrollTop` param to list and set ``overscanRowCount` to 2.
+- Pass `scrollTop` param to list and set `overscanRowCount` to 2.
 
 ## [3.11.0] - 2019-01-30
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -34,6 +34,7 @@ const Gallery = ({
   itemWidth,
 }) => {
 
+  //Necessary to compute layout properly (e.g. from 'inline' to 'normal' or small)
   cache.clearAll()
 
   const renderItem = item => (
@@ -92,17 +93,19 @@ const Gallery = ({
             scroller: <WindowScroller />,
             autoSizer: <AutoSizer disableHeight />,
           }}
-          mapProps={({ scroller: { height }, autoSizer: { width } }) => ({ width, height })}
+          mapProps={({ scroller: { height, scrollTop }, autoSizer: { width } }) => ({ width, height, scrollTop })}
         >
-          {({ width, height }) => {
+          {({ width, height, scrollTop }) => {
             const itemsPerRow = (layoutMode === 'small' && mobile) ? TWO_ITEMS : (Math.floor(width / itemWidth) || ONE_ITEM)
             const nRows = Math.ceil(products.length / itemsPerRow)
-
+          
             return (
               <List
                 key={layoutMode}
                 deferredMeasurementCache={cache}
+                overscanRowCount={2}
                 autoHeight
+                scrollTop={scrollTop}
                 width={width}
                 height={height}
                 rowCount={nRows}

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -3,6 +3,7 @@ import classNames from 'classnames'
 import { List, WindowScroller, AutoSizer, CellMeasurer, CellMeasurerCache } from 'react-virtualized'
 import PropTypes from 'prop-types'
 import { Adopt } from 'react-adopt'
+import { map } from 'ramda'
 
 import { withRuntimeContext, NoSSR } from 'vtex.render-runtime'
 
@@ -69,7 +70,7 @@ class Gallery extends Component {
         rowIndex={index}
       >
         <div className={containerClasses} key={key} style={style}>
-          {rowItems.map(this.renderItem)}
+          {map(this.renderItem, rowItems)}
         </div>
       </CellMeasurer>
     )
@@ -84,9 +85,14 @@ class Gallery extends Component {
 
     return (
       <div className={ssrContainer}>
-        {products.map(this.renderItem)}
+        {map(this.renderItem, products)}
       </div>
     )
+  }
+
+  updateCache = layoutMode => {
+      this.setState({ layoutMode })
+      this.cache.clearAll()
   }
 
   render() {
@@ -96,10 +102,12 @@ class Gallery extends Component {
       runtime: { hints: { mobile } },
       itemWidth,
     } = this.props
-
-    // Reset the cache to recalculate the heights when layout changes
+    // Maps the WindowScroller and the AutoSizer props to an adequate set of params
+    const mapContainerProps = ({ scroller: { height, scrollTop, isScrolling }, autoSizer: { width } }) => ({ width, height, scrollTop, isScrolling })
+    
+    //Updates the cache to recalculate heights if the layoutMode changes
     if (layoutMode !== this.state.prevLayoutMode) {
-      this.cache.clearAll()
+      this.updateCache(layoutMode)
     }
 
     return (
@@ -110,7 +118,7 @@ class Gallery extends Component {
               scroller: <WindowScroller />,
               autoSizer: <AutoSizer disableHeight />,
             }}
-            mapProps={({ scroller: { height, scrollTop, isScrolling }, autoSizer: { width } }) => ({ width, height, scrollTop, isScrolling })}
+            mapProps={mapContainerProps}
           >
             {({ width, height, scrollTop, isScrolling }) => {
               const itemsPerRow = (layoutMode === 'small' && mobile) ? TWO_ITEMS : (Math.floor(width / itemWidth) || ONE_ITEM)

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -91,8 +91,8 @@ class Gallery extends Component {
   }
 
   updateCache = layoutMode => {
-      this.setState({ layoutMode })
-      this.cache.clearAll()
+    this.setState({ prevLayoutMode: layoutMode })
+    this.cache.clearAll()
   }
 
   render() {
@@ -102,10 +102,10 @@ class Gallery extends Component {
       runtime: { hints: { mobile } },
       itemWidth,
     } = this.props
-    // Maps the WindowScroller and the AutoSizer props to an adequate set of params
+    // Maps the WindowScroller and the AutoSizer props to a more adequate set of params
     const mapContainerProps = ({ scroller: { height, scrollTop, isScrolling }, autoSizer: { width } }) => ({ width, height, scrollTop, isScrolling })
-    
-    //Updates the cache to recalculate heights if the layoutMode changes
+
+    // Updates the cache to recalculate heights if the layoutMode changes
     if (layoutMode !== this.state.prevLayoutMode) {
       this.updateCache(layoutMode)
     }

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -156,7 +156,7 @@ class SearchResult extends Component {
             <ExtensionPoint id="breadcrumb" {...breadcrumbsProps} />
           </div>
           <ExtensionPoint id="total-products"
-              recordsFiltered={recordsFiltered}
+            recordsFiltered={recordsFiltered}
           />
           {!hideFacets && (
             <ExtensionPoint

--- a/react/components/SearchResultContainer.js
+++ b/react/components/SearchResultContainer.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import QueryString from 'query-string'
+import { min } from 'ramda'
 
 import { Container } from 'vtex.store-components'
 
@@ -131,7 +132,7 @@ export default class SearchResultContainer extends Component {
 
     const { maxItemsPerPage, searchQuery: { products, recordsFiltered } } = this.props
 
-    const to = Math.min(+maxItemsPerPage + products.length, recordsFiltered) - 1
+    const to = min(maxItemsPerPage + products.length, recordsFiltered) - 1
 
     this.setState({
       fetchMoreLoading: true,

--- a/react/components/SearchResultContainer.js
+++ b/react/components/SearchResultContainer.js
@@ -139,9 +139,10 @@ export default class SearchResultContainer extends Component {
     this.props.searchQuery.fetchMore({
       variables: {
         from: products.length,
-        to,
+        ...to,
       },
       updateQuery: (prevResult, { fetchMoreResult }) => {
+        
         this.setState({
           fetchMoreLoading: false,
         }, () => {

--- a/react/components/SearchResultContainer.js
+++ b/react/components/SearchResultContainer.js
@@ -142,7 +142,6 @@ export default class SearchResultContainer extends Component {
         ...to,
       },
       updateQuery: (prevResult, { fetchMoreResult }) => {
-        
         this.setState({
           fetchMoreLoading: false,
         }, () => {

--- a/react/components/SearchResultContainer.js
+++ b/react/components/SearchResultContainer.js
@@ -19,6 +19,7 @@ export default class SearchResultContainer extends Component {
 
   static defaultProps = {
     showMore: false,
+    maxItemsPerPage: 10
   }
 
   state = {
@@ -128,9 +129,10 @@ export default class SearchResultContainer extends Component {
 
     this._fetchMoreLocked = true
 
-    const { maxItemsPerPage, searchQuery: { products } } = this.props
+    const { maxItemsPerPage, searchQuery: { products, recordsFiltered } } = this.props
 
-    const to = maxItemsPerPage + products.length - 1
+    const to = Math.min(+maxItemsPerPage + products.length, recordsFiltered) - 1
+    console.log(to, maxItemsPerPage, recordsFiltered)
 
     this.setState({
       fetchMoreLoading: true,

--- a/react/components/SearchResultContainer.js
+++ b/react/components/SearchResultContainer.js
@@ -141,7 +141,7 @@ export default class SearchResultContainer extends Component {
     this.props.searchQuery.fetchMore({
       variables: {
         from: products.length,
-        ...to,
+        to,
       },
       updateQuery: (prevResult, { fetchMoreResult }) => {
         this.setState({

--- a/react/components/SearchResultContainer.js
+++ b/react/components/SearchResultContainer.js
@@ -19,7 +19,7 @@ export default class SearchResultContainer extends Component {
 
   static defaultProps = {
     showMore: false,
-    maxItemsPerPage: 10
+    maxItemsPerPage: 10,
   }
 
   state = {
@@ -132,7 +132,6 @@ export default class SearchResultContainer extends Component {
     const { maxItemsPerPage, searchQuery: { products, recordsFiltered } } = this.props
 
     const to = Math.min(+maxItemsPerPage + products.length, recordsFiltered) - 1
-    console.log(to, maxItemsPerPage, recordsFiltered)
 
     this.setState({
       fetchMoreLoading: true,


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix the query that loaded more items and fix the size of the gallery items when more items were loaded.

### What problem is this solving?
The loadmore wasn't working at all and the layout broke when more items were loaded.

#### How should this be manually tested?
[workspace](https://fixsrscroll--phmex.myvtex.com/pizza)

#### Types of changes

* [X] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
