### PR TITLE
Correction for typo in url for AccordionFilterItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,15 +344,15 @@ Below, we describe the namespaces that are defined in the search-result.
 | `accordionFilterItemActive`       | Container of the accordion filter item when it is active   | [AccordionFilterItem](/react/components/AccordionFilterItem.js)           |
 | `totalProducts`                   | The main container of total-products                       | [TotalProducts](/react/TotalProducts.js)                                  |
 | `orderBy`                         | The main container of order-by                             | [OrderBy](/react/OrderBy.js)                                              |
-| `accordionFilterItemHidden`       | Accordion filter item container when it is hidden          | [AccordionFilterItem](/react/compoents/AccordionFilterItem.js)            |
-| `accordionFilterItem`             | Accordion filter item container                            | [AccordionFilterItem](/react/compoents/AccordionFilterItem.js)            |
-| `accordionFilterItemBox`          | Accordion filter item box                                  | [AccordionFilterItem](/react/compoents/AccordionFilterItem.js)            |
-| `accordionFilterItemTitle`        | Accordion filter item title container                      | [AccordionFilterItem](/react/compoents/AccordionFilterItem.js)            |
-| `accordionFilterItemIcon`         | Accordion filter item icon container                       | [AccordionFilterItem](/react/compoents/AccordionFilterItem.js)            |
-| `filterAvailable`                 | Filter option template main container when it is available | [FilterOptionTemplate](/react/compoents/AccordionFilterItem.js)           |
-| `filterSelected`                  | Filter option template main container when it is selected  | [FilterOptionTemplate](/react/compoents/AccordionFilterItem.js)           |
-| `filterPopupTitle`                | Filter pop-up title label                                  | [FilterSidebar](/react/compoents/FilterSidebar.js)                        |
-| `filterPopupArrowIcon`            | Filter pop-up arrow icon container                         | [FilterSidebar](/react/compoents/FilterSidebar.js)                        |
+| `accordionFilterItemHidden`       | Accordion filter item container when it is hidden          | [AccordionFilterItem](/react/components/AccordionFilterItem.js)            |
+| `accordionFilterItem`             | Accordion filter item container                            | [AccordionFilterItem](/react/components/AccordionFilterItem.js)            |
+| `accordionFilterItemBox`          | Accordion filter item box                                  | [AccordionFilterItem](/react/components/AccordionFilterItem.js)            |
+| `accordionFilterItemTitle`        | Accordion filter item title container                      | [AccordionFilterItem](/react/components/AccordionFilterItem.js)            |
+| `accordionFilterItemIcon`         | Accordion filter item icon container                       | [AccordionFilterItem](/react/components/AccordionFilterItem.js)            |
+| `filterAvailable`                 | Filter option template main container when it is available | [FilterOptionTemplate](/react/components/AccordionFilterItem.js)           |
+| `filterSelected`                  | Filter option template main container when it is selected  | [FilterOptionTemplate](/react/components/AccordionFilterItem.js)           |
+| `filterPopupTitle`                | Filter pop-up title label                                  | [FilterSidebar](/react/components/FilterSidebar.js)                        |
+| `filterPopupArrowIcon`            | Filter pop-up arrow icon container                         | [FilterSidebar](/react/components/FilterSidebar.js)                        |
 | `footerButton`                    | Footer button                                              | [FooterButton](/react/components/FooterButton.js)                         |
 | `layoutSwitcher`                  | Layout mode switcher container                             | [LayoutModeSwitcher](/react/components/LayoutModeSwitcher.js)             |
 | `filterPopup`                     | Main container of filter pop-up                            | [FilterPopup](/react/components/FilterPopup.js)                           |


### PR DESCRIPTION
URL correction applied from `/react/compoents` to `/react/components`

#### What is the purpose of this pull request?

Correction for typo in url for AccordionFilterItem

#### What problem is this solving?

Fixes annotation for AccordionFilterItem component

#### Types of changes

* [ * ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
