### PR TITLE
Mobile layout adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Enable the user to control wheter the `LayoutModeSwitcher` component is rendered. If only a `mode1` is provided to `mobileLayout`, the switcher will not be shown.
+- Better documentation on the use of `mobileLayout` prop.
+
 ## [3.24.0] - 2019-08-01
 ### Fixed
 - Fixed the style of the "sort by" dropdown found on the search results.

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ These properties can be changed in the `blocks.json` file of your theme.
 | `showFacetQuantity` | `Boolean`      | If quantity of items filtered by facet should appear besides its name on `filter-navigator` | `false`           |
 | `blockClass`        | `String`       | Unique class name to be appended to block classes                                           | `""`              |
 
-QuerySchema
+##### QuerySchema
 
 | Prop name              | Type      | Description                                                                                                                                                                                           | Default value |
 | ---------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
@@ -268,7 +268,7 @@ QuerySchema
 | `orderByField`         | `Enum`    | Order by field (values: `OrderByTopSaleDESC`, `OrderByReleaseDateDESC`, `OrderByBestDiscountDESC`, `OrderByPriceDESC`, `OrderByPriceASC`, `OrderByNameASC`, `OrderByNameDESC` or `''` (by relevance)) | `''`          |
 | `hideUnavailableItems` | `Boolean` | Set if unavailable items should show on search                                                                                                                                                        | `false`       |
 
-HiddenFacets
+##### HiddenFacets
 
 | Prop name              | Type                   | Description                 | Default value |
 | ---------------------- | ---------------------- | --------------------------- | ------------- |
@@ -277,20 +277,20 @@ HiddenFacets
 | `priceRange`           | `Boolean`              | Hide Price filter           | false         |
 | `specificationFilters` | `SpecificationFilters` | Hide Specifications filters | N/A           |
 
-SpecificationFilters
+##### SpecificationFilters
 
 | Prop name       | Type                      | Description                                           | Default value |
 | --------------- | ------------------------- | ----------------------------------------------------- | ------------- |
 | `hideAll`       | `Boolean`                 | Hide specifications filters                           | false         |
 | `hiddenFilters` | `Array(HiddenFilterUnit)` | Array of specifications filters that should be hidden | N/A           |
 
-HiddenFilterUnit
+##### HiddenFilterUnit
 
 | Prop name | Type    | Description                         | Default value |
 | --------- | ------- | ----------------------------------- | ------------- |
 | name      | String! | Name of Hidden specification filter | ""            |
 
