### PR TITLE
Use stable filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+
+- Use filters value instead of encoded link on navigate.
 
 ## [3.14.1] - 2019-04-26
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.15.0] - 2019-04-26
 ### Changed
 
 - Use filters value instead of encoded link on navigate.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "3.14.1",
+  "version": "3.15.0",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/messages/context.json
+++ b/messages/context.json
@@ -22,6 +22,7 @@
   "admin/editor.search-result.hiddenFacets.specificationFilters.hiddenFilter.name": "Hidden Specification filter name",
   "admin/editor.search-result.showTitle": "Show category title or search term above the gallery",
   "admin/editor.search-result.gap.title": "Gap between gallery items",
+  "admin/editor.search-result.facet-quantity": "Show filter item quantity",
 
   "store/search-result.show-more-button": "Show more",
   "store/search-result.filter-button.title": "Filters",

--- a/messages/context.json
+++ b/messages/context.json
@@ -43,6 +43,7 @@
   "store/search.what-to-do.2": "Try to use a single word.",
   "store/search.what-to-do.3": "Use generic terms in the search.",
   "store/search.what-to-do.4": "Try to search synonyms of the desired term.",
+  "store/search.no-products": "No products were found",
   "store/ordenation.button": "Sort",
   "store/ordenation.sort-by": "Sort By",
   "store/ordenation.sales": "Sales",

--- a/messages/en.json
+++ b/messages/en.json
@@ -22,6 +22,7 @@
   "admin/editor.search-result.hiddenFacets.specificationFilters.hiddenFilter.name": "Hidden Specification filter name",
   "admin/editor.search-result.showTitle": "Show category title or search term above the gallery",
   "admin/editor.search-result.gap.title": "Gap between gallery items",
+  "admin/editor.search-result.facet-quantity": "Show filter item quantity",
 
   "store/search-result.show-more-button": "Show more",
   "store/search-result.filter-button.title": "Filters",

--- a/messages/en.json
+++ b/messages/en.json
@@ -43,6 +43,7 @@
   "store/search.what-to-do.2": "Try to use a single word.",
   "store/search.what-to-do.3": "Use generic terms in the search.",
   "store/search.what-to-do.4": "Try to search synonyms of the desired term.",
+  "store/search.no-products": "No products were found",
   "store/ordenation.button": "Sort",
   "store/ordenation.sort-by": "Sort By",
   "store/ordenation.sales": "Sales",

--- a/messages/es.json
+++ b/messages/es.json
@@ -43,6 +43,7 @@
   "store/search.what-to-do.2": "Intenta utilizar una sola palabra.",
   "store/search.what-to-do.3": "Utilice términos genéricos en la búsqueda.",
   "store/search.what-to-do.4": "Busque utilizar sinónimos al término deseado.",
+  "store/search.no-products": "No se ha encontrado ningún producto",
   "store/ordenation.button": "Ordenar",
   "store/ordenation.sort-by": "Ordenar por",
   "store/ordenation.sales": "Vendas",

--- a/messages/es.json
+++ b/messages/es.json
@@ -22,6 +22,7 @@
   "admin/editor.search-result.hiddenFacets.specificationFilters.hiddenFilter.name": "Nombre del filtro de Especificaciones oculto",
   "admin/editor.search-result.showTitle": "Mostrar el título de la categoría o el término de búsqueda en la parte superior de la galería",
   "admin/editor.search-result.gap.title": "Espacio entre los elementos de la galería",
+  "admin/editor.search-result.facet-quantity": "Mostrar la cantidad de filtros",
 
   "store/search-result.show-more-button": "Mostrar más",
   "store/search-result.filter-button.title": "Filtros",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -43,6 +43,7 @@
   "store/search.what-to-do.2": "Tente utilizar uma única palavra.",
   "store/search.what-to-do.3": "Utilize termos genéricos na busca.",
   "store/search.what-to-do.4": "Procure utilizar sinônimos ao termo desejado.",
