### PR TITLE
Hotfix/cluster title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.17.5] - 2019-05-10
 ### Fixed
 - Displays the correct product cluster title, instead of its id.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Displays the correct product cluster title, instead of its id.
 
 ## [3.17.4] - 2019-05-10
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "3.17.4",
+  "version": "3.17.5",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/SearchTitle.js
+++ b/react/SearchTitle.js
@@ -29,7 +29,7 @@ const padRight = (array, num) =>
 
 const SearchTitle = ({ params, map, products }) => {
   // Terrible hotfix for product clusters/collections name below!
-  // The title should come from store-graphql. Once that's done, 
+  // The title should come from store-graphql. Once that's done,
   // all this logic should be removed from here.
 
   let title = null
@@ -67,7 +67,9 @@ const SearchTitle = ({ params, map, products }) => {
   }
 
   return (
-    <h1 className={classNames(styles.galleryTitle, 't-heading-1')}>{decodeURI(title)}</h1>
+    <h1 className={classNames(styles.galleryTitle, 't-heading-1')}>
+      {decodeURI(title)}
+    </h1>
   )
 }
 

--- a/react/SearchTitle.js
+++ b/react/SearchTitle.js
@@ -28,8 +28,9 @@ const padRight = (array, num) =>
   array.concat(Array.from(Array(num))).slice(0, num)
 
 const SearchTitle = ({ params, map, products }) => {
-  // Terrible hotfix for product cluster name below!!!
-  // Should be updated with a better version
+  // Terrible hotfix for product clusters/collections name below!
+  // The title should come from store-graphql. Once that's done, 
+  // all this logic should be removed from here.
 
   let title = null
 

--- a/react/SearchTitle.js
+++ b/react/SearchTitle.js
@@ -4,12 +4,18 @@ import { zip } from 'ramda'
 
 import styles from './searchResult.css'
 
+const isIterable = object =>
+  object != null && typeof object[Symbol.iterator] === 'function'
+
 const getClusterById = (products, id) => {
-  if (!products) {
+  if (!isIterable(products)) {
     return
   }
 
   for (const product of products) {
+    if (!product || !isIterable(product.productClusters)) {
+      continue
+    }
     for (const cluster of product.productClusters) {
       if (cluster.id === id) {
         return cluster.name
@@ -17,6 +23,9 @@ const getClusterById = (products, id) => {
     }
   }
 }
+
+const padRight = (array, num) =>
+  array.concat(Array.from(Array(num))).slice(0, num)
 
 const SearchTitle = ({ params, map, products }) => {
   // Terrible hotfix for product cluster name below!!!
@@ -26,12 +35,17 @@ const SearchTitle = ({ params, map, products }) => {
 
   // matches title "sources" with its respective map,
   // and gets the last valid one
-  const titleSources = zip([
+  const categories = [
     params.department,
     params.category,
     params.subcategory,
     params.term,
-  ], map.split(',')).reverse()
+  ]
+
+  const splitMap = padRight(map ? map.split(',') : [], categories.length)
+
+  const titleSources = zip(categories, splitMap).reverse()
+
   const [titleValue, titleMap] = titleSources.find(([param]) => !!param)
 
   // if the title maps to productClusterIds, gets the cluster name

--- a/react/SearchTitle.js
+++ b/react/SearchTitle.js
@@ -1,11 +1,51 @@
 import classNames from 'classnames'
 import React from 'react'
+import { zip } from 'ramda'
 
 import styles from './searchResult.css'
 
-const SearchTitle = ({ params }) => {
-  const title =
-    params.term || params.subcategory || params.category || params.department
+const getClusterById = (products, id) => {
+  if (!products) {
+    return
+  }
+
+  for (const product of products) {
+    for (const cluster of product.productClusters) {
+      if (cluster.id === id) {
+        return cluster.name
+      }
+    }
+  }
+}
+
+const SearchTitle = ({ params, map, products }) => {
+  // Terrible hotfix for product cluster name below!!!
+  // Should be updated with a better version
+
+  let title = null
+
+  // matches title "sources" with its respective map,
+  // and gets the last valid one
+  const titleSources = zip([
+    params.department,
+    params.category,
+    params.subcategory,
+    params.term,
+  ], map.split(',')).reverse()
+  const [titleValue, titleMap] = titleSources.find(([param]) => !!param)
+
+  // if the title maps to productClusterIds, gets the cluster name
+  // from the product list (which hopefully at least one
+  // product will have listed on its productClusters key)
+  if (titleMap === 'productClusterIds') {
+    const productCluster = getClusterById(products, titleValue)
+
+    if (productCluster) {
+      title = productCluster
+    }
+  } else {
+    title = titleValue
+  }
 
   if (!title) {
     return null

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -153,7 +153,7 @@ class SearchResult extends Component {
               <ExtensionPoint id="breadcrumb" {...breadcrumbsProps} />
             </div>
           )}
-          <ExtensionPoint id="search-title" params={params} />
+          <ExtensionPoint id="search-title" params={params} map={map} products={products} />
           <ExtensionPoint
             id="total-products"
             recordsFiltered={recordsFiltered}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fixes issue where the product cluster id was being displayed as title instead of its name.

This is a hotfix; an actual fix should be done on store-graphql. Once that's done, the logic on `SearchTitle` should be removed.

Before: https://invictastores.myvtex.com/watches/146?map=c%2CproductClusterIds (look at the "146" on the title)

After: https://lbebber--invictastores.myvtex.com/watches/146?map=c%2CproductClusterIds (the title should be "home page")

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
