### PR TITLE
Improvements on the "sort by" dropdown style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed the style of the "sort by" dropdown found on the search results.
 
 ## [3.22.12] - 2019-07-31
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -368,6 +368,10 @@ Below, we describe the namespaces that are defined in the search-result.
 | `filterItem`                      | Checkbox and label for Filters (desktop only)              | [SearchFilter](/react/components/SearchFilter.js)                         |
 | `filterItem--selected`            | Checkbox and label for selected Filters (desktop only)     | [SearchFilter](/react/components/SearchFilter.js)                         |
 | `selectedFilterItem`              | Checkbox and label for selected Filters (desktop only)     | [SelectedFilters](/react/components/SelectedFilters.js)                   |
+| `sortByBt`              | the "Sort By" button found on search results     | [SelectionListOrderBy](/react/components/SelectionListOrderBy.js)                   |
+| `orderByDropdown`              | the dropdown that appears when the "Sort By" button found on search results is pressed     | [SelectionListOrderBy](/react/components/SelectionListOrderBy.js)                   |
+| `orderByOptionsContainer`              | the container with the "Order by" options of the "Sort by" button   | [SelectionListOrderBy](/react/components/SelectionListItem.js)                   |
+| `orderByOptionItem`              | the "Order by" option that appears in the container of the "Sort by" button   | [SelectionListOrderBy](/react/components/SelectionListItem.js)                   |
 
 | `categoriesContainer` | The container for the department filters | [DepartmentFilters](/react/components/DepartmentFilters.js) |
 | `categoryGroup` | Container for each category group in the department filters | [CategoryFilter](/react/components/CategoryFilter.js) |

--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ Below, we describe the namespaces that are defined in the search-result.
 | `filterItem`                      | Checkbox and label for Filters (desktop only)              | [SearchFilter](/react/components/SearchFilter.js)                         |
 | `filterItem--selected`            | Checkbox and label for selected Filters (desktop only)     | [SearchFilter](/react/components/SearchFilter.js)                         |
 | `selectedFilterItem`              | Checkbox and label for selected Filters (desktop only)     | [SelectedFilters](/react/components/SelectedFilters.js)                   |
-| `sortByBt`              | the "Sort By" button found on search results     | [SelectionListOrderBy](/react/components/SelectionListOrderBy.js)                   |
+| `orderByButton`              | the "Sort By" button found on search results     | [SelectionListOrderBy](/react/components/SelectionListOrderBy.js)                   |
 | `orderByDropdown`              | the dropdown that appears when the "Sort By" button found on search results is pressed     | [SelectionListOrderBy](/react/components/SelectionListOrderBy.js)                   |
 | `orderByOptionsContainer`              | the container with the "Order by" options of the "Sort by" button   | [SelectionListOrderBy](/react/components/SelectionListItem.js)                   |
 | `orderByOptionItem`              | the "Order by" option that appears in the container of the "Sort by" button   | [SelectionListOrderBy](/react/components/SelectionListItem.js)                   |