+  "store/search.no-products": "Nenhum produto foi encontrado",
   "store/ordenation.button": "Ordenar",
   "store/ordenation.sort-by": "Ordenar Por",
   "store/ordenation.sales": "Mais Vendidos",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -22,6 +22,7 @@
   "admin/editor.search-result.hiddenFacets.specificationFilters.hiddenFilter.name": "Nome do filtro de Especificações oculto",
   "admin/editor.search-result.showTitle": "Mostrar titulo da categoria ou termo de busca em cima da galeria",
   "admin/editor.search-result.gap.title": "Espaço entre os itens da galeria",
+  "admin/editor.search-result.facet-quantity": "Mostrar quantidade dos filtros",
 
   "store/search-result.show-more-button": "Mostrar mais",
   "store/search-result.filter-button.title": "Filtros",

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -1,7 +1,7 @@
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import { map, flatten, path, contains, filter, prop } from 'ramda'
-import React from 'react'
+import React, { useMemo } from 'react'
 import ContentLoader from 'react-content-loader'
 import { FormattedMessage } from 'react-intl'
 import { useRuntime } from 'vtex.render-runtime'
@@ -14,6 +14,7 @@ import {
   paramShape,
   hiddenFacetsSchema,
 } from './constants/propTypes'
+import useSelectedFilters from './hooks/useSelectedFilters'
 
 import searchResult from './searchResult.css'
 
