### PR TITLE
use product-summary parsing logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Use product parsing logic from `product-summary`.
 
 ## [3.25.0] - 2019-08-01
 

--- a/react/__mocks__/vtex.product-summary/ProductSummaryCustom.js
+++ b/react/__mocks__/vtex.product-summary/ProductSummaryCustom.js
@@ -1,0 +1,20 @@
+import React from 'react'
+const ProductSummary = () => <div>ProductSummary</div>
+
+ProductSummary.mapCatalogProductToProductSummary = product => {
+  if (!product) {
+    return null
+  }
+  const sku = product.items[0]
+  return {
+    ...product,
+    sku: {
+      ...sku,
+      seller: sku.sellers && sku.sellers[0],
+      referenceId: sku.referenceId && sku.referenceId[0],
+      image: sku.images && sku.images[0],
+    },
+  }
+}
+
+export default ProductSummary

--- a/react/components/GalleryItem.js
+++ b/react/components/GalleryItem.js
@@ -1,10 +1,10 @@
 import React, { useMemo, useCallback, memo } from 'react'
 import { ExtensionPoint } from 'vtex.render-runtime'
 import { usePixel } from 'vtex.pixel-manager/PixelContext'
+import ProductSummary from 'vtex.product-summary/ProductSummaryCustom'
 
 import { productShape } from '../constants/propTypes'
 import { PropTypes } from 'prop-types'
-import { normalizeProduct } from '../constants/productHelpers'
 
 /**
  * Normalizes the item received in the props to adapt to the extension point prop.
@@ -12,7 +12,10 @@ import { normalizeProduct } from '../constants/productHelpers'
 const GalleryItem = ({ item, displayMode, summary }) => {
   const { push } = usePixel()
 
-  const product = useMemo(() => normalizeProduct(item), [item])
+  const product = useMemo(
+    () => ProductSummary.mapCatalogProductToProductSummary(item),
+    [item]
+  )
 
   const handleClick = useCallback(
     () => push({ event: 'productClick', product }),

--- a/react/components/GalleryRow.js
+++ b/react/components/GalleryRow.js
@@ -1,8 +1,4 @@
 import React, { useRef, useEffect, memo } from 'react'
-/* The IntersectionObserver polyfill from polyfill.io is incorrectly ignoring
- * Safari 12.0 at the time of writing. This polyfill here should be removed
- * once that issue is fixed. */
-import 'intersection-observer'
 import { useInView } from 'react-intersection-observer'
 import { usePixel } from 'vtex.pixel-manager/PixelContext'
 import classNames from 'classnames'

--- a/react/package.json
+++ b/react/package.json
@@ -11,7 +11,6 @@
     "@vtex/css-handles": "^1.1.0",
     "classnames": "^2.2.6",
     "immer": "^3.1.2",
-    "intersection-observer": "^0.7.0",
     "ramda": "^0.25.0",
     "react-apollo": "^2.5.1",
     "react-collapse": "^4.0.3",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -3099,11 +3099,6 @@ inquirer@^6.2.2:
     strip-ansi "^5.0.0"
     through "^2.3.6"
 
-intersection-observer@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.7.0.tgz#ee16bee978db53516ead2f0a8154b09b400bbdc9"
-  integrity sha512-Id0Fij0HsB/vKWGeBe9PxeY45ttRiBmhFyyt/geBdDHBYNctMRTE3dC1U3ujzz3lap+hVXlEcVaB56kZP/eEUg==
-
 intl-format-cache@^2.0.5:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/intl-format-cache/-/intl-format-cache-2.1.0.tgz#04a369fecbfad6da6005bae1f14333332dcf9316"


### PR DESCRIPTION
#### What is the purpose of this pull request?

- Shelf and Search-Result (SR) were doing the same thing, using copied code, to parse catalog product to the product-summary.
- Unify the logic at product-summary, use that method.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
https://fidshelf--alssports.myvtex.com/

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
