### PR TITLE
Dispatch productImpression events to PixelManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.19.0] - 2019-05-23
+
 ### Added
 
 - Send productImpression events to Pixel Manager.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Send productImpression events to Pixel Manager.
+
+### Fixed
+
+- Fixed bug when pushing productClick event (param expected was not being sent)
+
 ## [3.18.1] - 2019-05-20
+
 ### Changed
+
 - Use new breadcrumb resolver on productSearch.
 - Get Search Title from last breadcrumb name returned.
 
@@ -19,119 +29,168 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Send productClick events to Pixel Manager.
 
 ## [3.17.8] - 2019-05-10
+
 ### Fixed
+
 - Fixed bug where the extension would break if no title was found.
 
 ## [3.17.7] - 2019-05-10
+
 ### Fixed
+
 - Not found page being shown without filter navigator when the cause for the
   lack of products is an applied filter.
 
 ## [3.17.6] - 2019-05-10
+
 ### Fixed
+
 - Fetch more on `LocalQuery` was always fetching 10 more items, and not fetching the next maxItemsPerPage items.
 
 ## [3.17.5] - 2019-05-10
+
 ### Fixed
+
 - Displays the correct product cluster title, instead of its id.
 
 ## [3.17.4] - 2019-05-10
+
 ### Fixed
+
 - Refrain from throwing error when LayoutModeSwitcher icon is not found.
 
 ## [3.17.3] - 2019-05-10
+
 ### Fixed
+
 - Vendas to Ventas in es.json
 
 ## [3.17.2] - 2019-05-08
+
 ### Fixed
+
 - Use `setQuery` method when selecting a sort by option.
 
 ## [3.17.1] - 2019-05-07
+
 ### Fixed
+
 - Correctly slugify facets when comparing if they are selected.
 
 ## [3.17.0] - 2019-05-07
+
 ### Changed
+
 - Generates category to use as prop categoryTree in breadcrumb
 
 ## [3.16.2] - 2019-05-07
+
 ### Added
+
 - Prop `hideUnavailableItems` to querySchema and use it on `LocalQuery`.
 
 ## [3.16.1] - 2019-05-06
 
 ## [3.16.0] - 2019-05-06
+
 ### Fixed
+
 - Remove the default 'Sort By' option on `OrderBy` component.
 
 ## [3.15.5] - 2019-05-06
+
 ### Fixed
+
 - Selected filters not accounting for map parameter.
 
 ## [3.15.4] - 2019-05-06
+
 ### Fixed
+
 - Make `LocalQuery` use productSearchV2 and set default items per page.
 
 ## [3.15.3] - 2019-05-06
+
 ### Fixed
+
 - Decode gallery title.
 
 ## [3.15.2] - 2019-05-03
+
 ### Fixed
+
 - Infinite loading on fetch more.
 
 ## [3.15.1] - 2019-05-01
+
 ### Changed
+
 - Use `recordsFiltered` value from productSearch query.
 
 ## [3.15.0] - 2019-04-26
+
 ### Changed
 
 - Use filters value instead of encoded link on navigate.
 
 ## [3.14.1] - 2019-04-26
+
 ### Fixed
+
 - Messages on not found page.
 
 ## [3.14.0] - 2019-04-26
+
 ### Changed
 
 - Remove usage of `rest` parameter.
 
 ## [3.13.4] - 2019-04-26
+
 ### Fixed
+
 - undefined error in fetch more.
 
 ## [3.13.3] - 2019-04-25
+
 ### Fixed
+
 - `TotalProducts` proptype error.
 
 ## [3.13.2] - 2019-04-12
+
 ### Changed
+
 - Removed option `showTitle` on schema.
 
 ## [3.13.1] - 2019-04-10
 
 ## [3.13.0] - 2019-04-10
+
 ### Added
 
 - Add `search-title` block for displaying category or search term.
 
 ## [3.12.14] - 2019-04-10
+
 ### Changed
+
 - Using `store-icons` instead of `dreamstore-icons`.
 
 ## [3.12.13] - 2019-04-10
+
 ### Changed
-- Add new CSS handle `filterContent`. 
+
+- Add new CSS handle `filterContent`.
 
 ## [3.12.12] - 2019-04-10
+
 ### Fixed
 
 - Error when trying to read properties from facets while loading.
 
 ## [3.12.11] - 2019-03-29
+
 ### Fixed
 
 - Added the department before each category to pass it to `Breadcrubms`.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "3.18.1",
+  "version": "3.19.0",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -2,7 +2,7 @@ import React from 'react'
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import { withResizeDetector } from 'react-resize-detector'
-import { map, pluck } from 'ramda'
+import { map, pluck, addIndex } from 'ramda'
 
 import { useRuntime } from 'vtex.render-runtime'
 
