### PR TITLE
Use flex instead Grid in Galley component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.11.5] - 2019-02-11
 ### Changed
 - Use flex instead grid in `Gallery` and spaces between `GalleryItems` can be customized.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Use flex instead grid in `Gallery` and spaces between `GalleryItems` can be customized.
 
 ## [3.11.4] - 2019-02-06
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "3.11.4",
+  "version": "3.11.5",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -11,28 +11,26 @@ import GalleryItem from './components/GalleryItem'
 
 import searchResult from './searchResult.css'
 
+/** Layout with two column */
+const TWO_COLUMN_ITEMS = 2
+/** Layout with one column */
+const ONE_COLUMN_ITEM = 1
+
 /**
  * Canonical gallery that displays a list of given products.
  */
-
-const TWO_ITEMS = 2
-const ONE_ITEM = 1
-
 class Gallery extends Component {
-  constructor(props) {
-    super(props)
-    this.state = { prevLayoutMode: this.props.layoutMode }
-  }
+  state = { prevLayoutMode: this.props.layoutMode }
 
   renderItem = item => {
     const { summary, layoutMode, gap, runtime: { hints: { mobile } } } = this.props
-    const itemsPerRow = (layoutMode === 'small' && mobile) ? TWO_ITEMS : (this.itemsPerRow || ONE_ITEM)
-    
+    const itemsPerRow = (layoutMode === 'small' && mobile) ? TWO_COLUMN_ITEMS : (this.itemsPerRow || ONE_COLUMN_ITEM)
+
     const style = {
-      flexBasis: `calc(${100/itemsPerRow}% - ${gap}px)`,
-      maxWidth: `calc(${100/itemsPerRow}% - ${gap}px)`,
-      marginLeft: gap/2,
-      marginRight: gap/2,
+      flexBasis: `calc(${100 / itemsPerRow}% - ${gap}px)`,
+      maxWidth: `calc(${100 / itemsPerRow}% - ${gap}px)`,
+      marginLeft: gap / 2,
+      marginRight: gap / 2,
     }
 
     return (
@@ -52,17 +50,17 @@ class Gallery extends Component {
 
   get itemsPerRow() {
     const { maxItemsPerRow, gap, minItemWidth, width } = this.props
-    const maxItems = Math.floor(width/(minItemWidth + gap))
+    const maxItems = Math.floor(width / (minItemWidth + gap))
     return maxItemsPerRow <= maxItems ? maxItemsPerRow : maxItems
   }
-  
+
   render() {
     const {
       products,
       runtime: { hints: { mobile } },
     } = this.props
 
-    const galleryClasses = classNames(searchResult.gallery, 'flex flex-row flex-wrap items-center content-stretch pa3 bn',{
+    const galleryClasses = classNames(searchResult.gallery, 'flex flex-row flex-wrap items-center content-stretch pa3 bn', {
       'mh4': !mobile,
     })
 
@@ -75,6 +73,8 @@ class Gallery extends Component {
 }
 
 Gallery.propTypes = {
+  /** Container width */
+  width: PropTypes.number,
   /** Products to be displayed. */
   products: PropTypes.arrayOf(productShape),
   /** ProductSummary props. */

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -1,7 +1,8 @@
 import React, { Component } from 'react'
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import { map } from 'ramda'
+import { withResizeDetector } from 'react-resize-detector'
+import { map, compose } from 'ramda'
 
 import { withRuntimeContext } from 'vtex.render-runtime'
 
@@ -13,13 +14,32 @@ import searchResult from './searchResult.css'
 /**
  * Canonical gallery that displays a list of given products.
  */
+
+const TWO_ITEMS = 2
+const ONE_ITEM = 1
+
 class Gallery extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { prevLayoutMode: this.props.layoutMode }
+  }
+
   renderItem = item => {
-    const { summary, layoutMode } = this.props
+    const { summary, layoutMode, gap, runtime: { hints: { mobile } } } = this.props
+    const itemsPerRow = (layoutMode === 'small' && mobile) ? TWO_ITEMS : (this.getItemsPerRow() || ONE_ITEM)
+    
+    const style = {
+      flexBasis: `calc(${100/itemsPerRow}% - ${gap}px)`,
+      maxWidth: `calc(${100/itemsPerRow}% - ${gap}px)`,
+      marginLeft: gap/2,
+      marginRight: gap/2,
+    }
+
     return (
       <div
         key={item.productId}
-        className={`${searchResult.galleryItem} mv2 pa1`}
+        style={style}
+        className={searchResult.galleryItem}
       >
         <GalleryItem
           item={item}
@@ -29,20 +49,28 @@ class Gallery extends Component {
       </div>
     )
   }
+
+  getItemsPerRow = () => {
+    const { maxItemsPerRow, gap, minItemWidth, width } = this.props
+    let maxItems = maxItemsPerRow
+    while ((minItemWidth + gap) * maxItems >= width) {
+      --maxItems
+    }
+    return maxItems
+  }
   
   render() {
     const {
       products,
-      layoutMode,
       runtime: { hints: { mobile } },
     } = this.props
 
-    const containerClasses = classNames(`${searchResult.gallery} pa3 bn`, {
-      [searchResult.galleryTwoColumns]: layoutMode === 'small' && mobile,
+    const galleryClasses = classNames(searchResult.gallery, 'flex items-center content-stretch flex-row flex-wrap pa3 bn',{
+      'mh4': !mobile,
     })
 
     return (
-      <div className={containerClasses}>
+      <div className={galleryClasses}>
         {map(this.renderItem, products)}
       </div >
     )
@@ -54,8 +82,14 @@ Gallery.propTypes = {
   products: PropTypes.arrayOf(productShape),
   /** ProductSummary props. */
   summary: PropTypes.any,
+  /** Grid gap */
+  gap: PropTypes.number,
+  /** Max Items per Row */
+  maxItemsPerRow: PropTypes.number,
   /** Layout mode of the gallery */
   layoutMode: PropTypes.string,
+  /** Min Item Width. */
+  minItemWidth: PropTypes.number,
   /** Render runtime mobile hint */
   runtime: PropTypes.shape({
     hints: PropTypes.shape({
@@ -67,6 +101,9 @@ Gallery.propTypes = {
 Gallery.defaultProps = {
   maxItemsPerPage: 10,
   products: [],
+  gap: 16,
+  maxItemsPerRow: 5,
+  minItemWidth: 230,
 }
 
-export default withRuntimeContext(Gallery)
+export default compose(withResizeDetector, withRuntimeContext)(Gallery)

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -82,7 +82,7 @@ Gallery.propTypes = {
   products: PropTypes.arrayOf(productShape),
   /** ProductSummary props. */
   summary: PropTypes.any,
-  /** Grid gap */
+  /** Gap in Px between items */
   gap: PropTypes.number,
   /** Max Items per Row */
   maxItemsPerRow: PropTypes.number,

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -26,7 +26,7 @@ class Gallery extends Component {
 
   renderItem = item => {
     const { summary, layoutMode, gap, runtime: { hints: { mobile } } } = this.props
-    const itemsPerRow = (layoutMode === 'small' && mobile) ? TWO_ITEMS : (this.getItemsPerRow() || ONE_ITEM)
+    const itemsPerRow = (layoutMode === 'small' && mobile) ? TWO_ITEMS : (this.itemsPerRow || ONE_ITEM)
     
     const style = {
       flexBasis: `calc(${100/itemsPerRow}% - ${gap}px)`,
@@ -50,13 +50,10 @@ class Gallery extends Component {
     )
   }
 
-  getItemsPerRow = () => {
+  get itemsPerRow() {
     const { maxItemsPerRow, gap, minItemWidth, width } = this.props
-    let maxItems = maxItemsPerRow
-    while ((minItemWidth + gap) * maxItems >= width) {
-      --maxItems
-    }
-    return maxItems
+    const maxItems = Math.floor(width/(minItemWidth + gap))
+    return maxItemsPerRow <= maxItems ? maxItemsPerRow : maxItems
   }
   
   render() {
@@ -65,7 +62,7 @@ class Gallery extends Component {
       runtime: { hints: { mobile } },
     } = this.props
 
-    const galleryClasses = classNames(searchResult.gallery, 'flex items-center content-stretch flex-row flex-wrap pa3 bn',{
+    const galleryClasses = classNames(searchResult.gallery, 'flex flex-row flex-wrap items-center content-stretch pa3 bn',{
       'mh4': !mobile,
     })
 

--- a/react/package.json
+++ b/react/package.json
@@ -18,6 +18,7 @@
     "react-intl": "^2.4.0",
     "react-motion": "^0.5.2",
     "react-outside-click-handler": "^1.2.2",
+    "react-resize-detector": "^3.4.0",
     "unorm": "^1.4.1"
   },
   "devDependencies": {

--- a/react/searchResult.css
+++ b/react/searchResult.css
@@ -82,8 +82,6 @@
 
 .gallery {}
 
-.galleryTwoColumns {}
-
 .filterPopupButton {
   background: none;
   height: 3.3rem;

--- a/react/searchResult.css
+++ b/react/searchResult.css
@@ -80,20 +80,9 @@
   width: 2px;
 }
 
-.gallery {
-  display: grid;
-  display: -ms-flexbox;
-  -ms-flex-wrap: wrap;
-  -ms-flex-direction: column;
-  grid-template-columns: repeat(auto-fill, minmax(17.5rem, 1fr));
-  grid-gap: 0.375rem;
-  margin: 0 auto;
-}
+.gallery {}
 
-.galleryTwoColumns {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-}
+.galleryTwoColumns {}
 
 .filterPopupButton {
   background: none;
@@ -227,14 +216,6 @@
   .resultGallery {
     grid-column-start: gallery;
     grid-column-end: gallery;
-  }
-
-  .gallery {
-    grid-template-columns: 1fr;
-  }
-
-  .galleryTwoColumns {
-    grid-template-columns: repeat(2, 1fr);
   }
 
   .filterTitle {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Use flex instead grid in `Gallery` and spaces between `GalleryItems` can be customized.

#### How should this be manually tested?

[Access this workspace](https://galleryspace--storecomponents.myvtex.com/)

#### Screenshots or example usage
![galleryspace--storecomponents myvtex com_ 2](https://user-images.githubusercontent.com/10901554/52419919-34e16500-2ad8-11e9-8760-e5b9734653b3.png)
![galleryspace--storecomponents myvtex com_ 3](https://user-images.githubusercontent.com/10901554/52419923-36129200-2ad8-11e9-806a-d60eda77ec3b.png)


#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
