### PR TITLE
Fixing grid IE compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Using display `flex` instead display `grid` in gallery row for IE compatibility.
 
 ## [3.11.2] - 2019-02-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Using display `flex` instead display `grid` in gallery row for IE compatibility.
+- Fix IE grid compatibility.
 
 ## [3.11.2] - 2019-02-01
 

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -37,6 +37,7 @@ class Gallery extends Component {
 
   renderItem = item => {
     const { summary, layoutMode } = this.props
+    
     return (
       <div
         key={item.productId}
@@ -57,8 +58,9 @@ class Gallery extends Component {
     const from = index * itemsPerRow
     const rowItems = products.slice(from, from + itemsPerRow)
 
-    const containerClasses = classNames(searchResult.galleryRow, {
+    const containerClasses = classNames(searchResult.galleryRow, 'flex', {
       [searchResult.galleryTwoColumns]: layoutMode === 'small' && mobile,
+      'justify-center': mobile,
     })
 
     return (

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -58,7 +58,7 @@ class Gallery extends Component {
     const from = index * itemsPerRow
     const rowItems = products.slice(from, from + itemsPerRow)
 
-    const containerClasses = classNames(searchResult.galleryRow, 'justify-center', {
+    const containerClasses = classNames(searchResult.galleryRow, {
       [searchResult.galleryTwoColumns]: layoutMode === 'small' && mobile,
     })
 

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -58,9 +58,8 @@ class Gallery extends Component {
     const from = index * itemsPerRow
     const rowItems = products.slice(from, from + itemsPerRow)
 
-    const containerClasses = classNames(searchResult.galleryRow, 'flex', {
+    const containerClasses = classNames(searchResult.galleryRow, 'justify-center', {
       [searchResult.galleryTwoColumns]: layoutMode === 'small' && mobile,
-      'justify-center': mobile,
     })
 
     return (
@@ -169,7 +168,7 @@ Gallery.propTypes = {
 Gallery.defaultProps = {
   maxItemsPerPage: 10,
   products: [],
-  itemWidth: 300,
+  itemWidth: 285,
 }
 
 export default withRuntimeContext(Gallery)

--- a/react/searchResult.css
+++ b/react/searchResult.css
@@ -82,7 +82,15 @@
 
 .gallery {}
 
-.galleryRow {}
+.galleryRow {
+  display: grid;	
+  display: -ms-flexbox;	
+  -ms-flex-wrap: wrap;	
+  -ms-flex-direction: column;	
+  grid-template-columns: repeat(auto-fill, minmax(17.5rem, 1fr));	
+  grid-gap: 0.375rem;	
+  margin: 0 auto;
+}
 
 .galleryTwoColumns {
   display: grid;

--- a/react/searchResult.css
+++ b/react/searchResult.css
@@ -80,21 +80,9 @@
   width: 2px;
 }
 
-.gallery {
-  display: grid;
-  display: -ms-flexbox;
-  -ms-flex-wrap: wrap;
-  -ms-flex-direction: column;
-  grid-template-columns: repeat(auto-fill, minmax(17.5rem, 1fr));
-  grid-gap: 0.375rem;
-  margin: 0 auto;
-}
+.gallery {}
 
-.galleryRow {
-  display: grid;
-  grid-gap: 0.375rem;
-  grid-template-columns: repeat(auto-fill, minmax(17.5rem, 1fr));
-}
+.galleryRow {}
 
 .galleryTwoColumns {
   display: grid;


### PR DESCRIPTION
#### What is the purpose of this pull request?

As title says.

#### What problem is this solving?

Internet Explorer doesn't support grid layout.

#### How should this be manually tested?
[Access this workspace](https://gridfix--storecomponents.myvtex.com/)

#### Screenshots
Before:
![captura de tela 20](https://user-images.githubusercontent.com/10901554/52244045-90cea280-28ba-11e9-9c9c-654836496cab.png)

After:
![captura de tela 19](https://user-images.githubusercontent.com/10901554/52243894-f1a9ab00-28b9-11e9-8921-7ed6cedf0d49.png)
![captura de tela 21](https://user-images.githubusercontent.com/10901554/52244124-eb67fe80-28ba-11e9-855c-7d9a00f99344.png)


#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
