### PR TITLE
Fix gallery layout in mobile mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix gallery layout when in mobile mode.
 
 ## [3.11.2] - 2019-02-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.11.3] - 2019-02-04
 ### Fixed
 - Fix gallery layout when in mobile mode.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "3.11.2",
+  "version": "3.11.3",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/searchResult.css
+++ b/react/searchResult.css
@@ -230,6 +230,11 @@
       "gallery gallery gallery gallery gallery";
   }
 
+  .resultGallery {
+    grid-column-start: gallery;
+    grid-column-end: gallery;
+  }
+
   .gallery {
     grid-template-columns: 1fr;
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add rule for `.resultGallery` on the mobile media query.

#### What problem is this solving?
Fix the layout of the gallery when in the mobile mode.

#### How should this be manually tested?
[Workspace](https://grid--storecomponents.myvtex.com/clothing).

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
