### PR TITLE
Remove showTitle schema property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.13.2] - 2019-04-12
 ### Changed
 - Removed option `showTitle` on schema.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Removed option `showTitle` on schema.
 
 ## [3.13.1] - 2019-04-10
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ Through the Storefront, you can change the search-result behavior and interface.
 | `querySchema` | `QuerySchema` | Query made when there's no context | N/A |
 | `hiddenFacets` | `HiddenFacets` | Indicates which facets will be hidden | N/A |
 | `pagination` | `Enum` | Pagination type (values: 'show-more' or 'infinite-scroll') | `infinity-scroll` |
-| `showTitle` | `boolean` | Enables the category name or search term as a title bellow breadcrumbs | `false` |
 
 QuerySchema
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "3.13.1",
+  "version": "3.13.2",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/SearchTitle.js
+++ b/react/SearchTitle.js
@@ -3,7 +3,7 @@ import React from 'react'
 
 import styles from './searchResult.css'
 
-const Title = ({ params }) => {
+const SearchTitle = ({ params }) => {
   const title = params.term ||
     params.subcategory ||
     params.category ||
@@ -16,4 +16,4 @@ const Title = ({ params }) => {
   )
 }
 
-export default Title
+export default SearchTitle

--- a/react/Title.js
+++ b/react/Title.js
@@ -3,11 +3,7 @@ import React from 'react'
 
 import styles from './searchResult.css'
 
-const Title = ({ params, showTitle }) => {
-  if (!showTitle) {
-    return null
-  }
-
+const Title = ({ params }) => {
   const title = params.term ||
     params.subcategory ||
     params.category ||

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -120,7 +120,6 @@ class SearchResult extends Component {
       orderBy,
       runtime: { hints: { mobile } },
       gap,
-      showTitle,
     } = this.props
     const {
       mobileLayoutMode,
@@ -158,11 +157,7 @@ class SearchResult extends Component {
           <div className={`${searchResult.breadcrumb} db-ns dn-s`}>
             <ExtensionPoint id="breadcrumb" {...breadcrumbsProps} />
           </div>
-          <ExtensionPoint
-            id="search-title"
-            params={params}
-            showTitle={showTitle}
-          />
+          <ExtensionPoint id="search-title" params={params} />
           <ExtensionPoint id="total-products"
             recordsFiltered={recordsFiltered}
           />

--- a/react/index.js
+++ b/react/index.js
@@ -184,11 +184,6 @@ SearchResultQueryLoader.getSchema = props => {
           'editor.search-result.pagination.infinite-scroll',
         ],
       },
-      showTitle: {
-        type: 'boolean',
-        title: 'editor.search-result.showTitle',
-        default: false,
-      }
     },
   }
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -35,6 +35,6 @@
     "component": "TotalProducts"
   },
   "search-title": {
-    "component": "Title"
+    "component": "SearchTitle"
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove the `showTitle` schema property.

#### What problem is this solving?
The title in the search should be configured only in the blocks, not on the storefront.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
