### PR TITLE
Updated the context in the props

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Now, you can change the behavior of the search result block that is in the store
       "search-title"
     ],
     "props": {
-      "querySchema": {
+      "context": {
         "maxItemsPerPage": 2,
         "orderByField": "OrderByReleaseDateDESC"
       },


### PR DESCRIPTION
The amount of items returned by search result is not accepting the configuration of the current documentation. Only by applying a context in the props of the component, the standard quantity of items returned by the search result works.

at least from the app I'm setting up, it worked this way.
