### PR TITLE
fixed oops typo

### DIFF
--- a/react/NotFoundSearch.js
+++ b/react/NotFoundSearch.js
@@ -24,7 +24,7 @@ const NotFoundSearch = ({ term }) => {
           className="flex justify-end-ns justify-center-s ttu f1 ph4 pv4-s pv0-ns c-muted-3 ph9 b"
           style={flexStyle}
         >
-          ops!
+          oops!
         </div>
         <div className="ph9" style={flexStyle}>
           {term ? (


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix typo of empty search-results. OPS should become OOPS.

#### How should this be manually tested?
https://denise--delivery.myvtex.com/sdjasoidjoasiidjaii?map=ft

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/12139385/61811694-6b0d6980-ae18-11e9-947f-d54bc55b4eac.png)

#### Types of changes

* [X] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