@@ -51,18 +52,20 @@ const FilterNavigator = ({
     hints: { mobile },
   } = useRuntime()
 
-  const getSelectedFilters = () => {
-    const availableCategories = filter(prop('selected'), getCategories(tree))
+  const selectedFilters = useSelectedFilters(
+    useMemo(() => {
+      const availableCategories = filter(prop('selected'), getCategories(tree))
 
-    const options = [
-      ...availableCategories,
-      ...map(prop('facets'), specificationFilters),
-      ...brands,
-      ...priceRanges,
-    ]
+      const options = [
+        ...availableCategories,
+        ...map(prop('facets'), specificationFilters),
+        ...brands,
+        ...priceRanges,
+      ]
 
-    return flatten(options).filter(opt => opt.selected)
-  }
+      return flatten(options)
+    }, [brands, priceRanges, specificationFilters, tree])
+  ).filter(facet => facet.selected)
 
   const getFilters = () => {
     const categories = getCategories(tree)
@@ -152,7 +155,7 @@ const FilterNavigator = ({
             <FormattedMessage id="store/search-result.filter-button.title" />
           </h5>
         </div>
-        <SelectedFilters filters={getSelectedFilters()} />
+        <SelectedFilters filters={selectedFilters} />
         <AvailableFilters filters={getFilters()} priceRange={priceRange} />
       </div>
     </div>

--- a/react/NotFoundSearch.js
+++ b/react/NotFoundSearch.js
@@ -27,20 +27,24 @@ const NotFoundSearch = ({ term }) => {
           ops!
         </div>
         <div className="ph9" style={flexStyle}>
-          <FormattedMessage
-            id="store/search.empty-products"
-            values={{
-              term: <span className="c-action-primary">{term}</span>,
-            }}
-          >
-            {(...textList) => (
-              <span className="c-muted-1 b">
-                {textList.map((text, index) => (
-                  <Fragment key={index}>{text}</Fragment>
-                ))}
-              </span>
-            )}
-          </FormattedMessage>
+          {term ? (
+            <FormattedMessage
+              id="store/search.empty-products"
+              values={{
+                term: <span className="c-action-primary">{term}</span>,
+              }}
+            >
+              {(...textList) => (
+                <span className="c-muted-1 b">
+                  {textList.map((text, index) => (
+                    <Fragment key={index}>{text}</Fragment>
+                  ))}
+                </span>
+              )}
+            </FormattedMessage>
+          ) : (
+            <FormattedMessage id="store/search.no-products" />
+          )}
           <FormattedMessage id="store/search.what-do-i-do">
             {text => <p className="c-muted-2">{text}</p>}
           </FormattedMessage>
@@ -60,7 +64,7 @@ const NotFoundSearch = ({ term }) => {
 
 NotFoundSearch.propTypes = {
   /** Search term */
-  term: PropTypes.string.isRequired,
+  term: PropTypes.string,
 }
 
 export default NotFoundSearch

--- a/react/__mocks__/categoriesTree.js
+++ b/react/__mocks__/categoriesTree.js
@@ -1,57 +1,57 @@
 export default [
   {
-    Name: 'Eletrônicos',
-    Link: '/Eletronicos',
-    Quantity: 0,
-    Children: [
+    name: 'Eletrônicos',
+    link: '/Eletronicos',
+    quantity: 0,
+    children: [
       {
-        Name: 'Smartphones',
-        Link: '/Eletronicos/Smartphones',
-        Quantity: 0,
+        name: 'Smartphones',
+        link: '/Eletronicos/Smartphones',
+        quantity: 0,
       },
       {
-        Name: 'Videogames',
-        Link: '/Eletronicos/Videogames',
-        Quantity: 0,
+        name: 'Videogames',
+        link: '/Eletronicos/Videogames',
+        quantity: 0,
       },
       {
-        Name: 'TVs',
-        Link: '/Eletronicos/TVs',
-        Quantity: 0,
-      },
-    ],
-  },
-  {
-    Name: 'Livros',
-    Link: '/Livros',
-    Quantity: 0,
-    Children: [
-      {
-        Name: 'HQs e Mangas',
-        Link: '/Livros/HQs e Mangas',
-        Quantity: 0,
+        name: 'TVs',
+        link: '/Eletronicos/TVs',
+        quantity: 0,
       },
     ],
   },
   {
-    Name: 'Roupas',
-    Link: '/Roupas',
-    Quantity: 0,
-    Children: [
+    name: 'Livros',
+    link: '/Livros',
+    quantity: 0,
+    children: [
       {
-        Name: 'Blusas',
-        Link: '/Roupas/Blusas',
-        Quantity: 0,
+        name: 'HQs e Mangas',
+        link: '/Livros/HQs e Mangas',
+        quantity: 0,
+      },
+    ],
+  },
+  {
+    name: 'Roupas',
+    link: '/Roupas',
+    quantity: 0,
+    children: [
+      {
+        name: 'Blusas',
+        link: '/Roupas/Blusas',
+        quantity: 0,
       },
       {
-        Name: 'Calças',
-        Link: '/Roupas/Calcas',
-        Quantity: 0,
+        name: 'Calças',
+        link: '/Roupas/Calcas',
+        quantity: 0,
       },
       {
-        Name: 'Moletom',
-        Link: '/Roupas/Moletom',
-        Quantity: 0,
+        name: 'Moletom',
+        link: '/Roupas/Moletom',
+        quantity: 0,
       },
     ],
   },

--- a/react/__tests__/FilterNavigator.test.js
+++ b/react/__tests__/FilterNavigator.test.js
@@ -5,17 +5,23 @@ import { render } from '@vtex/test-tools/react'
 import categoriesTree from 'categoriesTree'
 
 import FilterNavigator from '../FilterNavigator'
+import QueryContext from '../components/QueryContext'
 
 describe('<FilterNavigator />', () => {
-  const renderComponent = customProps => {
+  const renderComponent = (customProps = { query: 'clothing' }) => {
     const props = {
       map: 'c',
-      rest: '',
       tree: categoriesTree,
       ...customProps,
     }
 
-    return render(<FilterNavigator {...props} />)
+    return render(
+      <QueryContext.Provider
+        value={{ query: customProps.query, map: props.map }}
+      >
+        <FilterNavigator {...props} />
+      </QueryContext.Provider>
+    )
   }
 
   it('should match snapshot with all', () => {

--- a/react/components/FacetItem.js
+++ b/react/components/FacetItem.js
@@ -3,6 +3,7 @@ import { useRuntime } from 'vtex.render-runtime'
 import { Checkbox } from 'vtex.styleguide'
 
 import QueryContext from './QueryContext'
+import SettingsContext from './SettingsContext'
 import { HEADER_SCROLL_OFFSET } from '../constants/SearchHelpers'
 
 const scrollOptions = {
@@ -19,6 +20,7 @@ const removeElementAtIndex = (str, index, separator) =>
 const FacetItem = ({ facet }) => {
   const { navigate } = useRuntime()
   const { query, map } = useContext(QueryContext)
+  const { showFacetQuantity } = useContext(SettingsContext)
 
   const handleChange = () => {
     const urlParams = new URLSearchParams(window.location.search)
@@ -56,7 +58,9 @@ const FacetItem = ({ facet }) => {
       <Checkbox
         id={facet.value}
         checked={facet.selected}
-        label={`${facet.name} (${facet.quantity})`}
+        label={
+          showFacetQuantity ? `${facet.name} (${facet.quantity})` : facet.name
+        }
         name={facet.name}
         onChange={handleChange}
         value={facet.name}

--- a/react/components/FacetItem.js
+++ b/react/components/FacetItem.js
@@ -21,6 +21,8 @@ const FacetItem = ({ facet }) => {
   const { query, map } = useContext(QueryContext)
 
   const handleChange = () => {
+    const urlParams = new URLSearchParams(window.location.search)
+
     if (facet.selected) {
       const facetIndex = query
         .toLowerCase()
@@ -29,8 +31,6 @@ const FacetItem = ({ facet }) => {
         .findIndex(
           value => value === decodeURIComponent(facet.value).toLowerCase()
         )
-
-      const urlParams = new URLSearchParams(window.location.search)
 
       urlParams.set('map', removeElementAtIndex(map, facetIndex, ','))
 
@@ -42,11 +42,11 @@ const FacetItem = ({ facet }) => {
       return
     }
 
-    const [path, queryParams] = facet.linkEncoded.split('?')
+    urlParams.set('map', `${map},${facet.map}`)
 
     navigate({
-      to: path,
-      query: queryParams,
+      to: `/${query}/${facet.value}`,
+      query: urlParams.toString(),
       scrollOptions,
     })
   }

--- a/react/components/QueryContext.js
+++ b/react/components/QueryContext.js
@@ -1,5 +1,5 @@
 import { createContext } from 'react'
 
-const QueryContext = createContext(null)
+const QueryContext = createContext({})
 
 export default QueryContext

--- a/react/components/SearchFilter.js
+++ b/react/components/SearchFilter.js
@@ -6,13 +6,19 @@ import FilterOptionTemplate from './FilterOptionTemplate'
 import FacetItem from './FacetItem'
 import { facetOptionShape } from '../constants/propTypes'
 import { getFilterTitle } from '../constants/SearchHelpers'
+import useSelectedFilters from '../hooks/useSelectedFilters'
 
 /**
  * Search Filter Component.
  */
 const SearchFilter = ({ title = 'Default Title', facets = [], intl }) => {
+  const filtersWithSelected = useSelectedFilters(facets)
+
   return (
-    <FilterOptionTemplate title={getFilterTitle(title, intl)} filters={facets}>
+    <FilterOptionTemplate
+      title={getFilterTitle(title, intl)}
+      filters={filtersWithSelected}
+    >
       {facet => <FacetItem key={facet.name} facet={facet} />}
     </FilterOptionTemplate>
   )

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -6,7 +6,7 @@ import LoadingOverlay from './LoadingOverlay'
 import { searchResultPropTypes } from '../constants/propTypes'
 import LayoutModeSwitcher, { LAYOUT_MODE } from './LayoutModeSwitcher'
 
-import searchResult from '../searchResult.css'
+import styles from '../searchResult.css'
 
 /**
  * Search Result Component.
@@ -136,7 +136,7 @@ class SearchResult extends Component {
     const term =
       params && params.term ? decodeURIComponent(params.term) : undefined
 
-    if (!products.length && !loading) {
+    if (recordsFiltered === 0 && !loading) {
       return <ExtensionPoint id="not-found" term={term} />
     }
 
@@ -146,9 +146,9 @@ class SearchResult extends Component {
 
     return (
       <LoadingOverlay loading={showLoading && showLoadingAsOverlay}>
-        <div className={`${searchResult.container} w-100 mw9`}>
+        <div className={`${styles.container} w-100 mw9`}>
           {!mobile && (
-            <div className={searchResult.breadcrumb}>
+            <div className={styles.breadcrumb}>
               <ExtensionPoint id="breadcrumb" {...breadcrumbsProps} />
             </div>
           )}
@@ -171,14 +171,14 @@ class SearchResult extends Component {
               loading={showContentLoader}
             />
           )}
-          <div className={searchResult.resultGallery}>
+          <div className={styles.resultGallery}>
             {showContentLoader ? (
               <div className="w-100 flex justify-center">
                 <div className="w3 ma0">
                   <Spinner />
                 </div>
               </div>
-            ) : (
+            ) : products.length > 0 ? (
               <ExtensionPoint
                 id="gallery"
                 products={products}
@@ -186,25 +186,23 @@ class SearchResult extends Component {
                 className="bn"
                 mobileLayoutMode={mobileLayoutMode}
               />
+            ) : (
+              <div className={styles.gallery}>
+                <ExtensionPoint id="not-found" term="test" />
+              </div>
             )}
             {children}
           </div>
           {mobile && (
-            <div
-              className={`${searchResult.border} bg-muted-5 h-50 self-center`}
-            />
+            <div className={`${styles.border} bg-muted-5 h-50 self-center`} />
           )}
           <ExtensionPoint id="order-by" orderBy={orderBy} />
           {mobile && (
-            <div
-              className={`${searchResult.border2} bg-muted-5 h-50 self-center`}
-            />
+            <div className={`${styles.border2} bg-muted-5 h-50 self-center`} />
           )}
           {mobile && (
             <div
-              className={`${
-                searchResult.switch
-              } flex justify-center items-center`}
+              className={`${styles.switch} flex justify-center items-center`}
             >
               <LayoutModeSwitcher
                 activeMode={mobileLayoutMode}

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -114,6 +114,7 @@ class SearchResult extends Component {
       fetchMoreLoading,
       summary,
       orderBy,
+      showFacetQuantity,
       runtime: {
         hints: { mobile },
       },
@@ -169,6 +170,7 @@ class SearchResult extends Component {
               tree={tree}
               hiddenFacets={hiddenFacets}
               loading={showContentLoader}
+              showFacetQuantity={showFacetQuantity}
             />
           )}
           <div className={styles.resultGallery}>

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -188,7 +188,7 @@ class SearchResult extends Component {
               />
             ) : (
               <div className={styles.gallery}>
-                <ExtensionPoint id="not-found" term="test" />
+                <ExtensionPoint id="not-found" />
               </div>
             )}
             {children}

--- a/react/components/SearchResultContainer.js
+++ b/react/components/SearchResultContainer.js
@@ -78,7 +78,7 @@ const SearchResultContainer = props => {
   const fetchMoreLocked = useRef(false)
 
   const handleFetchMore = () => {
-    if (fetchMoreLocked.current) {
+    if (fetchMoreLocked.current || products.length === 0) {
       return
     }
 

--- a/react/components/SearchResultContainer.js
+++ b/react/components/SearchResultContainer.js
@@ -111,6 +111,7 @@ const SearchResultContainer = props => {
         }
 
         return {
+          ...prevResult,
           products: [...prevResult.products, ...fetchMoreResult.products],
         }
       },

--- a/react/components/SettingsContext.js
+++ b/react/components/SettingsContext.js
@@ -1,0 +1,5 @@
+import { createContext } from 'react'
+
+const SettingsContext = createContext({})
+
+export default SettingsContext

--- a/react/components/SideBar.js
+++ b/react/components/SideBar.js
@@ -62,7 +62,7 @@ Sidebar.propTypes = {
   /* Set the sideBar visibility */
   isOpen: PropTypes.bool,
   /* Sidebar content */
-  children: PropTypes.object.isRequired,
+  children: PropTypes.node,
   /* Function to be called when click in the close sidebar button or outside the sidebar */
   onOutsideClick: PropTypes.func,
 }

--- a/react/hooks/useSelectedFilters.js
+++ b/react/hooks/useSelectedFilters.js
@@ -1,0 +1,20 @@
+import { useContext } from 'react'
+import QueryContext from '../components/QueryContext'
+
+const useSelectedFilters = facets => {
+  const { query } = useContext(QueryContext)
+
+  const queryValues = query
+    .toLowerCase()
+    .split('/')
+    .map(decodeURIComponent)
+
+  return facets.map(facet => ({
+    ...facet,
+    selected: queryValues.includes(
+      decodeURIComponent(facet.value).toLowerCase()
+    ),
+  }))
+}
+
+export default useSelectedFilters

--- a/react/index.js
+++ b/react/index.js
@@ -5,6 +5,7 @@ import { SORT_OPTIONS } from './OrderBy'
 import LocalQuery from './components/LocalQuery'
 import { LAYOUT_MODE } from './components/LayoutModeSwitcher'
 import QueryContext from './components/QueryContext'
+import SettingsContext from './components/SettingsContext'
 
 const PAGINATION_TYPES = ['show-more', 'infinite-scroll']
 const DEFAULT_MAX_ITEMS_PER_PAGE = 10
@@ -28,7 +29,21 @@ export default class SearchResultQueryLoader extends Component {
   }
 
   render() {
-    const { querySchema } = this.props
+    const {
+      querySchema,
+      hiddenFacets,
+      showFacetsQuantity,
+      pagination,
+      mobileLayout,
+    } = this.props
+
+    const settings = {
+      hiddenFacets,
+      showFacetsQuantity,
+      pagination,
+      mobileLayout,
+    }
+
     return !this.props.searchQuery ||
       (querySchema && querySchema.enableCustomQuery) ? (
       <LocalQuery
@@ -36,13 +51,17 @@ export default class SearchResultQueryLoader extends Component {
         {...querySchema}
         render={props => (
           <QueryContext.Provider value={props.searchQuery.variables}>
-            <SearchResultContainer {...props} />
+            <SettingsContext.Provider value={settings}>
+              <SearchResultContainer {...props} />
+            </SettingsContext.Provider>
           </QueryContext.Provider>
         )}
       />
     ) : (
       <QueryContext.Provider value={this.props.searchQuery.variables}>
-        <SearchResultContainer {...this.props} />
+        <SettingsContext.Provider value={settings}>
+          <SearchResultContainer {...this.props} />
+        </SettingsContext.Provider>
       </QueryContext.Provider>
     )
   }
@@ -173,6 +192,11 @@ SearchResultQueryLoader.getSchema = props => {
           'admin/editor.search-result.pagination.show-more',
           'admin/editor.search-result.pagination.infinite-scroll',
         ],
+      },
+      showFacetQuantity: {
+        type: 'boolean',
+        title: 'admin/editor.search-result.facet-quantity',
+        default: false,
       },
     },
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add logic for selected filters in the components and use the facets value to add it to the url, instead of the `linkEncoded`, because it's not "reliable" anymore.

#### What problem is this solving?
In order for the filters to be consistent with the products shown, we shouldn't fetch the facets more than once per category or full text (i.e. search). This is because if we change the filters for every change in the own filters, the quantity shown becomes inconsistent (because they are calculated on the filters sent to the api) and we lose the ability to filter by more than 1 brand, for example.

#### How should this be manually tested?
[This workspace](https://lucas--storecomponents.myvtex.com/clothing/shirts?map=c%2Cc), try changing the brand or specification filters.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
