### PR TITLE
Fix/intersection observer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Issue with IntersectionObserver on Safari 12.0, making the whole page crash. A polyfill has been added for the time being, while the fix for the issue is not published on polyfill.io.
 
 ## [3.23.0] - 2019-07-31
 ### Added

--- a/react/components/GalleryRow.js
+++ b/react/components/GalleryRow.js
@@ -1,6 +1,10 @@
 import React, { useRef, useEffect, memo } from 'react'
-import { usePixel } from 'vtex.pixel-manager/PixelContext'
+/* The IntersectionObserver polyfill from polyfill.io is incorrectly ignoring
+ * Safari 12.0 at the time of writing. This polyfill here should be removed
+ * once that issue is fixed. */
+import 'intersection-observer'
 import { useInView } from 'react-intersection-observer'
+import { usePixel } from 'vtex.pixel-manager/PixelContext'
 import classNames from 'classnames'
 
 import GalleryItem from './GalleryItem'

--- a/react/package.json
+++ b/react/package.json
@@ -11,6 +11,7 @@
     "@vtex/css-handles": "^1.1.0",
     "classnames": "^2.2.6",
     "immer": "^3.1.2",
+    "intersection-observer": "^0.7.0",
     "ramda": "^0.25.0",
     "react-apollo": "^2.5.1",
     "react-collapse": "^4.0.3",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -3099,6 +3099,11 @@ inquirer@^6.2.2:
     strip-ansi "^5.0.0"
     through "^2.3.6"
 
+intersection-observer@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.7.0.tgz#ee16bee978db53516ead2f0a8154b09b400bbdc9"
+  integrity sha512-Id0Fij0HsB/vKWGeBe9PxeY45ttRiBmhFyyt/geBdDHBYNctMRTE3dC1U3ujzz3lap+hVXlEcVaB56kZP/eEUg==
+
 intl-format-cache@^2.0.5:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/intl-format-cache/-/intl-format-cache-2.1.0.tgz#04a369fecbfad6da6005bae1f14333332dcf9316"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fixes issue with IntersectionObserver on Safari 12.0, making the whole page crash. A polyfill has been added for the time being, while the fix for the issue is not published on polyfill.io

https://lbebber--alssports.myvtex.com

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
