### PR TITLE
Feature/query search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Prop `preventRouteChange` on (legacy for now) FilterNavigator, to prevent changing the route when filters are selected, changing just the query string instead. This is intended for `search-result` blocks inserted on custom pages with static routes.
+- Prop `preventRouteChange` on legacy FilterNavigator (for now), to prevent changing the route when filters are selected, changing just the query string instead. This is intended for `search-result` blocks inserted on custom pages with static routes.
 
 ## [3.22.12] - 2019-07-31
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Prop `preventRouteChange` on (legacy for now) FilterNavigator, to prevent changing the route when filters are selected, changing just the query string instead. This is intended for `search-result` blocks inserted on custom pages with static routes.
 
 ## [3.22.12] - 2019-07-31
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -295,6 +295,11 @@ MobileLayout
 | `mode1` | `Enum` | Layout mode of the switcher (values: 'normal', 'small' or 'inline') | `normal` |
 | `mode2` | `Enum` | Layout mode of the switcher 2 (values: 'normal', 'small' or 'inline') | `small` |
 
+`filter-navigator.v1` block
+| Prop name | Type | Description | Default value |
+| --- | --- | --- | --- |
+| `preventRouteChange` | `Boolean` | Prevents route change when selecting filters, using the query string instead. Intended for `search-result` blocks inserted on custom pages with static routes. | `false` |
+
 Also, you can configure the product summary that is defined on search-result. See [here](https://github.com/vtex-apps/product-summary/blob/master/README.md#configuration) the Product Summary API.
 
 ### Styles API

--- a/react/components/FilterNavigator/legacy/AvailableFilters.js
+++ b/react/components/FilterNavigator/legacy/AvailableFilters.js
@@ -4,7 +4,11 @@ import PropTypes from 'prop-types'
 import SearchFilter from './SearchFilter'
 import PriceRange from './PriceRange'
 
-const AvailableFilters = ({ filters = [], priceRange }) =>
+const AvailableFilters = ({
+  filters = [],
+  priceRange,
+  preventRouteChange = false,
+}) =>
   filters.map(filter => {
     const { type, title, facets, oneSelectedCollapse = false } = filter
 
@@ -24,6 +28,7 @@ const AvailableFilters = ({ filters = [], priceRange }) =>
             key={title}
             title={title}
             facets={facets}
+            preventRouteChange={preventRouteChange}
             oneSelectedCollapse={oneSelectedCollapse}
           />
         )
@@ -39,6 +44,8 @@ AvailableFilters.propTypes = {
       oneSelectedCollapse: PropTypes.bool,
     })
   ),
+  /** Prevents changing route when setting filters (uses URL search params instead) */
+  preventRouteChange: PropTypes.bool,
   /** Price range query parameter */
   priceRange: PropTypes.string,
 }

