### PR TITLE
Fix overflow itens in the Gallery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix overriding itens in the `Gallery`.
 
 ## [3.11.3] - 2019-02-04
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Fix overflowing itens in the `Gallery`.
+- Fix overflowing Itens in the `Gallery`.
 
 ## [3.11.3] - 2019-02-04
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Fix overriding itens in the `Gallery`.
+- Fix overflowing itens in the `Gallery`.
 
 ## [3.11.3] - 2019-02-04
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Fix overflowing Itens in the `Gallery`.
+- Fix overflowing items in the `Gallery`.
 
 ## [3.11.3] - 2019-02-04
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.11.4] - 2019-02-06
 ### Fixed
 - Fix overflowing items in the `Gallery`.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "3.11.3",
+  "version": "3.11.4",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -3,7 +3,7 @@ import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import { map } from 'ramda'
 
-import { withRuntimeContext, NoSSR } from 'vtex.render-runtime'
+import { withRuntimeContext } from 'vtex.render-runtime'
 
 import { productShape } from './constants/propTypes'
 import GalleryItem from './components/GalleryItem'
@@ -29,21 +29,7 @@ class Gallery extends Component {
       </div>
     )
   }
-
-  handleSSR() {
-    const { products, layoutMode, runtime: { hints: { mobile } } } = this.props
-
-    const ssrContainer = classNames(`${searchResult.gallery} pa3 bn`, {
-      [searchResult.galleryTwoColumns]: layoutMode === 'small' && mobile,
-    })
-
-    return (
-      <div className={ssrContainer}>
-        {map(this.renderItem, products)}
-      </div>
-    )
-  }
-
+  
   render() {
     const {
       products,
@@ -56,11 +42,9 @@ class Gallery extends Component {
     })
 
     return (
-      <NoSSR onSSR={this.handleSSR()}>
-        <div className={containerClasses}>
-          {map(this.renderItem, products)}
-        </div >
-      </NoSSR>
+      <div className={containerClasses}>
+        {map(this.renderItem, products)}
+      </div >
     )
   }
 }

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import { map, splitEvery, toString, head, last } from 'ramda'
+import { map } from 'ramda'
 
 import { withRuntimeContext, NoSSR } from 'vtex.render-runtime'
 
@@ -13,10 +13,6 @@ import searchResult from './searchResult.css'
 /**
  * Canonical gallery that displays a list of given products.
  */
-
-const TWO_ITEMS = 2
-const ONE_ITEM = 1
-
 class Gallery extends Component {
   renderItem = item => {
     const { summary, layoutMode } = this.props
@@ -30,21 +26,6 @@ class Gallery extends Component {
           summary={summary}
           displayMode={layoutMode}
         />
-      </div>
-    )
-  }
-
-  renderRow = (rowItems) => {
-    const { layoutMode, runtime: { hints: { mobile } } } = this.props
-
-    const containerClasses = classNames(searchResult.galleryRow, {
-      [searchResult.galleryTwoColumns]: layoutMode === 'small' && mobile,
-    })
-
-    const key = toString(head(rowItems)) + toString(last(rowItems))
-    return (
-      <div className={containerClasses} key={key}>
-        {map(this.renderItem, rowItems)}
       </div>
     )
   }
@@ -68,19 +49,16 @@ class Gallery extends Component {
       products,
       layoutMode,
       runtime: { hints: { mobile } },
-      itemWidth,
     } = this.props
 
-    //TODO check how the heck can I see the maximum number of items per row
-    // const itemsPerRow = (layoutMode === 'small' && mobile) ? TWO_ITEMS : (5 || ONE_ITEM)
-    // const nRows = Math.ceil(products.length / itemsPerRow)
-
-    const itemsPerRow = 5
+    const containerClasses = classNames(`${searchResult.gallery} pa3 bn`, {
+      [searchResult.galleryTwoColumns]: layoutMode === 'small' && mobile,
+    })
 
     return (
       <NoSSR onSSR={this.handleSSR()}>
-        <div className={`${searchResult.gallery} pa3 bn`}>
-          {map(this.renderRow, splitEvery(itemsPerRow, products))}
+        <div className={containerClasses}>
+          {map(this.renderItem, products)}
         </div >
       </NoSSR>
     )
@@ -94,8 +72,6 @@ Gallery.propTypes = {
   summary: PropTypes.any,
   /** Layout mode of the gallery */
   layoutMode: PropTypes.string,
-  /** Item Width. */
-  itemWidth: PropTypes.number,
   /** Render runtime mobile hint */
   runtime: PropTypes.shape({
     hints: PropTypes.shape({
@@ -107,7 +83,6 @@ Gallery.propTypes = {
 Gallery.defaultProps = {
   maxItemsPerPage: 10,
   products: [],
-  itemWidth: 300,
 }
 
 export default withRuntimeContext(Gallery)

--- a/react/package.json
+++ b/react/package.json
@@ -19,7 +19,6 @@
     "react-intl": "^2.4.0",
     "react-motion": "^0.5.2",
     "react-outside-click-handler": "^1.2.2",
-    "react-virtualized": "^9.21.0",
     "unorm": "^1.4.1"
   },
   "devDependencies": {

--- a/react/package.json
+++ b/react/package.json
@@ -11,7 +11,6 @@
     "classnames": "^2.2.6",
     "query-string": "5",
     "ramda": "^0.25.0",
-    "react-adopt": "^0.6.0",
     "react-apollo": "^2.3.2",
     "react-collapse": "^4.0.3",
     "react-content-loader": "^3.1.2",

--- a/react/searchResult.css
+++ b/react/searchResult.css
@@ -90,12 +90,6 @@
   margin: 0 auto;
 }
 
-.galleryRow {
-  display: grid;
-  grid-gap: 0.375rem;
-  grid-template-columns: repeat(auto-fill, minmax(17.5rem, 1fr));
-}
-
 .galleryTwoColumns {
   display: grid;
   grid-template-columns: repeat(2, 1fr);


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
As described in the title.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
In the Pizza Hut's Gallery, `react-virtualized` wasn't making the item's height dynamic, so if a new item appeared with a bigger name or description, it would overflow in other items.

#### How should this be manually tested?
[Here](https://alves--phmex.myvtex.com/)

#### Screenshots or example usage

_Before_
![image](https://user-images.githubusercontent.com/6223208/52361362-d73c1280-2a1c-11e9-8bea-59cfcc31fd2a.png)

_After_
![image](https://user-images.githubusercontent.com/6223208/52361404-f0dd5a00-2a1c-11e9-80f1-0406e5ed219c.png)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
