### PR TITLE
Fix Gallery small layout not working properly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [3.12.4] - 2019-03-07
 ### Fixed
+
+- Fix `Gallery` small layout not working properly.
+
+## [3.12.4] - 2019-03-07
+
+### Fixed
+
 - Orderby Button with fixed width in search result grid.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.12.5] - 2019-03-12
+
 ### Fixed
 
 - Fix `Gallery` small layout not working properly.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "3.12.4",
+  "version": "3.12.5",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -23,22 +23,27 @@ class Gallery extends Component {
   get layoutMode() {
     const {
       mobileLayoutMode,
-      runtime: { hints: { mobile } },
+      runtime: {
+        hints: { mobile },
+      },
     } = this.props
 
     return mobile ? mobileLayoutMode : 'normal'
-  }  
+  }
 
   get itemsPerRow() {
     const { maxItemsPerRow, minItemWidth, width } = this.props
-    const maxItems = Math.floor(width / (minItemWidth))
+    const maxItems = Math.floor(width / minItemWidth)
     return maxItemsPerRow <= maxItems ? maxItemsPerRow : maxItems
   }
 
   renderItem = item => {
-    const { summary, layoutMode, gap, runtime: { hints: { mobile } }, maxItemsPerRow } = this.props
-    const itemsPerRow = (layoutMode === 'small' && mobile) ? TWO_COLUMN_ITEMS : (this.itemsPerRow || maxItemsPerRow)
-    
+    const { summary, gap, maxItemsPerRow } = this.props
+    const itemsPerRow =
+      this.layoutMode === 'small'
+        ? TWO_COLUMN_ITEMS
+        : this.itemsPerRow || maxItemsPerRow
+
     const style = {
       flexBasis: `${100 / itemsPerRow}%`,
       maxWidth: `${100 / itemsPerRow}%`,
@@ -61,24 +66,28 @@ class Gallery extends Component {
 
   get itemsPerRow() {
     const { maxItemsPerRow, minItemWidth, width } = this.props
-    const maxItems = Math.floor(width / (minItemWidth))
+    const maxItems = Math.floor(width / minItemWidth)
     return maxItemsPerRow <= maxItems ? maxItemsPerRow : maxItems
   }
 
   render() {
     const {
       products,
-      runtime: { hints: { mobile } },
+      runtime: {
+        hints: { mobile },
+      },
     } = this.props
 
-    const galleryClasses = classNames(searchResult.gallery, 'flex flex-row flex-wrap items-stretch pa3 bn', {
-      'mh4': !mobile,
-    })
+    const galleryClasses = classNames(
+      searchResult.gallery,
+      'flex flex-row flex-wrap items-stretch pa3 bn',
+      {
+        mh4: !mobile,
+      }
+    )
 
     return (
-      <div className={galleryClasses}>
-        {map(this.renderItem, products)}
-      </div >
+      <div className={galleryClasses}>{map(this.renderItem, products)}</div>
     )
   }
 }
@@ -113,4 +122,7 @@ Gallery.defaultProps = {
   mobileLayoutMode: LAYOUT_MODE[0].value,
 }
 
-export default compose(withResizeDetector, withRuntimeContext)(Gallery)
+export default compose(
+  withResizeDetector,
+  withRuntimeContext
+)(Gallery)


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says.

#### What problem is this solving?

Gallery normal and small modes are practically the same.

#### How should this be manually tested?

[Access this workspace](https://fixmobilelayout--storecomponents.myvtex.com/)

#### Screenshots or example usage
Before:
<img width="214" alt="galleryB" src="https://user-images.githubusercontent.com/10901554/54148097-5c4a8b00-4412-11e9-957c-f6e8a4578975.png">
After:
<img width="210" alt="galleryA" src="https://user-images.githubusercontent.com/10901554/54148102-6076a880-4412-11e9-8bed-f1f03f797df7.png">


#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
