### PR TITLE
Fix infinite loading on fetch more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.15.2] - 2019-05-03
 ### Fixed
 - Infinite loading on fetch more.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Infinite loading on fetch more.
 
 ## [3.15.1] - 2019-05-01
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "3.15.1",
+  "version": "3.15.2",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/components/SearchResultContainer.js
+++ b/react/components/SearchResultContainer.js
@@ -111,7 +111,13 @@ const SearchResultContainer = props => {
 
         return {
           ...prevResult,
-          products: [...prevResult.products, ...fetchMoreResult.products],
+          productSearch: {
+            ...prevResult.productSearch,
+            products: [
+              ...prevResult.productSearch.products,
+              ...fetchMoreResult.productSearch.products,
+            ],
+          },
         }
       },
     })


### PR DESCRIPTION
#### What is the purpose of this pull request?
Update the query used in fetch more to `productSearch`.

#### What problem is this solving?
The property `products` doesn't exist anymore in the `fetchMoreResult`, and so when we tried to spread it, it throwed an exception, and made the search display a loading indicator indefinitely.

#### How should this be manually tested?
[workspace](https://lucas--storecomponents.myvtex.com/teste?map=c), scroll a bit further down to trigger the fetch more.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
