### PR TITLE
Added the department before each category to pass it to Breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- Added the department before each category to pass it to `Breadcrubms`.
 
 ## [3.12.10] - 2019-03-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.12.11] - 2019-03-29
 ### Fixed
 
 - Added the department before each category to pass it to `Breadcrubms`.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "3.12.10",
+  "version": "3.12.11",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/components/SearchResultContainer.js
+++ b/react/components/SearchResultContainer.js
@@ -39,8 +39,10 @@ export default class SearchResultContainer extends Component {
 
     const categoryWithChildrenReducer = (acc, category) => [
       ...acc,
-      category.Link,
-      ...category.Children.reduce(categoryReducer, []),
+      `/${category.Name}`,
+      ...category.Children.reduce(categoryReducer, []).map(
+        children => `/${category.Name}${children}`
+      ),
     ]
 
     const getCategoryList = (reducer, initial = []) =>

--- a/react/components/SearchResultContainer.js
+++ b/react/components/SearchResultContainer.js
@@ -40,8 +40,8 @@ export default class SearchResultContainer extends Component {
     const categoryWithChildrenReducer = (acc, category) => [
       ...acc,
       `/${category.Name}`,
-      ...category.Children.reduce(categoryReducer, []).map(
-        children => `/${category.Name}${children}`
+      ...category.Children.map(
+        children => `/${category.Name}/${children.Name}`
       ),
     ]
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.

#### What problem is this solving?
**Fix**
*Should pass:* `[ '/Clothing', '/Clothing/Shirts' ]`
*Was passing:* `[ '/Clothing', '/Shirts' ]`

#### How should this be manually tested?
Linked @ [workspace](https://catorder--storecomponents.myvtex.com). ⚠️Test for more than one department/category

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
