### PR TITLE
Add default orderBy to relevance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.12.1] - 2019-02-25
 ### Fixed
 - Add default orderBy to relevance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add default orderBy to relevance
 
 ## [3.12.0] - 2019-02-14
 ### Changed
@@ -118,7 +120,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [3.4.0] - 2018-12-19
 ### Changed
-- New layout and behavior of search result filter 
+- New layout and behavior of search result filter
 
 ## [3.3.0] - 2018-12-18
 ### Added
@@ -141,7 +143,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [3.0.0] - 2018-12-04
 ### Fixed
-- Add default behavoir when `querySchema` comes undefined from server. 
+- Add default behavoir when `querySchema` comes undefined from server.
 
 ### Added
 - Add new mobile design.
@@ -203,7 +205,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.0.2] - 2018-10-09
 ### Fixed
-- Change breakpoint of vertical divider in SearchResult in mobile view and add :term to the view + correction of encoded values passed to :term 
+- Change breakpoint of vertical divider in SearchResult in mobile view and add :term to the view + correction of encoded values passed to :term
 
 ## [2.0.1] - 2018-10-02
 ### Changed
@@ -350,6 +352,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.2.0] - 2018-05-11
 ### Added
-- Refactor app to import as default the product-summary app. 
+- Refactor app to import as default the product-summary app.
 - **Orderable gallery** Displays a list of products that can be ordered.
 - **Update to the new Pages** Update to new version of Pages.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/messages/context.json
+++ b/messages/context.json
@@ -20,6 +20,7 @@
   "search.what-to-do.3": "search.what-to-do.3",
   "search.what-to-do.4": "search.what-to-do.4",
   "ordenation.button": "ordenation.button",
+  "ordenation.choose": "ordenation.choose",
   "ordenation.sales": "ordenation.sales",
   "ordenation.release.date": "ordenation.release.date",
   "ordenation.discount": "ordenation.discount",

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -20,6 +20,7 @@
   "search.what-to-do.3": "Use generic terms in the search.",
   "search.what-to-do.4": "Try to search synonyms of the desired term.",
   "ordenation.button": "Sort",
+  "ordenation.choose": "Choose",
   "ordenation.sales": "Sales",
   "ordenation.release.date": "Release Date",
   "ordenation.discount": "Discount",

--- a/messages/es-AR.json
+++ b/messages/es-AR.json
@@ -20,6 +20,7 @@
   "search.what-to-do.3": "Utilice términos genéricos en la búsqueda.",
   "search.what-to-do.4": "Busque utilizar sinónimos al término deseado.",
   "ordenation.button": "Ordenar",
+  "ordenation.choose": "Seleccionar",
   "ordenation.sales": "Vendas",
   "ordenation.release.date": "Más reciente",
   "ordenation.discount": "Descuento",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -20,6 +20,7 @@
   "search.what-to-do.3": "Utilize termos genéricos na busca.",
   "search.what-to-do.4": "Procure utilizar sinônimos ao termo desejado.",
   "ordenation.button": "Ordenar",
+  "ordenation.choose": "Selecione",
   "ordenation.sales": "Mais Vendidos",
   "ordenation.release.date": "Mais recentes",
   "ordenation.discount": "Descontos",

--- a/react/OrderBy.js
+++ b/react/OrderBy.js
@@ -11,6 +11,10 @@ import searchResult from './searchResult.css'
 
 export const SORT_OPTIONS = [
   {
+    value: 'OrderBy',
+    label: 'ordenation.choose',
+  },
+  {
     value: 'OrderByTopSaleDESC',
     label: 'ordenation.sales',
   },


### PR DESCRIPTION
#### What is the purpose of this pull request?

The default order by should be by relevance of the search or the default of the category.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
