### PR TITLE
removed the "(default)" from default options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- removed the "(default)" from default options
 
 ## [3.22.7] - 2019-07-24
 

--- a/messages/context.json
+++ b/messages/context.json
@@ -52,7 +52,7 @@
   "store/search.no-products": "No products were found",
   "store/ordenation.button": "Sort",
   "store/ordenation.sort-by": "Sort By",
-  "store/ordenation.relevance": "Relevance (Default)",
+  "store/ordenation.relevance": "Relevance",
   "store/ordenation.sales": "Sales",
   "store/ordenation.release.date": "Release Date",
   "store/ordenation.discount": "Discount",

--- a/messages/en.json
+++ b/messages/en.json
@@ -52,7 +52,7 @@
   "store/search.no-products": "No products were found",
   "store/ordenation.button": "Sort",
   "store/ordenation.sort-by": "Sort By",
-  "store/ordenation.relevance": "Relevance (Default)",
+  "store/ordenation.relevance": "Relevance",
   "store/ordenation.sales": "Sales",
   "store/ordenation.release.date": "Release Date",
   "store/ordenation.discount": "Discount",

--- a/messages/es.json
+++ b/messages/es.json
@@ -52,7 +52,7 @@
   "store/search.no-products": "No se ha encontrado ningún producto",
   "store/ordenation.button": "Ordenar",
   "store/ordenation.sort-by": "Ordenar por",
-  "store/ordenation.relevance": "Relevancia (Defecto)",
+  "store/ordenation.relevance": "Relevancia",
   "store/ordenation.sales": "Ventas",
   "store/ordenation.release.date": "Más reciente",
   "store/ordenation.discount": "Descuento",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -52,7 +52,7 @@
   "store/search.no-products": "Nenhum produto foi encontrado",
   "store/ordenation.button": "Ordenar",
   "store/ordenation.sort-by": "Ordenar Por",
-  "store/ordenation.relevance": "Relevância (Padrão)",
+  "store/ordenation.relevance": "Relevância",
   "store/ordenation.sales": "Mais Vendidos",
   "store/ordenation.release.date": "Mais recentes",
   "store/ordenation.discount": "Descontos",

--- a/react/__tests__/__snapshots__/OrderBy.test.js.snap
+++ b/react/__tests__/__snapshots__/OrderBy.test.js.snap
@@ -35,7 +35,7 @@ exports[`<OrderBy /> should match snapshot in mobile 1`] = `
         <button
           class="bg-base c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 hover-bg-muted-4 w-100"
         >
-          Relevance (Default)
+          Relevance
         </button>
         <button
           class="bg-base c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 hover-bg-muted-4 w-100"
@@ -113,7 +113,7 @@ exports[`<OrderBy /> should match snapshot in web mod 1`] = `
         <button
           class="bg-base c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 hover-bg-muted-4 w-100"
         >
-          Relevance (Default)
+          Relevance
         </button>
         <button
           class="bg-base c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 hover-bg-muted-4 w-100"


### PR DESCRIPTION
#### What is the purpose of this pull request?
removed the "(default)" from default ordination options

#### How should this be manually tested?
Open the ordination options of a search-result and check that there is no "Relevance (Default)" option, but just "Relevance"

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/8443580/61903775-b9476900-aefb-11e9-8b3a-5518b2655325.png)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
