### PR TITLE
Fix cannot read 'CategoriesTrees' of undefined error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.12.12] - 2019-04-10
 ### Fixed
 
 - Error when trying to read properties from facets while loading.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- Error when trying to read properties from facets while loading.
 
 ## [3.12.11] - 2019-03-29
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "3.12.11",
+  "version": "3.12.12",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/components/SearchResultContainer.js
+++ b/react/components/SearchResultContainer.js
@@ -35,7 +35,7 @@ export default class SearchResultContainer extends Component {
       searchQuery: { facets },
     } = this.props
 
-    const categories = facets ? facets.CategoriesTrees : []
+    const categoriesTrees = facets ? facets.CategoriesTrees : []
 
     const categoryReducer = (acc, category) => [...acc, `/${category.Name}`]
 
@@ -48,7 +48,7 @@ export default class SearchResultContainer extends Component {
     ]
 
     const getCategoryList = (reducer, initial = []) =>
-      categories.reduce(reducer, initial)
+      categoriesTrees.reduce(reducer, initial)
 
     const categories =
       department && category

--- a/react/components/SearchResultContainer.js
+++ b/react/components/SearchResultContainer.js
@@ -35,6 +35,8 @@ export default class SearchResultContainer extends Component {
       searchQuery: { facets },
     } = this.props
 
+    const categories = facets ? facets.CategoriesTrees : []
+
     const categoryReducer = (acc, category) => [...acc, `/${category.Name}`]
 
     const categoryWithChildrenReducer = (acc, category) => [
@@ -46,7 +48,7 @@ export default class SearchResultContainer extends Component {
     ]
 
     const getCategoryList = (reducer, initial = []) =>
-      facets.CategoriesTrees.reduce(reducer, initial)
+      categories.reduce(reducer, initial)
 
     const categories =
       department && category


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix error when trying to mount the breadcrumb props when the search is still loading.

#### What problem is this solving?

![image](https://user-images.githubusercontent.com/10223856/55877288-0b909400-5b70-11e9-9985-14b0774fd3e2.png)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
