### PR TITLE
Fix/search title fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.17.8] - 2019-05-10
 ### Fixed
 - Fixed bug where the extension would break if no title was found.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed bug where the extension would break if no title was found.
 
 ## [3.17.7] - 2019-05-10
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "3.17.7",
+  "version": "3.17.8",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/SearchTitle.js
+++ b/react/SearchTitle.js
@@ -47,7 +47,10 @@ const SearchTitle = ({ params, map, products }) => {
 
   const titleSources = zip(categories, splitMap).reverse()
 
-  const [titleValue, titleMap] = titleSources.find(([param]) => !!param)
+  const [titleValue, titleMap] = titleSources.find(([param]) => !!param) || [
+    null,
+    null,
+  ]
 
   // if the title maps to productClusterIds, gets the cluster name
   // from the product list (which hopefully at least one


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fixes bug where the extension would break if no title was found.

To see it working, go to https://lbebber--invictastores.myvtex.com/watches/invicta, then select "Men" and then "Mens" on the left bar.

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