-MobileLayout
+##### MobileLayout
 
 This prop controls the way search results are displayed on mobile. The default values are shown below.
 

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ Notice that the default behavior for your store will be the one defined by the `
 | `mode1`   | `Enum` | Layout mode of the switcher (values: 'normal', 'small' or 'inline')   | `normal`      |
 | `mode2`   | `Enum` | Layout mode of the switcher 2 (values: 'normal', 'small' or 'inline') | `small`       |
 
-`filter-navigator.v1` block
+##### `filter-navigator` block
 
 | Prop name            | Type      | Description                                                                                                                                                    | Default value |
 | -------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |

--- a/README.md
+++ b/README.md
@@ -259,14 +259,14 @@ These properties can be changed in the `blocks.json` file of your theme.
 
 QuerySchema
 
-| Prop name              | Type      | Description                                                                                                                                                                      | Default value            |
-| ---------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
-| `maxItemsPerPage`      | `Number`  | Maximum number of items per search page                                                                                                                                          | 10                       |
-| `queryField`           | `String`  | Query field                                                                                                                                                                      | N/A                      |
-| `mapField`             | `String`  | Map field                                                                                                                                                                        | N/A                      |
-| `restField`            | `String`  | Other Query Strings                                                                                                                                                              | N/A                      |
-| `orderByField`         | `Enum`    | Order by field (values: `OrderByTopSaleDESC`, `OrderByReleaseDateDESC`, `OrderByBestDiscountDESC`, `OrderByPriceDESC`, `OrderByPriceASC`, `OrderByNameASC`, `OrderByNameDESC` or `''` (by relevance)) | `''` |
-| `hideUnavailableItems` | `Boolean` | Set if unavailable items should show on search                                                                                                                                   | `false`                  |
+| Prop name              | Type      | Description                                                                                                                                                                                           | Default value |
+| ---------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `maxItemsPerPage`      | `Number`  | Maximum number of items per search page                                                                                                                                                               | 10            |
+| `queryField`           | `String`  | Query field                                                                                                                                                                                           | N/A           |
+| `mapField`             | `String`  | Map field                                                                                                                                                                                             | N/A           |
+| `restField`            | `String`  | Other Query Strings                                                                                                                                                                                   | N/A           |
+| `orderByField`         | `Enum`    | Order by field (values: `OrderByTopSaleDESC`, `OrderByReleaseDateDESC`, `OrderByBestDiscountDESC`, `OrderByPriceDESC`, `OrderByPriceASC`, `OrderByNameASC`, `OrderByNameDESC` or `''` (by relevance)) | `''`          |
+| `hideUnavailableItems` | `Boolean` | Set if unavailable items should show on search                                                                                                                                                        | `false`       |
 
 HiddenFacets
 
@@ -285,20 +285,23 @@ SpecificationFilters
 | `hiddenFilters` | `Array(HiddenFilterUnit)` | Array of specifications filters that should be hidden | N/A           |
 
 HiddenFilterUnit
-| Prop name | Type | Description | Default value |
-| --- | --- | --- | --- |
-| `name` | `String!` | Name of Hidden specification filter | `""` |
+
+| Prop name | Type    | Description                         | Default value |
+| --------- | ------- | ----------------------------------- | ------------- |
+| name      | String! | Name of Hidden specification filter | ""            |
 
 MobileLayout
-| Prop name | Type | Description | Default value |
-| --- | --- | --- | --- |
-| `mode1` | `Enum` | Layout mode of the switcher (values: 'normal', 'small' or 'inline') | `normal` |
-| `mode2` | `Enum` | Layout mode of the switcher 2 (values: 'normal', 'small' or 'inline') | `small` |
+
+| Prop name | Type   | Description                                                           | Default value |
+| --------- | ------ | --------------------------------------------------------------------- | ------------- |
+| `mode1`   | `Enum` | Layout mode of the switcher (values: 'normal', 'small' or 'inline')   | `normal`      |
+| `mode2`   | `Enum` | Layout mode of the switcher 2 (values: 'normal', 'small' or 'inline') | `small`       |
 
 `filter-navigator.v1` block
-| Prop name | Type | Description | Default value |
-| --- | --- | --- | --- |
-| `preventRouteChange` | `Boolean` | Prevents route change when selecting filters, using the query string instead. Intended for `search-result` blocks inserted on custom pages with static routes. | `false` |
+
+| Prop name            | Type      | Description                                                                                                                                                    | Default value |
+| -------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `preventRouteChange` | `Boolean` | Prevents route change when selecting filters, using the query string instead. Intended for `search-result` blocks inserted on custom pages with static routes. | `false`       |
 
 Also, you can configure the product summary that is defined on search-result. See [here](https://github.com/vtex-apps/product-summary/blob/master/README.md#configuration) the Product Summary API.
 
@@ -349,15 +352,15 @@ Below, we describe the namespaces that are defined in the search-result.
 | `accordionFilterItemActive`       | Container of the accordion filter item when it is active   | [AccordionFilterItem](/react/components/AccordionFilterItem.js)           |
 | `totalProducts`                   | The main container of total-products                       | [TotalProducts](/react/TotalProducts.js)                                  |
 | `orderBy`                         | The main container of order-by                             | [OrderBy](/react/OrderBy.js)                                              |
-| `accordionFilterItemHidden`       | Accordion filter item container when it is hidden          | [AccordionFilterItem](/react/components/AccordionFilterItem.js)            |
-| `accordionFilterItem`             | Accordion filter item container                            | [AccordionFilterItem](/react/components/AccordionFilterItem.js)            |
-| `accordionFilterItemBox`          | Accordion filter item box                                  | [AccordionFilterItem](/react/components/AccordionFilterItem.js)            |
-| `accordionFilterItemTitle`        | Accordion filter item title container                      | [AccordionFilterItem](/react/components/AccordionFilterItem.js)            |
-| `accordionFilterItemIcon`         | Accordion filter item icon container                       | [AccordionFilterItem](/react/components/AccordionFilterItem.js)            |
-| `filterAvailable`                 | Filter option template main container when it is available | [FilterOptionTemplate](/react/components/AccordionFilterItem.js)           |
-| `filterSelected`                  | Filter option template main container when it is selected  | [FilterOptionTemplate](/react/components/AccordionFilterItem.js)           |
-| `filterPopupTitle`                | Filter pop-up title label                                  | [FilterSidebar](/react/components/FilterSidebar.js)                        |
-| `filterPopupArrowIcon`            | Filter pop-up arrow icon container                         | [FilterSidebar](/react/components/FilterSidebar.js)                        |
+| `accordionFilterItemHidden`       | Accordion filter item container when it is hidden          | [AccordionFilterItem](/react/components/AccordionFilterItem.js)           |
+| `accordionFilterItem`             | Accordion filter item container                            | [AccordionFilterItem](/react/components/AccordionFilterItem.js)           |
+| `accordionFilterItemBox`          | Accordion filter item box                                  | [AccordionFilterItem](/react/components/AccordionFilterItem.js)           |
+| `accordionFilterItemTitle`        | Accordion filter item title container                      | [AccordionFilterItem](/react/components/AccordionFilterItem.js)           |
+| `accordionFilterItemIcon`         | Accordion filter item icon container                       | [AccordionFilterItem](/react/components/AccordionFilterItem.js)           |
+| `filterAvailable`                 | Filter option template main container when it is available | [FilterOptionTemplate](/react/components/AccordionFilterItem.js)          |
+| `filterSelected`                  | Filter option template main container when it is selected  | [FilterOptionTemplate](/react/components/AccordionFilterItem.js)          |
+| `filterPopupTitle`                | Filter pop-up title label                                  | [FilterSidebar](/react/components/FilterSidebar.js)                       |
+| `filterPopupArrowIcon`            | Filter pop-up arrow icon container                         | [FilterSidebar](/react/components/FilterSidebar.js)                       |
 | `footerButton`                    | Footer button                                              | [FooterButton](/react/components/FooterButton.js)                         |
 | `layoutSwitcher`                  | Layout mode switcher container                             | [LayoutModeSwitcher](/react/components/LayoutModeSwitcher.js)             |
 | `filterPopup`                     | Main container of filter pop-up                            | [FilterPopup](/react/components/FilterPopup.js)                           |

--- a/README.md
+++ b/README.md
@@ -292,6 +292,10 @@ HiddenFilterUnit
 
 MobileLayout
 
+This prop controls the way search results are displayed on mobile. The default values are shown below.
+
+Notice that the default behavior for your store will be the one defined by the `mode1`. If you want the user to be able to switch between two modes, you must specify the `mode2` prop. If only the `mode1` is provided, the layout switcher will not be shown and search results will always be rendered according to `mode1`.
+
 | Prop name | Type   | Description                                                           | Default value |
 | --------- | ------ | --------------------------------------------------------------------- | ------------- |
 | `mode1`   | `Enum` | Layout mode of the switcher (values: 'normal', 'small' or 'inline')   | `normal`      |

--- a/manifest.json
+++ b/manifest.json
@@ -25,7 +25,8 @@
     "vtex.store-icons": "0.x",
     "vtex.shop-review-interfaces": "0.x",
     "vtex.pixel-manager": "1.x",
-    "vtex.format-currency": "0.x"
+    "vtex.format-currency": "0.x",
+    "vtex.device-detector": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -4,8 +4,8 @@ import { map, flatten, prop } from 'ramda'
 import React, { useMemo } from 'react'
 import ContentLoader from 'react-content-loader'
 import { FormattedMessage } from 'react-intl'
-import { useRuntime } from 'vtex.render-runtime'
 import { ExtensionPoint } from 'vtex.render-runtime'
+import { useDevice } from 'vtex.device-detector'
 import FilterSidebar from './components/FilterSidebar'
 import SelectedFilters from './components/SelectedFilters'
 import AvailableFilters from './components/AvailableFilters'
@@ -36,9 +36,7 @@ const FilterNavigator = ({
   filters = [],
   hiddenFacets = {},
 }) => {
-  const {
-    hints: { mobile },
-  } = useRuntime()
+  const { isMobile } = useDevice()
 
   const navigateToFacet = useFacetNavigation()
 
@@ -55,14 +53,14 @@ const FilterNavigator = ({
   ).filter(facet => facet.selected)
 
   const filterClasses = classNames({
-    'flex items-center justify-center flex-auto h-100': mobile,
+    'flex items-center justify-center flex-auto h-100': isMobile,
   })
 
   if (!showFilters) {
     return null
   }
 
-  if (loading && !mobile) {
+  if (loading && !isMobile) {
     return (
       <div className={styles.filters}>
         <ContentLoader
@@ -84,11 +82,15 @@ const FilterNavigator = ({
     )
   }
 
-  if (mobile) {
+  if (isMobile) {
     return (
       <div className={styles.filters}>
         <div className={filterClasses}>
-          <FilterSidebar filters={filters} tree={tree} priceRange={priceRange} />
+          <FilterSidebar
+            filters={filters}
+            tree={tree}
+            priceRange={priceRange}
+          />
         </div>
       </div>
     )

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -85,6 +85,7 @@ Gallery.propTypes = {
   mobileLayoutMode: PropTypes.oneOf(pluck('value', LAYOUT_MODE)),
   /** Min Item Width. */
   minItemWidth: PropTypes.number,
+  showingFacets: PropTypes.bool,
 }
 
 export default withResizeDetector(Gallery)

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -3,7 +3,7 @@ import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import { pluck, splitEvery } from 'ramda'
 
-import { useRuntime } from 'vtex.render-runtime'
+import { useDevice } from 'vtex.device-detector'
 
 import { LAYOUT_MODE } from './components/LayoutModeSwitcher'
 import { productShape } from './constants/propTypes'
@@ -27,9 +27,9 @@ const Gallery = ({
   summary,
   showingFacets,
 }) => {
-  const runtime = useRuntime()
+  const { isMobile } = useDevice()
 
-  const layoutMode = runtime.hints.mobile ? mobileLayoutMode : 'normal'
+  const layoutMode = isMobile ? mobileLayoutMode : 'normal'
 
   const getItemsPerRow = () => {
     const maxItems = Math.floor(width / minItemWidth)

--- a/react/__mocks__/vtex.device-detector.js
+++ b/react/__mocks__/vtex.device-detector.js
@@ -1,0 +1,3 @@
+export const useDevice = () => {
+  return { isMobile: true }
+}

--- a/react/components/FilterNavigator/legacy/index.js
+++ b/react/components/FilterNavigator/legacy/index.js
@@ -8,7 +8,7 @@ import { map, flatten, filter, prop } from 'ramda'
 import React, { useMemo } from 'react'
 import ContentLoader from 'react-content-loader'
 import { FormattedMessage } from 'react-intl'
-import { useRuntime } from 'vtex.render-runtime'
+import { useDevice } from 'vtex.device-detector'
 
 import FilterSidebar from './FilterSidebar'
 import SelectedFilters from './SelectedFilters'
@@ -45,9 +45,7 @@ const FilterNavigator = ({
   hiddenFacets = {},
   preventRouteChange = false,
 }) => {
-  const {
-    hints: { mobile },
-  } = useRuntime()
+  const { isMobile } = useDevice()
 
   const filters = getFilters({
     tree,
@@ -72,14 +70,14 @@ const FilterNavigator = ({
   ).filter(facet => facet.selected)
 
   const filterClasses = classNames({
-    'flex justify-center flex-auto bl br b--muted-5': mobile,
+    'flex justify-center flex-auto bl br b--muted-5': isMobile,
   })
 
   if (!showFilters) {
     return null
   }
 
-  if (loading && !mobile) {
+  if (loading && !isMobile) {
     return (
       <div className={searchResult.filters}>
         <ContentLoader
@@ -101,7 +99,7 @@ const FilterNavigator = ({
     )
   }
 
-  if (mobile) {
+  if (isMobile) {
     return (
       <div className={searchResult.filters}>
         <div className={filterClasses}>

--- a/react/components/LayoutModeSwitcher.js
+++ b/react/components/LayoutModeSwitcher.js
@@ -7,10 +7,12 @@ import searchResult from '../searchResult.css'
 
 export const LAYOUT_MODE = [
   {
+    /** This is the single product view on mobile */
     value: 'normal',
     label: 'layoutModeSwitcher.normal',
   },
   {
+    /** This is the grid product view on mobile */
     value: 'small',
     label: 'layoutModeSwitcher.small',
   },

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react'
+import { compose } from 'react-apollo'
 import { Spinner } from 'vtex.styleguide'
 import { ExtensionPoint, withRuntimeContext } from 'vtex.render-runtime'
+import { withDevice } from 'vtex.device-detector'
 import { isEmpty } from 'ramda'
 import { generateBlockClass } from '@vtex/css-handles'
 
@@ -122,9 +124,7 @@ class SearchResult extends Component {
       summary,
       orderBy,
       mobileLayout,
-      runtime: {
-        hints: { mobile },
-      },
+      isMobile,
     } = this.props
     const {
       mobileLayoutMode,
@@ -181,7 +181,7 @@ class SearchResult extends Component {
             this.props.blockClass
           )} w-100 mw9`}
         >
