### PR TITLE
Remove product summary schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.12.10] - 2019-03-29
+
 ### Fixed
 
 - Remove Product summary schema from Search Result.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove Product summary schema from Search Result.
+
 ## [3.12.9] - 2019-03-27
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "3.12.9",
+  "version": "3.12.10",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/messages/context.json
+++ b/messages/context.json
@@ -38,7 +38,6 @@
   "editor.search-result.pagination.infinite-scroll": "editor.search-result.pagination.infinite-scroll",
   "editor.search-result.description": "editor.search-result.description",
   "editor.search-result.maxItemsPerLine.title": "editor.search-result.maxItemsPerLine.title",
-  "editor.search-result.summary.title": "editor.search-result.summary.title",
   "editor.search-result.mobileLayout": "editor.search-result.mobileLayout",
   "editor.search-result.mobileLayout.mode1": "editor.search-result.mobileLayout.mode1",
   "editor.search-result.mobileLayout.mode2": "editor.search-result.mobileLayout.mode2",
@@ -53,9 +52,9 @@
   "layoutModeSwitcher.inline": "layoutModeSwitcher.inline",
   "layoutModeSwitcher.small": "layoutModeSwitcher.small",
   "layoutModeSwitcher.normal": "layoutModeSwitcher.normal",
-  "gallery.gapType.none" : "gallery.gapType.none",
-  "gallery.gapType.small" : "gallery.gapType.small",
-  "gallery.gapType.medium" : "gallery.gapType.medium",
-  "gallery.gapType.large" : "gallery.gapType.large",
+  "gallery.gapType.none": "gallery.gapType.none",
+  "gallery.gapType.small": "gallery.gapType.small",
+  "gallery.gapType.medium": "gallery.gapType.medium",
+  "gallery.gapType.large": "gallery.gapType.large",
   "editor.search-result.gap.title": "editor.search-result.gap.title"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -38,7 +38,6 @@
   "editor.search-result.pagination.infinite-scroll": "Infinite scrolling",
   "editor.search-result.description": "Search Result Wrapper",
   "editor.search-result.maxItemsPerLine.title": "Maximum number of items per line",
-  "editor.search-result.summary.title": "Product Summary",
   "editor.search-result.mobileLayout": "Mobile Layout Switcher",
   "editor.search-result.mobileLayout.mode1": "Layout Mode 1",
   "editor.search-result.mobileLayout.mode2": "Layout Mode 2",
@@ -53,9 +52,9 @@
   "layoutModeSwitcher.inline": "Line",
   "layoutModeSwitcher.small": "Small",
   "layoutModeSwitcher.normal": "Normal",
-  "gallery.gapType.none" : "None",
-  "gallery.gapType.small" : "Small",
-  "gallery.gapType.medium" : "Medium",
-  "gallery.gapType.large" : "Large",
+  "gallery.gapType.none": "None",
+  "gallery.gapType.small": "Small",
+  "gallery.gapType.medium": "Medium",
+  "gallery.gapType.large": "Large",
   "editor.search-result.gap.title": "Gap between gallery items"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -38,7 +38,6 @@
   "editor.search-result.pagination.infinite-scroll": "Desplazamiento infinito",
   "editor.search-result.description": "Contenedor de resultados de búsqueda",
   "editor.search-result.maxItemsPerLine.title": "Número máximo de elementos por línea",
-  "editor.search-result.summary.title": "Resumen del producto",
   "editor.search-result.mobileLayout": "Alternador de diseño en el celular",
   "editor.search-result.mobileLayout.mode1": "Modo de diseño 1",
   "editor.search-result.mobileLayout.mode2": "Modo de diseño 2",
@@ -53,9 +52,9 @@
   "layoutModeSwitcher.inline": "En línea",
   "layoutModeSwitcher.small": "Pequeño",
   "layoutModeSwitcher.normal": "Normal",
-  "gallery.gapType.none" : "Ninguno",
-  "gallery.gapType.small" : "Pequeño",
-  "gallery.gapType.medium" : "Medio",
-  "gallery.gapType.large" : "Grande",
+  "gallery.gapType.none": "Ninguno",
+  "gallery.gapType.small": "Pequeño",
+  "gallery.gapType.medium": "Medio",
+  "gallery.gapType.large": "Grande",
   "editor.search-result.gap.title": "Espacio entre los elementos de la galería"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -38,7 +38,6 @@
   "editor.search-result.pagination.infinite-scroll": "Rolagem infinita",
   "editor.search-result.description": "Conteúdo do resultado da pesquisa",
   "editor.search-result.maxItemsPerLine.title": "Número máximo de elementos por linha",
-  "editor.search-result.summary.title": "Resumo do produto",
   "editor.search-result.mobileLayout": "Alternador de leiaute no celular",
   "editor.search-result.mobileLayout.mode1": "Modo de leiaute 1",
   "editor.search-result.mobileLayout.mode2": "Modo de leiaute 2",
