### PR TITLE
 Avoid flickering triggered by resize of height in ReactResizeDetector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.19.2] - 2019-05-24
+
 ### Fixed
 
 - Flickering behaviour triggered by ResizeDetector.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Flickering behaviour triggered by ResizeDetector.
+
 ## [3.19.1] - 2019-05-23
+
 ### Fixed
 - Hides filters when there are no filters available.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "3.19.1",
+  "version": "3.19.2",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import { withResizeDetector } from 'react-resize-detector'
 import { map, pluck, addIndex } from 'ramda'
 
 import { useRuntime } from 'vtex.render-runtime'
@@ -9,6 +8,7 @@ import { useRuntime } from 'vtex.render-runtime'
 import { LAYOUT_MODE } from './components/LayoutModeSwitcher'
 import { productShape } from './constants/propTypes'
 import GalleryItem from './components/GalleryItem'
+import withResizeDetector from './components/withResizeDetector'
 
 import searchResult from './searchResult.css'
 

--- a/react/components/withResizeDetector.js
+++ b/react/components/withResizeDetector.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import ReactResizeDetector from 'react-resize-detector'
+
+function withResizeDetector(WrappedComponent) {
+  // eslint-disable-next-line react/display-name
+  return props => (
+    <ReactResizeDetector handleWidth>
+      {width => <WrappedComponent {...props} width={width} />}
+    </ReactResizeDetector>
+  )
+}
+
+export default withResizeDetector


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix flickering of gallery.

#### What problem is this solving?

Avoid flickering.

#### How should this be manually tested?

https://lbebber--ecowaterqa.myvtex.com/filter/s?map=ft

#### Screenshots or example usage

n/a

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