-          {!mobile && (
+          {!isMobile && (
             <div className={styles.breadcrumb}>
               <ExtensionPoint id="breadcrumb" {...breadcrumbsProps} />
             </div>
@@ -233,7 +233,7 @@ class SearchResult extends Component {
             {children}
           </div>
           <ExtensionPoint id="order-by" orderBy={orderBy} />
-          {mobile && shouldDisplayLayoutSwitcher && (
+          {isMobile && shouldDisplayLayoutSwitcher && (
             <div
               className={`${styles.switch} flex justify-center items-center`}
             >
@@ -249,4 +249,7 @@ class SearchResult extends Component {
   }
 }
 
-export default withRuntimeContext(SearchResult)
+export default compose(
+  withRuntimeContext,
+  withDevice
+)(SearchResult)

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -121,6 +121,7 @@ class SearchResult extends Component {
       fetchMoreLoading,
       summary,
       orderBy,
+      mobileLayout,
       runtime: {
         hints: { mobile },
       },
@@ -155,6 +156,7 @@ class SearchResult extends Component {
     const hideFacets = !map || !map.length
     const showLoading = loading && !fetchMoreLoading
     const showContentLoader = showLoading && !showLoadingAsOverlay
+    const shouldDisplayLayoutSwitcher = !!mobileLayout.mode2
 
     const filters = getFilters({
       specificationFilters,
@@ -231,7 +233,7 @@ class SearchResult extends Component {
             {children}
           </div>
           <ExtensionPoint id="order-by" orderBy={orderBy} />
-          {mobile && (
+          {mobile && shouldDisplayLayoutSwitcher && (
             <div
               className={`${styles.switch} flex justify-center items-center`}
             >

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { Spinner } from 'vtex.styleguide'
 import { ExtensionPoint, withRuntimeContext } from 'vtex.render-runtime'
-import { compose, prop, last, isEmpty } from 'ramda'
+import { isEmpty } from 'ramda'
 import { generateBlockClass } from '@vtex/css-handles'
 
 import LoadingOverlay from './LoadingOverlay'
@@ -184,7 +184,10 @@ class SearchResult extends Component {
               <ExtensionPoint id="breadcrumb" {...breadcrumbsProps} />
             </div>
           )}
-          <ExtensionPoint id="search-title" breadcrumb={breadcrumbsProps.breadcrumb} />
+          <ExtensionPoint
+            id="search-title"
+            breadcrumb={breadcrumbsProps.breadcrumb}
+          />
           {showFacets && (
             <ExtensionPoint
               id="filter-navigator"
@@ -230,9 +233,7 @@ class SearchResult extends Component {
           <ExtensionPoint id="order-by" orderBy={orderBy} />
           {mobile && (
             <div
-              className={`${
-                styles.switch
-              } flex justify-center items-center`}
+              className={`${styles.switch} flex justify-center items-center`}
             >
               <LayoutModeSwitcher
                 activeMode={mobileLayoutMode}

--- a/react/components/SelectionListOrderBy.js
+++ b/react/components/SelectionListOrderBy.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types'
 import { injectIntl, intlShape } from 'react-intl'
 import classNames from 'classnames'
 import { find, propEq } from 'ramda'
-import { useRuntime } from 'vtex.render-runtime'
 import { IconCaret } from 'vtex.store-icons'
+import { useDevice } from 'vtex.device-detector'
 
 import SelectionListItem from './SelectionListItem'
 import useOutsideClick from '../hooks/useOutsideClick'
@@ -24,9 +24,7 @@ const SelectionListOrderBy = ({ intl, orderBy, options }) => {
 
   useOutsideClick(orderByRef, handleOutsideClick, showDropdown)
 
-  const {
-    hints: { mobile },
-  } = useRuntime()
+  const { isMobile } = useDevice()
 
   const renderOptions = orderBy => {
     return options.map(option => {
@@ -50,7 +48,7 @@ const SelectionListOrderBy = ({ intl, orderBy, options }) => {
     searchResult.orderByButton,
     'ph3 pv5 mv0 pointer flex items-center justify-end bg-base c-on-base t-action--small bt br bl bb-0 br2 br--top bw1 w-100 outline-0',
     {
-      'b--muted-4': showDropdown && mobile,
+      'b--muted-4': showDropdown && isMobile,
       'b--transparent pl1': !showDropdown,
     }
   )


### PR DESCRIPTION
#### What is the purpose of this pull request?

Make it clear to the user how to use the `mobileLayout` prop with better documentation on it.

Add a new behavior for the user, where if no `mode2` is provided by the user along with a `mode1`, the search results are always shown according to `mode1` and the `LayoutModeSwitcher` is not rendered.

Also, using `vtex.device-detector` instead of `runtime.hints` to detect device screen sizes and switch to different layouts.

#### What problem is this solving?

- Users were not aware of this feature.
- `vtex.device-detector` should be more reliable in scenarios where the user resizes their browser window.
- Giving the user the ability to control whether their clients should be able to toggle between different mobile layouts.

#### How should this be manually tested?

https://victorhmp--storecomponents.myvtex.com/apparel---accessories/clothing/

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Requires change to documentation, which has been updated accordingly.
* [x] Technical improvements
