### PR TITLE
Clean subcategory filter based on category

### DIFF
--- a/react/components/FacetItem.js
+++ b/react/components/FacetItem.js
@@ -22,28 +22,49 @@ const FacetItem = ({ facet }) => {
   const { query, map } = useContext(QueryContext)
   const { showFacetQuantity } = useContext(SettingsContext)
 
+  const getFacetIndex = facet => {
+    return query
+      .toLowerCase()
+      .split('/')
+      .map(decodeURIComponent)
+      .findIndex(
+        value => value === decodeURIComponent(facet.value).toLowerCase()
+      )
+  }
+
+  const removeChildrenSelected = (facet, urlParams) => {
+    let newQuery = query
+    for (const child of facet.children) {
+      if (child.selected) {
+        if (child.children) {
+          for (const c of child.children) {
+            newQuery = removeChildrenSelected(c, urlParams)
+          }
+        }
+        const childIndex = getFacetIndex(child)
+        newQuery = removeElementAtIndex(query, childIndex, '/')
+        urlParams.set('map', removeElementAtIndex(map, childIndex, ','))
+      }
+    }
+    return newQuery
+  }
+
   const handleChange = () => {
     const urlParams = new URLSearchParams(window.location.search)
 
     if (facet.selected) {
-      const facetIndex = query
-        .toLowerCase()
-        .split('/')
-        .map(decodeURIComponent)
-        .findIndex(
-          value => value === decodeURIComponent(facet.value).toLowerCase()
-        )
-
+      const facetIndex = getFacetIndex(facet)
+      let newQuery = removeChildrenSelected(facet, urlParams)
       urlParams.set('map', removeElementAtIndex(map, facetIndex, ','))
 
       navigate({
-        to: `/${removeElementAtIndex(query, facetIndex, '/')}`,
+        to: `/${removeElementAtIndex(newQuery, facetIndex, '/')}`,
         query: urlParams.toString(),
         scrollOptions,
       })
       return
     }
-
+    
     urlParams.set('map', `${map},${facet.map}`)
 
     navigate({


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says

#### What problem is this solving?

When deselecting a category, if there is any subcategory of this selected, the subcategory isn't cleared, then the search result is not what is expected for the selected filters 

#### How should this be manually tested?

[Access this workspace](https://thalyta--storecomponents.myvtex.com)

#### Screenshots or example usage

#### Types of changes

* [ x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