@@ -53,9 +52,9 @@
   "layoutModeSwitcher.inline": "Na linha",
   "layoutModeSwitcher.small": "Pequeno",
   "layoutModeSwitcher.normal": "Normal",
-  "gallery.gapType.none" : "Nenhum",
-  "gallery.gapType.small" : "Pequeno",
-  "gallery.gapType.medium" : "Médio",
-  "gallery.gapType.large" : "Grande",
+  "gallery.gapType.none": "Nenhum",
+  "gallery.gapType.small": "Pequeno",
+  "gallery.gapType.medium": "Médio",
+  "gallery.gapType.large": "Grande",
   "editor.search-result.gap.title": "Espaço entre os itens da galeria"
 }

--- a/react/index.js
+++ b/react/index.js
@@ -1,11 +1,13 @@
 import React, { Component } from 'react'
-import ProductSummary from 'vtex.product-summary/index'
 
 import SearchResultContainer from './components/SearchResultContainer'
 import { SORT_OPTIONS } from './OrderBy'
 import LocalQuery from './components/LocalQuery'
 import { LAYOUT_MODE } from './components/LayoutModeSwitcher'
-import GapPaddingTypes, { getGapPaddingNames, getGapPaddingValues } from './constants/paddingEnum'
+import GapPaddingTypes, {
+  getGapPaddingNames,
+  getGapPaddingValues,
+} from './constants/paddingEnum'
 
 const PAGINATION_TYPES = ['show-more', 'infinite-scroll']
 const DEFAULT_MAX_ITEMS_PER_PAGE = 10
@@ -32,7 +34,8 @@ export default class SearchResultQueryLoader extends Component {
 
   render() {
     const { querySchema } = this.props
-    return !this.props.searchQuery || (querySchema && querySchema.enableCustomQuery) ? (
+    return !this.props.searchQuery ||
+      (querySchema && querySchema.enableCustomQuery) ? (
       <LocalQuery
         {...this.props}
         {...querySchema}
@@ -47,38 +50,38 @@ export default class SearchResultQueryLoader extends Component {
 SearchResultQueryLoader.getSchema = props => {
   const querySchema = !props.searchQuery
     ? {
-      querySchema: {
-        title: 'editor.search-result.query',
-        description: 'editor.search-result.query.description',
-        type: 'object',
-        properties: {
-          maxItemsPerPage: {
-            title: 'editor.search-result.query.maxItemsPerPage',
-            type: 'number',
-            default: DEFAULT_MAX_ITEMS_PER_PAGE,
-          },
-          queryField: {
-            title: 'Query',
-            type: 'string',
-          },
-          mapField: {
-            title: 'Map',
-            type: 'string',
-          },
-          restField: {
-            title: 'Other Query Strings',
-            type: 'string',
-          },
-          orderByField: {
-            title: 'Order by field',
-            type: 'string',
-            default: SORT_OPTIONS[1].value,
-            enum: SORT_OPTIONS.map(opt => opt.value),
-            enumNames: SORT_OPTIONS.map(opt => opt.label),
+        querySchema: {
+          title: 'editor.search-result.query',
+          description: 'editor.search-result.query.description',
+          type: 'object',
+          properties: {
+            maxItemsPerPage: {
+              title: 'editor.search-result.query.maxItemsPerPage',
+              type: 'number',
+              default: DEFAULT_MAX_ITEMS_PER_PAGE,
+            },
+            queryField: {
+              title: 'Query',
+              type: 'string',
+            },
+            mapField: {
+              title: 'Map',
+              type: 'string',
+            },
+            restField: {
+              title: 'Other Query Strings',
+              type: 'string',
+            },
+            orderByField: {
+              title: 'Order by field',
+              type: 'string',
+              default: SORT_OPTIONS[1].value,
+              enum: SORT_OPTIONS.map(opt => opt.value),
+              enumNames: SORT_OPTIONS.map(opt => opt.label),
+            },
           },
         },
-      },
-    }
+      }
     : {}
 
   return {
@@ -170,11 +173,6 @@ SearchResultQueryLoader.getSchema = props => {
         enumNames: getGapPaddingNames(),
         default: GapPaddingTypes.SMALL.value,
         isLayout: true,
-      },
-      summary: {
-        title: 'editor.search-result.summary.title',
-        type: 'object',
-        properties: ProductSummary.getSchema(props).properties,
       },
       pagination: {
         type: 'string',


### PR DESCRIPTION
#### What is the purpose of this pull request?

As title says.

#### What problem is this solving?

Product Summary's schema is duplicated. It is in the Product Summary and in the Search result.

#### How should this be manually tested?

[Access the storefront](https://schemas--storecomponents.myvtex.com/admin/cms/storefront)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
