### PR TITLE
Gallery spaces can be customized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Spaces between `Gallery Items` can be customized now and theses spaces width won't change on screen resize.
 
 ## [3.11.2] - 2019-02-01
 

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -37,8 +37,8 @@ class Gallery extends Component {
 
   renderItem = item => {
     const { summary, layoutMode, runtime: { hints: { mobile } } } = this.props
-    const galleryItemClasses = classNames(searchResult.galleryItem, {
-      'mv2 pa1': mobile
+    const galleryItemClasses = classNames(searchResult.galleryItem, 'pa1', {
+      'mv2': mobile
     })
     return (
       <div
@@ -66,7 +66,7 @@ class Gallery extends Component {
 
     const styleWithGap = {
       ...style,
-      gridGap: `${gap}rem`,
+      gridGap: gap,
     }
 
     return (
@@ -109,6 +109,7 @@ class Gallery extends Component {
       layoutMode,
       runtime: { hints: { mobile } },
       itemWidth,
+      gap,
     } = this.props
     // Maps the WindowScroller and the AutoSizer props to a more adequate set of params
     const mapContainerProps = ({ scroller: { height, scrollTop, isScrolling }, autoSizer: { width } }) => ({ width, height, scrollTop, isScrolling })
@@ -129,9 +130,9 @@ class Gallery extends Component {
             mapProps={mapContainerProps}
           >
             {({ width, height, scrollTop, isScrolling }) => {
-              const itemsPerRow = (layoutMode === 'small' && mobile) ? TWO_ITEMS : (Math.floor(width / itemWidth) || ONE_ITEM)
+              const itemsPerRow = (layoutMode === 'small' && mobile) ? TWO_ITEMS : (Math.floor(width / (itemWidth + gap)) || ONE_ITEM)
               const nRows = Math.ceil(products.length / itemsPerRow)
-
+              console.log(width / (itemWidth + gap), width, itemWidth + gap)
               return (
                 <List
                   key={layoutMode}
@@ -177,8 +178,8 @@ Gallery.propTypes = {
 Gallery.defaultProps = {
   maxItemsPerPage: 10,
   products: [],
-  itemWidth: 300,
-  gap: 2,
+  itemWidth: 280,
+  gap: 16,
 }
 
 export default withRuntimeContext(Gallery)

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -178,7 +178,7 @@ Gallery.defaultProps = {
   maxItemsPerPage: 10,
   products: [],
   itemWidth: 300,
-  gap: 0,
+  gap: 2,
 }
 
 export default withRuntimeContext(Gallery)

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -36,11 +36,14 @@ class Gallery extends Component {
   })
 
   renderItem = item => {
-    const { summary, layoutMode } = this.props
+    const { summary, layoutMode, runtime: { hints: { mobile } } } = this.props
+    const galleryItemClasses = classNames(searchResult.galleryItem, {
+      'mv2 pa1': mobile
+    })
     return (
       <div
         key={item.productId}
-        className={`${searchResult.galleryItem} mv2 pa1`}
+        className={galleryItemClasses}
       >
         <GalleryItem
           item={item}
@@ -52,7 +55,7 @@ class Gallery extends Component {
   }
 
   renderRow = ({ index, key, style, parent, itemsPerRow }) => {
-    const { products, layoutMode, runtime: { hints: { mobile } } } = this.props
+    const { products, layoutMode, gap, runtime: { hints: { mobile } } } = this.props
 
     const from = index * itemsPerRow
     const rowItems = products.slice(from, from + itemsPerRow)
@@ -60,6 +63,11 @@ class Gallery extends Component {
     const containerClasses = classNames(searchResult.galleryRow, {
       [searchResult.galleryTwoColumns]: layoutMode === 'small' && mobile,
     })
+
+    const styleWithGap = {
+      ...style,
+      gridGap: `${gap}rem`,
+    }
 
     return (
       <CellMeasurer
@@ -69,7 +77,7 @@ class Gallery extends Component {
         parent={parent}
         rowIndex={index}
       >
-        <div className={containerClasses} key={key} style={style}>
+        <div className={containerClasses} key={key} style={styleWithGap}>
           {map(this.renderItem, rowItems)}
         </div>
       </CellMeasurer>
@@ -152,6 +160,8 @@ Gallery.propTypes = {
   products: PropTypes.arrayOf(productShape),
   /** ProductSummary props. */
   summary: PropTypes.any,
+  /** Grid gap */
+  gap: PropTypes.number,
   /** Layout mode of the gallery */
   layoutMode: PropTypes.string,
   /** Item Width. */
@@ -168,6 +178,7 @@ Gallery.defaultProps = {
   maxItemsPerPage: 10,
   products: [],
   itemWidth: 300,
+  gap: 0,
 }
 
 export default withRuntimeContext(Gallery)

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -132,7 +132,6 @@ class Gallery extends Component {
             {({ width, height, scrollTop, isScrolling }) => {
               const itemsPerRow = (layoutMode === 'small' && mobile) ? TWO_ITEMS : (Math.floor(width / (itemWidth + gap)) || ONE_ITEM)
               const nRows = Math.ceil(products.length / itemsPerRow)
-              console.log(width / (itemWidth + gap), width, itemWidth + gap)
               return (
                 <List
                   key={layoutMode}

--- a/react/searchResult.css
+++ b/react/searchResult.css
@@ -92,8 +92,7 @@
 
 .galleryRow {
   display: grid;
-  grid-gap: 0.375rem;
-  grid-template-columns: repeat(auto-fill, minmax(17.5rem, 1fr));
+  grid-template-columns: repeat(auto-fill,  17rem);
 }
 
 .galleryTwoColumns {
@@ -185,8 +184,6 @@
 
 .filterPopup {}
 
-.filterPopupOpen {}
-
 .filterPopupContent {}
 
 .filterPopupContentContainer {}
@@ -231,6 +228,10 @@
   }
 
   .gallery {
+    grid-template-columns: 1fr;
+  }
+
+  .galleryRow {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Spaces between `Gallery Items` can be customized now and theses spaces width won't change on screen resize.

#### How should this be manually tested?

[Access this workspace](https://galleryspace--storecomponents.myvtex.com)

#### Screenshots or example usage

![galleryspace--storecomponents myvtex com_](https://user-images.githubusercontent.com/10901554/52213706-0284fd00-2877-11e9-8c0b-4aea5572fba3.png)
![galleryspace--storecomponents myvtex com_ 1](https://user-images.githubusercontent.com/10901554/52213707-04e75700-2877-11e9-850b-fdb0b95dd658.png)


#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
