### PR TITLE
order by relevance is now the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Added order by relevance to the order types
+- The default value of `orderByField` is now order by relevance.
 
 ## [3.22.5] - 2019-07-09
 ### Changed

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ QuerySchema
 | `queryField`           | `String`  | Query field                                                                                                                                                                      | N/A                      |
 | `mapField`             | `String`  | Map field                                                                                                                                                                        | N/A                      |
 | `restField`            | `String`  | Other Query Strings                                                                                                                                                              | N/A                      |
-| `orderByField`         | `Enum`    | Order by field (values: 'OrderByTopSaleDESC', 'OrderByReleaseDateDESC', 'OrderByBestDiscountDESC', 'OrderByPriceDESC', 'OrderByPriceASC', 'OrderByNameASC' or 'OrderByNameDESC') | `OrderByReleaseDateDESC` |
+| `orderByField`         | `Enum`    | Order by field (values: `OrderByTopSaleDESC`, `OrderByReleaseDateDESC`, `OrderByBestDiscountDESC`, `OrderByPriceDESC`, `OrderByPriceASC`, `OrderByNameASC`, `OrderByNameDESC` or `''` (by relevance)) | `''` |
 | `hideUnavailableItems` | `Boolean` | Set if unavailable items should show on search                                                                                                                                   | `false`                  |
 
 HiddenFacets

--- a/messages/context.json
+++ b/messages/context.json
@@ -52,6 +52,7 @@
   "store/search.no-products": "No products were found",
   "store/ordenation.button": "Sort",
   "store/ordenation.sort-by": "Sort By",
+  "store/ordenation.relevance": "Relevance (Default)",
   "store/ordenation.sales": "Sales",
   "store/ordenation.release.date": "Release Date",
   "store/ordenation.discount": "Discount",

--- a/messages/en.json
+++ b/messages/en.json
@@ -52,6 +52,7 @@
   "store/search.no-products": "No products were found",
   "store/ordenation.button": "Sort",
   "store/ordenation.sort-by": "Sort By",
+  "store/ordenation.relevance": "Relevance (Default)",
   "store/ordenation.sales": "Sales",
   "store/ordenation.release.date": "Release Date",
   "store/ordenation.discount": "Discount",

--- a/messages/es.json
+++ b/messages/es.json
@@ -52,6 +52,7 @@
   "store/search.no-products": "No se ha encontrado ningún producto",
   "store/ordenation.button": "Ordenar",
   "store/ordenation.sort-by": "Ordenar por",
+  "store/ordenation.relevance": "Relevancia (Defecto)",
   "store/ordenation.sales": "Ventas",
   "store/ordenation.release.date": "Más reciente",
   "store/ordenation.discount": "Descuento",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -52,6 +52,7 @@
   "store/search.no-products": "Nenhum produto foi encontrado",
   "store/ordenation.button": "Ordenar",
   "store/ordenation.sort-by": "Ordenar Por",
+  "store/ordenation.relevance": "Relevância (Padrão)",
   "store/ordenation.sales": "Mais Vendidos",
   "store/ordenation.release.date": "Mais recentes",
   "store/ordenation.discount": "Descontos",

--- a/react/OrderBy.js
+++ b/react/OrderBy.js
@@ -8,6 +8,10 @@ import searchResult from './searchResult.css'
 
 export const SORT_OPTIONS = [
   {
+    value: '',
+    label: 'store/ordenation.relevance',
+  },
+  {
     value: 'OrderByTopSaleDESC',
     label: 'store/ordenation.sales',
   },

--- a/react/__tests__/__snapshots__/OrderBy.test.js.snap
+++ b/react/__tests__/__snapshots__/OrderBy.test.js.snap
@@ -35,6 +35,11 @@ exports[`<OrderBy /> should match snapshot in mobile 1`] = `
         <button
           class="bg-base c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 hover-bg-muted-4 w-100"
         >
+          Relevance (Default)
+        </button>
+        <button
+          class="bg-base c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 hover-bg-muted-4 w-100"
+        >
           Sales
         </button>
         <button
@@ -105,6 +110,11 @@ exports[`<OrderBy /> should match snapshot in web mod 1`] = `
       <div
         class="z-1 absolute bg-base shadow-5 f5 w-100 b--muted-4 br2 ba bw1 br--bottom dn"
       >
+        <button
+          class="bg-base c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 hover-bg-muted-4 w-100"
+        >
+          Relevance (Default)
+        </button>
         <button
           class="bg-base c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 hover-bg-muted-4 w-100"
         >

--- a/react/index.js
+++ b/react/index.js
@@ -91,7 +91,7 @@ SearchResultQueryLoader.getSchema = props => {
             orderByField: {
               title: 'Order by field',
               type: 'string',
-              default: SORT_OPTIONS[1].value,
+              default: '',
               enum: SORT_OPTIONS.map(opt => opt.value),
               enumNames: SORT_OPTIONS.map(opt => opt.label),
             },


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add `order by relevance` to the order types and made it the default.

#### What problem is this solving?

It was requested that ordering by relevance should be the default option.

#### How should this be manually tested?
Add a search-result to your store through `blocks.json` without passing the `orderByField` prop and then assure that the search result is being sorted by relevance.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/8443580/61740869-0f82a380-ad66-11e9-93a0-45fa2307701b.png)


#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Requires change to documentation, which has been updated accordingly.
