### PR TITLE
fix price range navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix breaking search in cateogry page when setting a price range.
 
 ## [3.22.9] - 2019-07-26
 ### Fixed

--- a/react/components/PriceRange.js
+++ b/react/components/PriceRange.js
@@ -6,17 +6,14 @@ import { Slider } from 'vtex.styleguide'
 import { formatCurrency } from 'vtex.format-currency'
 
 import { facetOptionShape } from '../constants/propTypes'
-import {
-  getFilterTitle,
-  HEADER_SCROLL_OFFSET,
-} from '../constants/SearchHelpers'
+import { getFilterTitle } from '../constants/SearchHelpers'
 import FilterOptionTemplate from './FilterOptionTemplate'
 
 const DEBOUNCE_TIME = 500 // ms
 
 /** Price range slider component */
 const PriceRange = ({ title, facets, intl, priceRange }) => {
-  const { navigate, culture } = useRuntime()
+  const { culture, setQuery } = useRuntime()
 
   const navigateTimeoutId = useRef()
 
@@ -26,18 +23,7 @@ const PriceRange = ({ title, facets, intl, priceRange }) => {
     }
 
     navigateTimeoutId.current = setTimeout(() => {
-      const queryParams = new URLSearchParams(window.location.search)
-
-      queryParams.set('priceRange', `${left} TO ${right}`)
-
-      navigate({
-        to: window.location.pathname,
-        query: queryParams.toString(),
-        scrollOptions: {
-          baseElementId: 'search-result-anchor',
-          top: -HEADER_SCROLL_OFFSET,
-        },
-      })
+      setQuery({ priceRange: `${left} TO ${right}` }, { replace: true })
     }, DEBOUNCE_TIME)
   }
 

--- a/react/components/PriceRange.js
+++ b/react/components/PriceRange.js
@@ -23,7 +23,7 @@ const PriceRange = ({ title, facets, intl, priceRange }) => {
     }
 
     navigateTimeoutId.current = setTimeout(() => {
-      setQuery({ priceRange: `${left} TO ${right}` }, { replace: true })
+      setQuery({ priceRange: `${left} TO ${right}` })
     }, DEBOUNCE_TIME)
   }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

By using the setQuery method, it skips some steps of the navigation method, maintains the page context and only triggers the refetch of the query with the new price range query param.

#### What problem is this solving?

When setting a price range, it would redo the original query as a FT and not as a category, for example

#### How should this be manually tested?

https://fidteste--storecomponents.myvtex.com/apparel---accessories/d

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