--- a/react/components/FilterNavigator/legacy/FacetItem.js
+++ b/react/components/FilterNavigator/legacy/FacetItem.js
@@ -18,14 +18,9 @@ const removeElementAtIndex = (str, index, separator) =>
     .join(separator)
 
 const FacetItem = ({ facet, preventRouteChange = false }) => {
-  const {
-    navigate,
-    route: { path },
-  } = useRuntime()
+  const { navigate, setQuery } = useRuntime()
   const { query, map } = useContext(QueryContext)
   const { showFacetQuantity } = useContext(SettingsContext)
-
-  const [basePath] = path.split('?')
 
   const handleChange = () => {
     const urlParams = new URLSearchParams(window.location.search)
@@ -39,19 +34,14 @@ const FacetItem = ({ facet, preventRouteChange = false }) => {
           value => value === decodeURIComponent(facet.value).toLowerCase()
         )
 
-      urlParams.set('map', removeElementAtIndex(map, facetIndex, ','))
-
       if (preventRouteChange) {
-        urlParams.set(
-          'query',
-          `/${removeElementAtIndex(query, facetIndex, '/')}`
-        )
-
-        navigate({
-          to: `${basePath}?${urlParams.toString()}`,
-          scrollOptions,
+        setQuery({
+          map: removeElementAtIndex(map, facetIndex, ','),
+          query: `/${removeElementAtIndex(query, facetIndex, '/')}`,
         })
       } else {
+        urlParams.set('map', removeElementAtIndex(map, facetIndex, ','))
+
         navigate({
           to: `/${removeElementAtIndex(query, facetIndex, '/')}`,
           query: urlParams.toString(),
@@ -62,15 +52,14 @@ const FacetItem = ({ facet, preventRouteChange = false }) => {
       return
     }
 
-    urlParams.set('map', `${map},${facet.map}`)
     if (preventRouteChange) {
-      urlParams.set('query', `/${query}/${facet.value}`)
-
-      navigate({
-        to: `${basePath}?${urlParams.toString()}`,
-        scrollOptions,
+      setQuery({
+        map: `${map},${facet.map}`,
+        query: `/${query}/${facet.value}`,
       })
     } else {
+      urlParams.set('map', `${map},${facet.map}`)
+
       navigate({
         to: `/${query}/${facet.value}`,
         query: urlParams.toString(),

--- a/react/components/FilterNavigator/legacy/FacetItem.js
+++ b/react/components/FilterNavigator/legacy/FacetItem.js
@@ -17,10 +17,15 @@ const removeElementAtIndex = (str, index, separator) =>
     .filter((_, i) => i !== index)
     .join(separator)
 
-const FacetItem = ({ facet }) => {
-  const { navigate } = useRuntime()
+const FacetItem = ({ facet, preventRouteChange = false }) => {
+  const {
+    navigate,
+    route: { path },
+  } = useRuntime()
   const { query, map } = useContext(QueryContext)
   const { showFacetQuantity } = useContext(SettingsContext)
+
+  const [basePath] = path.split('?')
 
   const handleChange = () => {
     const urlParams = new URLSearchParams(window.location.search)
@@ -36,21 +41,42 @@ const FacetItem = ({ facet }) => {
 
       urlParams.set('map', removeElementAtIndex(map, facetIndex, ','))
 
-      navigate({
-        to: `/${removeElementAtIndex(query, facetIndex, '/')}`,
-        query: urlParams.toString(),
-        scrollOptions,
-      })
+      if (preventRouteChange) {
+        urlParams.set(
+          'query',
+          `/${removeElementAtIndex(query, facetIndex, '/')}`
+        )
+
+        navigate({
+          to: `${basePath}?${urlParams.toString()}`,
+          scrollOptions,
+        })
+      } else {
+        navigate({
+          to: `/${removeElementAtIndex(query, facetIndex, '/')}`,
+          query: urlParams.toString(),
+          scrollOptions,
+        })
+      }
+
       return
     }
 
     urlParams.set('map', `${map},${facet.map}`)
+    if (preventRouteChange) {
+      urlParams.set('query', `/${query}/${facet.value}`)
 
-    navigate({
-      to: `/${query}/${facet.value}`,
-      query: urlParams.toString(),
-      scrollOptions,
-    })
+      navigate({
+        to: `${basePath}?${urlParams.toString()}`,
+        scrollOptions,
+      })
+    } else {
+      navigate({
+        to: `/${query}/${facet.value}`,
+        query: urlParams.toString(),
+        scrollOptions,
+      })
+    }
   }
 
   return (

--- a/react/components/FilterNavigator/legacy/FilterSidebar.js
+++ b/react/components/FilterNavigator/legacy/FilterSidebar.js
@@ -17,10 +17,7 @@ import searchResult from './searchResult.css'
 import QueryContext from '../../QueryContext'
 
 const FilterSidebar = ({ filters, preventRouteChange = false }) => {
-  const {
-    navigate,
-    route: { path },
-  } = useRuntime()
+  const { navigate, setQuery } = useRuntime()
   const { query: queryField, map: mapField } = useContext(QueryContext)
 
   const [open, setOpen] = useState(false)
@@ -75,18 +72,13 @@ const FilterSidebar = ({ filters, preventRouteChange = false }) => {
     const query = selectedFilters.map(facet => facet.value).join('/')
     const map = selectedFilters.map(facet => facet.map).join(',')
 
-    const [basePath] = path.split('?')
-
-    const urlParams = new URLSearchParams(window.location.search)
-
     if (preventRouteChange) {
-      urlParams.set('query', `/${queryField}/${query}`)
-      urlParams.set('map', `${mapField},${map}`)
-
-      navigate({
-        to: `${basePath}?${urlParams.toString()}`,
+      setQuery({
+        map: `${mapField},${map}`,
+        query: `/${queryField}/${query}`,
       })
     } else {
+      const urlParams = new URLSearchParams(window.location.search)
       urlParams.set('map', map)
 
       navigate({

--- a/react/components/FilterNavigator/legacy/SearchFilter.js
+++ b/react/components/FilterNavigator/legacy/SearchFilter.js
@@ -11,7 +11,12 @@ import useSelectedFilters from './hooks/useSelectedFilters'
 /**
  * Search Filter Component.
  */
-const SearchFilter = ({ title = 'Default Title', facets = [], intl }) => {
+const SearchFilter = ({
+  title = 'Default Title',
+  facets = [],
+  preventRouteChange = false,
+  intl,
+}) => {
   const filtersWithSelected = useSelectedFilters(facets)
 
   return (
@@ -19,7 +24,13 @@ const SearchFilter = ({ title = 'Default Title', facets = [], intl }) => {
       title={getFilterTitle(title, intl)}
       filters={filtersWithSelected}
     >
-      {facet => <FacetItem key={facet.name} facet={facet} />}
+      {facet => (
+        <FacetItem
+          key={facet.name}
+          facet={facet}
+          preventRouteChange={preventRouteChange}
+        />
+      )}
     </FilterOptionTemplate>
   )
 }
@@ -29,6 +40,8 @@ SearchFilter.propTypes = {
   title: PropTypes.string.isRequired,
   /** SearchFilter's options. */
   facets: PropTypes.arrayOf(facetOptionShape),
+  /** Prevents changing route when setting filters (uses URL search params instead) */
+  preventRouteChange: PropTypes.bool,
   /** Intl instance. */
   intl: intlShape.isRequired,
 }

--- a/react/components/FilterNavigator/legacy/SelectedFilters.js
+++ b/react/components/FilterNavigator/legacy/SelectedFilters.js
@@ -9,7 +9,11 @@ import { facetOptionShape } from '../../../constants/propTypes'
 /**
  * Search Filter Component.
  */
-const SelectedFilters = ({ filters = [], intl }) => {
+const SelectedFilters = ({
+  filters = [],
+  intl,
+  preventRouteChange = false,
+}) => {
   const title = intl.formatMessage({ id: 'store/search.selected-filters' })
   return (
     <FilterOptionTemplate
@@ -18,7 +22,13 @@ const SelectedFilters = ({ filters = [], intl }) => {
       collapsable={false}
       selected
     >
-      {facet => <FacetItem key={facet.name} facet={facet} />}
+      {facet => (
+        <FacetItem
+          key={facet.name}
+          facet={facet}
+          preventRouteChange={preventRouteChange}
+        />
+      )}
     </FilterOptionTemplate>
   )
 }
@@ -26,6 +36,8 @@ const SelectedFilters = ({ filters = [], intl }) => {
 SelectedFilters.propTypes = {
   /** Selected filters. */
   filters: PropTypes.arrayOf(facetOptionShape).isRequired,
+  /** Prevents changing route when setting filters (uses URL search params instead) */
+  preventRouteChange: PropTypes.bool,
   /** Intl instance. */
   intl: intlShape,
 }

--- a/react/components/FilterNavigator/legacy/index.js
+++ b/react/components/FilterNavigator/legacy/index.js
@@ -43,8 +43,8 @@ const FilterNavigator = ({
   brands = [],
   loading = false,
   hiddenFacets = {},
+  preventRouteChange = false,
 }) => {
-
   const {
     hints: { mobile },
   } = useRuntime()
@@ -105,22 +105,32 @@ const FilterNavigator = ({
     return (
       <div className={searchResult.filters}>
         <div className={filterClasses}>
-          <FilterSidebar filters={filters} />
+          <FilterSidebar
+            filters={filters}
+            preventRouteChange={preventRouteChange}
+          />
         </div>
       </div>
     )
   }
 
   return (
-    <div className={searchResult.filters}> 
+    <div className={searchResult.filters}>
       <div className={filterClasses}>
         <div className="bb b--muted-4">
           <h5 className="t-heading-5 mv5">
-            <FormattedMessage id="store/search-result.filter-button.title"/>
+            <FormattedMessage id="store/search-result.filter-button.title" />
           </h5>
         </div>
-        <SelectedFilters filters={selectedFilters} />
-        <AvailableFilters filters={filters} priceRange={priceRange} />
+        <SelectedFilters
+          filters={selectedFilters}
+          preventRouteChange={preventRouteChange}
+        />
+        <AvailableFilters
+          filters={filters}
+          priceRange={priceRange}
+          preventRouteChange={preventRouteChange}
+        />
       </div>
     </div>
   )
@@ -148,6 +158,8 @@ FilterNavigator.propTypes = {
   showFilters: PropTypes.bool,
   /** Loading indicator */
   loading: PropTypes.bool,
+  /** Prevents changing route when setting filters (uses URL search params instead) */
+  preventRouteChange: PropTypes.bool,
   ...hiddenFacetsSchema,
 }
 

--- a/react/components/FilterNavigator/legacy/index.js
+++ b/react/components/FilterNavigator/legacy/index.js
@@ -21,7 +21,7 @@ import {
 import useSelectedFilters from './hooks/useSelectedFilters'
 
 import searchResult from './searchResult.css'
-import getFilters from './utils/getFilters';
+import getFilters from './utils/getFilters'
 
 const getCategories = (tree = []) => {
   return [

--- a/react/index.js
+++ b/react/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import { withRuntimeContext } from 'vtex.render-runtime'
 
 import SearchResultContainer from './components/SearchResultContainer'
 import { SORT_OPTIONS } from './OrderBy'
@@ -16,6 +17,7 @@ const DEFAULT_MAX_ITEMS_PER_PAGE = 10
  */
 const trimStartingSlash = value => value && value.replace(/^\//, '')
 
+class SearchResultQueryLoader extends Component {
   static defaultProps = {
     orderBy: SORT_OPTIONS[0].value,
   }
@@ -68,7 +70,9 @@ const trimStartingSlash = value => value && value.replace(/^\//, '')
   }
 }
 
-SearchResultQueryLoader.getSchema = props => {
+const SearchResult = withRuntimeContext(SearchResultQueryLoader)
+
+SearchResult.getSchema = props => {
   const querySchema = !props.searchQuery
     ? {
         querySchema: {
@@ -209,3 +213,5 @@ SearchResultQueryLoader.getSchema = props => {
     },
   }
 }
+
+export default SearchResult

--- a/react/index.js
+++ b/react/index.js
@@ -38,6 +38,7 @@ class SearchResultQueryLoader extends Component {
       showFacetsQuantity,
       pagination,
       mobileLayout,
+      runtime: { query },
     } = this.props
 
     const settings = {
@@ -47,11 +48,21 @@ class SearchResultQueryLoader extends Component {
       mobileLayout,
     }
 
+    const fieldsFromQueryString = {
+      mapField: query.map,
+      queryField: trimStartingSlash(query.query),
+    }
+
+    const areFieldsFromQueryStringValid = !!(
+      fieldsFromQueryString.mapField && fieldsFromQueryString.queryField
+    )
+
     return !this.props.searchQuery ||
       (querySchema && querySchema.enableCustomQuery) ? (
       <LocalQuery
         {...this.props}
         {...querySchema}
+        {...(areFieldsFromQueryStringValid ? fieldsFromQueryString : {})}
         render={props => (
           <QueryContext.Provider value={props.searchQuery.variables}>
             <SettingsContext.Provider value={settings}>

--- a/react/index.js
+++ b/react/index.js
@@ -14,7 +14,8 @@ const DEFAULT_MAX_ITEMS_PER_PAGE = 10
  * Search Result Query Loader Component.
  * This Component queries the search if the search-result doesn't receive it already
  */
-export default class SearchResultQueryLoader extends Component {
+const trimStartingSlash = value => value && value.replace(/^\//, '')
+
   static defaultProps = {
     orderBy: SORT_OPTIONS[0].value,
   }

--- a/react/package.json
+++ b/react/package.json
@@ -11,7 +11,6 @@
     "@vtex/css-handles": "^1.1.0",
     "classnames": "^2.2.6",
     "immer": "^3.1.2",
-    "query-string": "5",
     "ramda": "^0.25.0",
     "react-apollo": "^2.5.1",
     "react-collapse": "^4.0.3",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5061,15 +5061,6 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-query-string@5:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-5.1.1.tgz#a78c012b71c17e05f2e3fa2319dd330682efb3cb"
-  integrity sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==
-  dependencies:
-    decode-uri-component "^0.2.0"
-    object-assign "^4.1.0"
-    strict-uri-encode "^1.0.0"
-
 raf@^3.1.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
@@ -5818,11 +5809,6 @@ stealthy-require@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
-
-strict-uri-encode@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
-  integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Adds prop `preventRouteChange` on legacy FilterNavigator (for now), to prevent changing the route when filters are selected, changing just the query string instead. This is intended for `search-result` blocks inserted on custom pages with static routes.

Test on https://lbenabled--btpt.myvtex.com/nativa-spa-ameixa, with desktop and mobile.
Contrast with https://lbdisabled--btpt.myvtex.com/nativa-spa-ameixa, with this feature present but disabled.
Also compare with https://btpt.myvtex.com/nativa-spa-ameixa, without this PR applied.

Also test the last two workspaces on regular searches, to see if it affects them in any way (results shouldn't differ)


<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
