### PR TITLE
Fix TotalProducts proptype error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Fixed `TotalProducts` proptype error.
+- `TotalProducts` proptype error.
 
 ## [3.13.2] - 2019-04-12
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.13.3] - 2019-04-25
 ### Fixed
 - `TotalProducts` proptype error.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed `TotalProducts` proptype error.
 
 ## [3.13.2] - 2019-04-12
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "3.13.2",
+  "version": "3.13.3",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/TotalProducts.js
+++ b/react/TotalProducts.js
@@ -16,7 +16,7 @@ const TotalProducts = ({ recordsFiltered }) => {
 
 TotalProducts.propTypes = {
   /** Total of records filtered */
-  recordsFiltered: PropTypes.string.isRequired,
+  recordsFiltered: PropTypes.number.isRequired,
 }
 
 export default TotalProducts


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change `recordsFiltered` proptype from `string` to `number`.

#### What problem is this solving?
Fix ```Warning: Failed prop type: Invalid prop `recordsFiltered` of type `number` supplied to `TotalProducts`, expected `string`.```

#### How should this be manually tested?
[Workspace](https://elvis--storecomponents.myvtex.com/hats)

1. Visit any category of the store
2. Check in the console if the warning persists

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
