### PR TITLE
Fix selected filters not accounting for map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Selected filters not accounting for map parameter.
 
 ## [3.15.4] - 2019-05-06
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.15.5] - 2019-05-06
 ### Fixed
 - Selected filters not accounting for map parameter.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "3.15.4",
+  "version": "3.15.5",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/hooks/useSelectedFilters.js
+++ b/react/hooks/useSelectedFilters.js
@@ -1,20 +1,37 @@
+import { zip } from 'ramda'
 import { useContext } from 'react'
+
 import QueryContext from '../components/QueryContext'
 
+/**
+ * This hook is required because we make the facets query
+ * with only the categories and fulltext parameters, so we
+ * need to calculate manually if the other filters are selected
+ */
 const useSelectedFilters = facets => {
-  const { query } = useContext(QueryContext)
+  const { query, map } = useContext(QueryContext)
 
-  const queryValues = query
-    .toLowerCase()
-    .split('/')
-    .map(decodeURIComponent)
+  const queryAndMap = zip(
+    query
+      .toLowerCase()
+      .split('/')
+      .map(decodeURIComponent),
+    map.split(',')
+  )
 
-  return facets.map(facet => ({
-    ...facet,
-    selected: queryValues.includes(
-      decodeURIComponent(facet.value).toLowerCase()
-    ),
-  }))
+  return facets.map(facet => {
+    const currentFacetSlug = decodeURIComponent(facet.value).toLowerCase()
+
+    const isSelected =
+      queryAndMap.find(
+        ([slug, slugMap]) => slug === currentFacetSlug && slugMap === facet.map
+      ) !== undefined
+
+    return {
+      ...facet,
+      selected: isSelected,
+    }
+  })
 }
 
 export default useSelectedFilters


### PR DESCRIPTION
#### What is the purpose of this pull request?
Update the check for selected filters to also account for the map that each slug is corresponding to.

#### What problem is this solving?
In the invicta store, we have a category and a brand with the same name, which was marking both of them as selected filters, even though only one of them was selected.

#### How should this be manually tested?
[workspace](https://lucas--invictastores.myvtex.com/watches/Glycine?map=c%2Cc).

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