@@ -35,7 +35,7 @@ const Gallery = ({
     return maxItemsPerRow <= maxItems ? maxItemsPerRow : maxItems
   }
 
-  const renderItem = item => {
+  const renderItem = (item, index) => {
     const itemsPerRow =
       layoutMode === 'small'
         ? TWO_COLUMN_ITEMS
@@ -52,7 +52,7 @@ const Gallery = ({
         style={style}
         className={classNames(searchResult.galleryItem, 'pa4')}
       >
-        <GalleryItem item={item} summary={summary} displayMode={layoutMode} />
+        <GalleryItem item={item} summary={summary} positionList={index + 1} displayMode={layoutMode} />
       </div>
     )
   }
@@ -62,7 +62,9 @@ const Gallery = ({
     'flex flex-row flex-wrap items-stretch bn ph1 pl9-l na4'
   )
 
-  return <div className={galleryClasses}>{map(renderItem, products)}</div>
+  const mapWithIndex = addIndex(map)
+
+  return <div className={galleryClasses}>{mapWithIndex(renderItem, products)}</div>
 }
 
 Gallery.propTypes = {

--- a/react/__mocks__/vtex.pixel-manager/PixelContext.js
+++ b/react/__mocks__/vtex.pixel-manager/PixelContext.js
@@ -1,6 +1,7 @@
-export function usePixel(Comp) {
-  const usePixel = () => {
-    const push = () => {}
-  }
-  return usePixel
+import { useContext, createContext } from 'react'
+
+const PixelContext = createContext({ push: () => undefined })
+
+export const usePixel = () => {
+  return useContext(PixelContext)
 }

--- a/react/components/GalleryItem.js
+++ b/react/components/GalleryItem.js
@@ -56,13 +56,15 @@ const GalleryItem = ({ item, displayMode, summary }) => {
     push({ event: 'productClick', product })
   }
 
+  const product = normalizeProductSummary(item)
+
   return (
     <ExtensionPoint
       id="product-summary"
       {...summary}
-      product={normalizeProductSummary(item)}
+      product={product}
       displayMode={displayMode}
-      actionOnClick={() => sendProductClickEvent(item)}
+      actionOnClick={() => sendProductClickEvent(product)}
     />
   )
 }

--- a/react/components/GalleryItem.js
+++ b/react/components/GalleryItem.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useMemo } from 'react'
 import { ExtensionPoint } from 'vtex.render-runtime'
 import { usePixel } from 'vtex.pixel-manager/PixelContext'
 import { path, sort, comparator, useWith, gt } from 'ramda'
@@ -52,11 +52,24 @@ const GalleryItem = ({ item, displayMode, summary, positionList }) => {
 
   const { push } = usePixel()
 
-  const sendProductClickEvent = product => {
+  const pushPixelProductClickEvent = product => {
     push({ event: 'productClick', product })
   }
 
-  const product = normalizeProductSummary(item)
+  const pushPixelProductImpressionEvent = (product, position) => {
+    push({
+      event: 'productImpression',
+      list: 'Search result',
+      product,
+      position,
+    })
+  }
+
+  const product = useMemo(() => normalizeProductSummary(item), [item])
+
+  useEffect(() => {
+    pushPixelProductImpressionEvent(product, positionList)
+  }, [product])
 
   return (
     <ExtensionPoint
@@ -64,7 +77,7 @@ const GalleryItem = ({ item, displayMode, summary, positionList }) => {
       {...summary}
       product={product}
       displayMode={displayMode}
-      actionOnClick={() => sendProductClickEvent(product)}
+      actionOnClick={() => pushPixelProductClickEvent(product)}
     />
   )
 }
@@ -76,6 +89,8 @@ GalleryItem.propTypes = {
   summary: PropTypes.any,
   /** Display mode of the product summary */
   displayMode: PropTypes.string,
+  /** Item's position in the list in which it is rendered. */
+  positionList: PropTypes.number,
 }
 
 export default GalleryItem

--- a/react/components/GalleryItem.js
+++ b/react/components/GalleryItem.js
@@ -10,7 +10,7 @@ import { PropTypes } from 'prop-types'
 /**
  * Normalizes the item received in the props to adapt to the extension point prop.
  */
-const GalleryItem = ({ item, displayMode, summary }) => {
+const GalleryItem = ({ item, displayMode, summary, positionList }) => {
   const normalizeProductSummary = product => {
     if (!product) {
       return null


### PR DESCRIPTION
#### What is the purpose of this pull request?

As title says.
Also fix bug when pushing productClick event (param expected was not being sent)

#### How should this be manually tested?

https://italohmb--storecomponents.myvtex.com/

Click on a category gallery (ex: Notebooks). Events should be sent to Pixel.

#### Screenshots or example usage

#### Types of changes

* [X] Bug fix (a non-breaking change which fixes an issue)
* [X] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
