### PR TITLE
Fix case where filter navigation was hidden even though categories we…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.21.1] - 2019-05-28
+
 ### Fixed
 
 - Filter navigation that have set only not hide categories.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Filter navigation that have set only not hide categories.
+
 ## [3.21.0] - 2019-05-27
 ### Added
 - `filter-navigator.v2` using the Category Tree to show categories/departments in a correct hierarchy.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "3.21.0",
+  "version": "3.21.1",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -168,7 +168,13 @@ class SearchResult extends Component {
       hiddenFacets,
     })
 
-    const showFacets = !hideFacets && !isEmpty(filters)
+    const showCategories =
+      hiddenFacets &&
+      hiddenFacets.categories === false &&
+      tree &&
+      tree.length > 0
+
+    const showFacets = showCategories || (!hideFacets && !isEmpty(filters))
 
     return (
       <LoadingOverlay loading={showLoading && showLoadingAsOverlay}>


### PR DESCRIPTION
…re to be shown

#### What is the purpose of this pull request?

Fix Ecowater filters.

#### What problem is this solving?

In a store with the following settings:

```js
"search-result": {
    "blocks": [
      "filter-navigator.v2",
      "gallery",
      "not-found",
      "breadcrumb",
      "order-by"
    ],
    "props": {
      "maxItemsPerPage": 8,
      "querySchema": {
        "maxItemsPerPage": 8,
        "orderByField": "OrderByTopSaleDESC"
      },
      "hiddenFacets": {
        "layoutMode1": "inline",
        "layoutMode2": "inline",
        "categories": false,
        "brands": true,
        "priceRange": true,
        "specificationFilters": {
          "hideAll": true
        }
      },
      "pagination": "show-more"
    }
  },
```

The navigation filter is not shown for the categories.

#### How should this be manually tested?

https://breno2--storecomponents.myvtexdev.com/top

#### Screenshots or example usage

Before | After
---|---
![image](https://user-images.githubusercontent.com/284515/58519331-741bea80-8189-11e9-8ca3-407a22d4cdcd.png) | ![image](https://user-images.githubusercontent.com/284515/58519298-4f277780-8189-11e9-87c7-6f3636f23b39.png)
![image](https://user-images.githubusercontent.com/284515/58519564-9bbf8280-818a-11e9-82f2-bc19b9859bde.png) | ![image](https://user-images.githubusercontent.com/284515/58519554-8ea29380-818a-11e9-9dd8-9976ac247306.png)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
