### PR TITLE
Use recordsFiltered from facets query in not found page check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Not found page being shown without filter navigator when the cause for the
+  lack of products is an applied filter.
 
 ## [3.17.6] - 2019-05-10
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.17.7] - 2019-05-10
 ### Fixed
 - Not found page being shown without filter navigator when the cause for the
   lack of products is an applied filter.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "3.17.6",
+  "version": "3.17.7",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -28,6 +28,7 @@ class SearchResult extends Component {
     // on SSR the getDerivedStateFromProps isn't called
     products: this.props.products,
     recordsFiltered: this.props.recordsFiltered,
+    facetRecordsFiltered: this.props.facetRecordsFiltered,
     brands: this.props.brands,
     map: this.props.map,
     params: this.props.params,
@@ -63,6 +64,7 @@ class SearchResult extends Component {
       const {
         products,
         recordsFiltered,
+        facetRecordsFiltered,
         brands,
         map,
         params,
@@ -76,6 +78,7 @@ class SearchResult extends Component {
       return {
         products,
         recordsFiltered,
+        facetRecordsFiltered,
         brands,
         map,
         params,
@@ -122,6 +125,7 @@ class SearchResult extends Component {
     const {
       mobileLayoutMode,
       recordsFiltered,
+      facetRecordsFiltered,
       products = [],
       brands,
       map,
@@ -137,7 +141,11 @@ class SearchResult extends Component {
     const term =
       params && params.term ? decodeURIComponent(params.term) : undefined
 
-    if (recordsFiltered === 0 && !loading) {
+    // only show the not found page if the reason for it
+    // isn't because of some applied filter, but that we
+    // *really* don't have any products to show for the
+    // current query
+    if (facetRecordsFiltered === 0 && !loading) {
       return <ExtensionPoint id="not-found" term={term} />
     }
 

--- a/react/components/SearchResultContainer.js
+++ b/react/components/SearchResultContainer.js
@@ -24,7 +24,7 @@ const getBreadcrumbsProps = ({
   loading,
 }) => {
   const params = {
-    term: term ? decodeURIComponent(term) : term
+    term: term ? decodeURIComponent(term) : term,
   }
 
   if (loading || !categoriesTrees) {
@@ -32,7 +32,10 @@ const getBreadcrumbsProps = ({
   }
 
   if (department && category) {
-    params.categoryTree = categoriesTrees.reduce(categoryWithChildrenReducer, [])
+    params.categoryTree = categoriesTrees.reduce(
+      categoryWithChildrenReducer,
+      []
+    )
   } else if (department) {
     params.categoryTree = categoriesTrees
   }
@@ -56,6 +59,7 @@ const SearchResultContainer = props => {
           specificationFilters = [],
           priceRanges = [],
           categoriesTrees,
+          recordsFiltered: facetRecordsFiltered,
         } = {},
         productSearch: { products = [], recordsFiltered } = {},
       } = {},
@@ -136,6 +140,7 @@ const SearchResultContainer = props => {
           query={query}
           loading={loading}
           recordsFiltered={recordsFiltered}
+          facetRecordsFiltered={facetRecordsFiltered}
           products={products}
           brands={brands}
           specificationFilters={specificationFilters}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Update the check for when to display the not found page to use the recordsFiltered returned from the facets query, instead of the products.

#### What problem is this solving?
This is so we can show the "not found" only in the gallery if the cause for the lack of products is an applied filter by the user, so they can unapply the filter and get the products back in the list.

#### How should this be manually tested?
[workspace](https://lucas--invictastores.myvtex.com/watches/1603/Technomarine?map=c%2CspecificationFilter_69%2Cc)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