--- a/react/OrderBy.js
+++ b/react/OrderBy.js
@@ -42,17 +42,14 @@ export const SORT_OPTIONS = [
 ]
 
 const OrderBy = ({ orderBy, intl }) => {
-  const sortingOptions = useMemo(
-    () => {
-      return SORT_OPTIONS.map(({ value, label }) => {
-        return {
-          value: value,
-          label: intl.formatMessage({ id: label }),
-        }
-      })
-    },
-    [intl]
-  )
+  const sortingOptions = useMemo(() => {
+    return SORT_OPTIONS.map(({ value, label }) => {
+      return {
+        value: value,
+        label: intl.formatMessage({ id: label }),
+      }
+    })
+  }, [intl])
 
   return (
     <div className={searchResult.orderBy}>

--- a/react/__tests__/OrderBy.test.js
+++ b/react/__tests__/OrderBy.test.js
@@ -20,7 +20,7 @@ describe('<OrderBy />', () => {
   it('should shown dropdown box on mobile mode', () => {
     const { container } = renderComponent()(true)
 
-    let dropdownContainer = container.querySelector('.dropdownSort > .dn')
+    let dropdownContainer = container.querySelector('.orderByDropdown > .dn')
     const button = container.querySelector('button')
 
     // Expect Dropdown container be rendered with display none
@@ -28,7 +28,7 @@ describe('<OrderBy />', () => {
     expect(dropdownContainer).not.toBeNull()
 
     fireEvent.click(button)
-    dropdownContainer = container.querySelector('.dropdownSort > .dn')
+    dropdownContainer = container.querySelector('.orderByDropdown > .dn')
 
     // Expect Dropdown container be rendered without display none
     expect(dropdownContainer).toBeNull()

--- a/react/__tests__/__snapshots__/OrderBy.test.js.snap
+++ b/react/__tests__/__snapshots__/OrderBy.test.js.snap
@@ -6,10 +6,10 @@ exports[`<OrderBy /> should match snapshot in mobile 1`] = `
     class="orderBy"
   >
     <div
-      class="dropdownSort relative pt1 justify-center w-100 w-auto-ns center"
+      class="orderByDropdown relative pt1 justify-end w-100 w-auto-ns ml-auto"
     >
       <button
-        class="ph3 pv5 mv0 pointer flex items-center justify-between bg-base c-on-base t-action--small bt br bl bb-0 br2 br--top bw1 w-100 b--transparent pl1"
+        class="sortByBt ph3 pv5 mv0 pointer flex items-center justify-end bg-base c-on-base t-action--small bt br bl bb-0 br2 br--top bw1 w-100 outline-0 b--transparent pl1"
       >
         <span
           class="filterPopupTitle c-on-base t-action--small ml-auto-ns"
@@ -30,45 +30,45 @@ exports[`<OrderBy /> should match snapshot in mobile 1`] = `
         </span>
       </button>
       <div
-        class="z-1 absolute bg-base shadow-5 f5 w-100 b--muted-4 br2 ba bw1 br--bottom dn"
+        class="orderByOptionsContainer z-1 absolute bg-base shadow-5 w-100 f5 b--muted-4 br2 ba bw1 br--bottom top-0 right-0-ns dn"
       >
         <button
-          class="bg-base c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 hover-bg-muted-4 w-100"
+          class="orderByOptionItem hover-bg-muted-5 bg-base  c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 w-100 right-0-ns"
         >
           Relevance
         </button>
         <button
-          class="bg-base c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 hover-bg-muted-4 w-100"
+          class="orderByOptionItem bg-light-gray  c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 w-100 right-0-ns"
         >
           Sales
         </button>
         <button
-          class="bg-base c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 hover-bg-muted-4 w-100"
+          class="orderByOptionItem hover-bg-muted-5 bg-base  c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 w-100 right-0-ns"
         >
           Release Date
         </button>
         <button
-          class="bg-base c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 hover-bg-muted-4 w-100"
+          class="orderByOptionItem hover-bg-muted-5 bg-base  c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 w-100 right-0-ns"
         >
           Discount
         </button>
         <button
-          class="bg-base c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 hover-bg-muted-4 w-100"
+          class="orderByOptionItem hover-bg-muted-5 bg-base  c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 w-100 right-0-ns"
         >
           Price: High to Low
         </button>
         <button
-          class="bg-base c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 hover-bg-muted-4 w-100"
+          class="orderByOptionItem hover-bg-muted-5 bg-base  c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 w-100 right-0-ns"
         >
           Price: Low to High
         </button>
         <button
-          class="bg-base c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 hover-bg-muted-4 w-100"
+          class="orderByOptionItem hover-bg-muted-5 bg-base  c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 w-100 right-0-ns"
         >
           Name, ascending
         </button>
         <button
-          class="bg-base c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 hover-bg-muted-4 w-100"
+          class="orderByOptionItem hover-bg-muted-5 bg-base  c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 w-100 right-0-ns"
         >
           Name, descending
         </button>
@@ -84,10 +84,10 @@ exports[`<OrderBy /> should match snapshot in web mod 1`] = `
     class="orderBy"
   >
     <div
-      class="dropdownSort relative pt1 justify-center w-100 w-auto-ns center"
+      class="orderByDropdown relative pt1 justify-end w-100 w-auto-ns ml-auto"
     >
       <button
-        class="ph3 pv5 mv0 pointer flex items-center justify-between bg-base c-on-base t-action--small bt br bl bb-0 br2 br--top bw1 w-100 b--transparent pl1"
+        class="sortByBt ph3 pv5 mv0 pointer flex items-center justify-end bg-base c-on-base t-action--small bt br bl bb-0 br2 br--top bw1 w-100 outline-0 b--transparent pl1"
       >
         <span
           class="filterPopupTitle c-on-base t-action--small ml-auto-ns"
@@ -108,45 +108,45 @@ exports[`<OrderBy /> should match snapshot in web mod 1`] = `
         </span>
       </button>
       <div
-        class="z-1 absolute bg-base shadow-5 f5 w-100 b--muted-4 br2 ba bw1 br--bottom dn"
+        class="orderByOptionsContainer z-1 absolute bg-base shadow-5 w-100 f5 b--muted-4 br2 ba bw1 br--bottom top-0 right-0-ns dn"
       >
         <button
-          class="bg-base c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 hover-bg-muted-4 w-100"
+          class="orderByOptionItem hover-bg-muted-5 bg-base  c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 w-100 right-0-ns"
         >
           Relevance
         </button>
         <button
-          class="bg-base c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 hover-bg-muted-4 w-100"
+          class="orderByOptionItem bg-light-gray  c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 w-100 right-0-ns"
         >
           Sales
         </button>
         <button
-          class="bg-base c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 hover-bg-muted-4 w-100"
+          class="orderByOptionItem hover-bg-muted-5 bg-base  c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 w-100 right-0-ns"
         >
           Release Date
         </button>
         <button
-          class="bg-base c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 hover-bg-muted-4 w-100"
+          class="orderByOptionItem hover-bg-muted-5 bg-base  c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 w-100 right-0-ns"
         >
           Discount
         </button>
         <button
-          class="bg-base c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 hover-bg-muted-4 w-100"
+          class="orderByOptionItem hover-bg-muted-5 bg-base  c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 w-100 right-0-ns"
         >
           Price: High to Low
         </button>
         <button
-          class="bg-base c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 hover-bg-muted-4 w-100"
+          class="orderByOptionItem hover-bg-muted-5 bg-base  c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 w-100 right-0-ns"
         >
           Price: Low to High
         </button>
         <button
-          class="bg-base c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 hover-bg-muted-4 w-100"
+          class="orderByOptionItem hover-bg-muted-5 bg-base  c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 w-100 right-0-ns"
         >
           Name, ascending
         </button>
         <button
-          class="bg-base c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 hover-bg-muted-4 w-100"
+          class="orderByOptionItem hover-bg-muted-5 bg-base  c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 w-100 right-0-ns"
         >
           Name, descending
         </button>

--- a/react/__tests__/__snapshots__/OrderBy.test.js.snap
+++ b/react/__tests__/__snapshots__/OrderBy.test.js.snap
@@ -9,7 +9,7 @@ exports[`<OrderBy /> should match snapshot in mobile 1`] = `
       class="orderByDropdown relative pt1 justify-end w-100 w-auto-ns ml-auto"
     >
       <button
-        class="sortByBt ph3 pv5 mv0 pointer flex items-center justify-end bg-base c-on-base t-action--small bt br bl bb-0 br2 br--top bw1 w-100 outline-0 b--transparent pl1"
+        class="orderByButton ph3 pv5 mv0 pointer flex items-center justify-end bg-base c-on-base t-action--small bt br bl bb-0 br2 br--top bw1 w-100 outline-0 b--transparent pl1"
       >
         <span
           class="filterPopupTitle c-on-base t-action--small ml-auto-ns"
@@ -87,7 +87,7 @@ exports[`<OrderBy /> should match snapshot in web mod 1`] = `
       class="orderByDropdown relative pt1 justify-end w-100 w-auto-ns ml-auto"
     >
       <button
-        class="sortByBt ph3 pv5 mv0 pointer flex items-center justify-end bg-base c-on-base t-action--small bt br bl bb-0 br2 br--top bw1 w-100 outline-0 b--transparent pl1"
+        class="orderByButton ph3 pv5 mv0 pointer flex items-center justify-end bg-base c-on-base t-action--small bt br bl bb-0 br2 br--top bw1 w-100 outline-0 b--transparent pl1"
       >
         <span
           class="filterPopupTitle c-on-base t-action--small ml-auto-ns"

--- a/react/components/SelectionListItem.js
+++ b/react/components/SelectionListItem.js
@@ -1,7 +1,9 @@
 import React from 'react'
 import { useRuntime } from 'vtex.render-runtime'
+import classNames from 'classnames'
+import searchResult from '../searchResult.css'
 
-const SelectionListItem = ({ option, onItemClick }) => {
+const SelectionListItem = ({ option, onItemClick, selectedSpotlight }) => {
   const { setQuery } = useRuntime()
 
   const handleOptionClick = () => {
@@ -9,9 +11,17 @@ const SelectionListItem = ({ option, onItemClick }) => {
     setQuery({ order: option.value })
   }
 
+  const spotlight = selectedSpotlight
+    ? 'bg-light-gray'
+    : 'hover-bg-muted-5 bg-base'
+
   return (
     <button
-      className="bg-base c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 hover-bg-muted-4 w-100"
+      className={classNames(
+        searchResult.orderByOptionItem,
+        spotlight,
+        ' c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 w-100 right-0-ns'
+      )}
       key={option.value}
       onClick={handleOptionClick}
     >

--- a/react/components/SelectionListItem.js
+++ b/react/components/SelectionListItem.js
@@ -3,7 +3,7 @@ import { useRuntime } from 'vtex.render-runtime'
 import classNames from 'classnames'
 import searchResult from '../searchResult.css'
 
-const SelectionListItem = ({ option, onItemClick, selectedSpotlight }) => {
+const SelectionListItem = ({ option, onItemClick, selected }) => {
   const { setQuery } = useRuntime()
 
   const handleOptionClick = () => {
@@ -11,15 +11,13 @@ const SelectionListItem = ({ option, onItemClick, selectedSpotlight }) => {
     setQuery({ order: option.value })
   }
 
-  const spotlight = selectedSpotlight
-    ? 'bg-light-gray'
-    : 'hover-bg-muted-5 bg-base'
+  const highlight = selected ? 'bg-light-gray' : 'hover-bg-muted-5 bg-base'
 
   return (
     <button
       className={classNames(
         searchResult.orderByOptionItem,
-        spotlight,
+        highlight,
         ' c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 w-100 right-0-ns'
       )}
       key={option.value}

--- a/react/components/SelectionListOrderBy.js
+++ b/react/components/SelectionListOrderBy.js
@@ -35,7 +35,7 @@ const SelectionListOrderBy = ({ intl, orderBy, options }) => {
           key={option.value}
           onItemClick={handleOutsideClick}
           option={option}
-          selectedSpotlight={option.value == orderBy}
+          selected={option.value == orderBy}
         />
       )
     })

--- a/react/components/SelectionListOrderBy.js
+++ b/react/components/SelectionListOrderBy.js
@@ -47,10 +47,10 @@ const SelectionListOrderBy = ({ intl, orderBy, options }) => {
   )
 
   const btClass = classNames(
-    searchResult.sortByBt,
+    searchResult.orderByButton,
     'ph3 pv5 mv0 pointer flex items-center justify-end bg-base c-on-base t-action--small bt br bl bb-0 br2 br--top bw1 w-100 outline-0',
     {
-      'b--muted-4 shadow-1': showDropdown && mobile,
+      'b--muted-4': showDropdown && mobile,
       'b--transparent pl1': !showDropdown,
     }
   )

--- a/react/components/SelectionListOrderBy.js
+++ b/react/components/SelectionListOrderBy.js
@@ -28,13 +28,14 @@ const SelectionListOrderBy = ({ intl, orderBy, options }) => {
     hints: { mobile },
   } = useRuntime()
 
-  const renderOptions = () => {
+  const renderOptions = orderBy => {
     return options.map(option => {
       return (
         <SelectionListItem
           key={option.value}
           onItemClick={handleOutsideClick}
           option={option}
+          selectedSpotlight={option.value == orderBy}
         />
       )
     })
@@ -46,7 +47,8 @@ const SelectionListOrderBy = ({ intl, orderBy, options }) => {
   )
 
   const btClass = classNames(
-    'ph3 pv5 mv0 pointer flex items-center justify-between bg-base c-on-base t-action--small bt br bl bb-0 br2 br--top bw1 w-100',
+    searchResult.sortByBt,
+    'ph3 pv5 mv0 pointer flex items-center justify-end bg-base c-on-base t-action--small bt br bl bb-0 br2 br--top bw1 w-100',
     {
       'b--muted-4 shadow-1': showDropdown && mobile,
       'b--transparent pl1': !showDropdown,
@@ -54,7 +56,8 @@ const SelectionListOrderBy = ({ intl, orderBy, options }) => {
   )
 
   const contentClass = classNames(
-    'z-1 absolute bg-base shadow-5 f5 w-100 b--muted-4 br2 ba bw1 br--bottom',
+    searchResult.orderByOptionsContainer,
+    'z-1 absolute bg-base shadow-5 w-100 f5 b--muted-4 br2 ba bw1 br--bottom top-0 right-0-ns',
     {
       db: showDropdown,
       dn: !showDropdown,
@@ -62,8 +65,8 @@ const SelectionListOrderBy = ({ intl, orderBy, options }) => {
   )
 
   const dropdownSort = classNames(
-    searchResult.dropdownSort,
-    'relative pt1 justify-center w-100 w-auto-ns center'
+    searchResult.orderByDropdown,
+    'relative pt1 justify-end w-100 w-auto-ns ml-auto'
   )
 
   return (
@@ -89,7 +92,7 @@ const SelectionListOrderBy = ({ intl, orderBy, options }) => {
         </span>
       </button>
 
-      <div className={contentClass}>{renderOptions()}</div>
+      <div className={contentClass}>{renderOptions(orderBy)}</div>
     </div>
   )
 }

--- a/react/components/SelectionListOrderBy.js
+++ b/react/components/SelectionListOrderBy.js
@@ -35,7 +35,7 @@ const SelectionListOrderBy = ({ intl, orderBy, options }) => {
           key={option.value}
           onItemClick={handleOutsideClick}
           option={option}
-          selected={option.value == orderBy}
+          selected={option.value === orderBy}
         />
       )
     })

--- a/react/components/SelectionListOrderBy.js
+++ b/react/components/SelectionListOrderBy.js
@@ -48,7 +48,7 @@ const SelectionListOrderBy = ({ intl, orderBy, options }) => {
 
   const btClass = classNames(
     searchResult.sortByBt,
-    'ph3 pv5 mv0 pointer flex items-center justify-end bg-base c-on-base t-action--small bt br bl bb-0 br2 br--top bw1 w-100',
+    'ph3 pv5 mv0 pointer flex items-center justify-end bg-base c-on-base t-action--small bt br bl bb-0 br2 br--top bw1 w-100 outline-0',
     {
       'b--muted-4 shadow-1': showDropdown && mobile,
       'b--transparent pl1': !showDropdown,

--- a/react/searchResult.css
+++ b/react/searchResult.css
@@ -133,6 +133,7 @@
   align-self: center;
   justify-self: stretch;
   display: flex;
+  
 }
 
 .accordionFilterItemHidden {}
@@ -176,6 +177,18 @@
 .filterTitle {}
 
 .filterIcon {}
+
+.sortByBt {}
+
+.orderByDropdown {}
+
+.orderByOptionItem {
+  min-width: 180px;
+}
+
+.orderByOptionsContainer {
+  min-width: 180px;
+}
 
 @media only screen and (max-width: 60em) {
   .container {

--- a/react/searchResult.css
+++ b/react/searchResult.css
@@ -133,7 +133,6 @@
   align-self: center;
   justify-self: stretch;
   display: flex;
-  
 }
 
 .accordionFilterItemHidden {}

--- a/react/searchResult.css
+++ b/react/searchResult.css
@@ -177,7 +177,7 @@
 
 .filterIcon {}
 
-.sortByBt {}
+.orderByButton {}
 
 .orderByDropdown {}
 

--- a/react/searchResult.css
+++ b/react/searchResult.css
@@ -182,11 +182,11 @@
 
 .orderByDropdown {}
 
-.orderByOptionItem {
+.orderByOptionsContainer {
   min-width: 180px;
 }
 
-.orderByOptionsContainer {
+.orderByOptionItem {
   min-width: 180px;
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

The "sort by" dropdown on search results used to break some "order by" options into two lines if the selected option was small

![image](https://user-images.githubusercontent.com/8443580/62315259-5a3da300-b46b-11e9-8c60-0655492f2249.png)

With this PR the overall style of the dropdown was changed to solve this problem while keeping its design clean and simple

![image](https://user-images.githubusercontent.com/8443580/62315453-b4d6ff00-b46b-11e9-98ab-b7fa46f964fd.png)



#### How should this be manually tested?
[workspace](https://iaronaraujo--storecomponents.myvtex.com/apparel---accessories/clothing?order=OrderByNameASC)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Requires change to documentation, which has been updated accordingly.
