### PR TITLE
Added `showItemQuantityOnShowMoreButton` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- `showQuantityOnShowMoreButton` prop that controls if the number of products on the page and total quantity of items in a search result is displayed below the `show more` button.
+- `showProductsCount` prop that controls if the number of products on the page and total quantity of items in a search result is displayed under the `show more` button.
 
 ## [3.27.0] - 2019-08-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- `showQuantityOnShowMoreButton` prop that controls if the number of products on the page and total quantity of items in a search result is displayed on the `show more` button.
+- `showQuantityOnShowMoreButton` prop that controls if the number of products on the page and total quantity of items in a search result is displayed below the `show more` button.
 
 ## [3.27.0] - 2019-08-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `showItemQuantityOnShowMoreButton` prop that controls if the quantity of products on the page and total quantity of items in a search result are displayed on the `show more` button.
+
 ## [3.27.0] - 2019-08-14
 ### Added
 - Add `rich-text` to `search-result` block.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- `showItemQuantityOnShowMoreButton` prop that controls if the quantity of products on the page and total quantity of items in a search result are displayed on the `show more` button.
+- `showQuantityOnShowMoreButton` prop that controls if the number of products on the page and total quantity of items in a search result is displayed on the `show more` button.
 
 ## [3.27.0] - 2019-08-14
 ### Added

--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ These properties can be changed in the `blocks.json` file of your theme.
 | `mobileLayout`      | `MobileLayout` | Control mobile layout                                                                       | N/A               |
 | `showFacetQuantity` | `Boolean`      | If quantity of items filtered by facet should appear besides its name on `filter-navigator` | `false`           |
 | `blockClass`        | `String`       | Unique class name to be appended to block classes                                           | `""`              |
+| `showItemQuantityOnShowMoreButton`        | `Boolean`       |         controls if the quantity of products on the page and total quantity of items in a search result are displayed on the `show more` button.  | `false`              |
 
 ##### QuerySchema
 

--- a/README.md
+++ b/README.md
@@ -340,6 +340,8 @@ Below, we describe the namespaces that are defined in the search-result.
 | --------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------- |
 | `container`                       | The main container of search-result                        | [SearchResult](/react/components/SearchResult.js)                         |
 | `buttonShowMore`                  | Show the see more button                                   | [ShowMoreLoaderResult](/react/components/loaders/ShowMoreLoaderResult.js) |
+| `showMoreButtonText`                  | Text below the show mnore button                                | [ShowMoreLoaderResult](/react/components/loaders/ShowMoreLoaderResult.js) |
+| `showMoreButtonTextValue`                  | The range part of the text below the show more button                                  | [ShowMoreLoaderResult](/react/components/loaders/ShowMoreLoaderResult.js) |
 | `switch`                          | Layout mode switcher container                             | [SearchResult](/react/components/SearchResult.js)                         |
 | `breadcrumb`                      | Breadcrumb container                                       | [SearchResult](/react/components/SearchResult.js)                         |
 | `filter`                          | Filter option container                                    | [FilterOptionTemplate](/react/components/FilterOptionTemplate.js)         |

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ These properties can be changed in the `blocks.json` file of your theme.
 | `mobileLayout`      | `MobileLayout` | Control mobile layout                                                                       | N/A               |
 | `showFacetQuantity` | `Boolean`      | If quantity of items filtered by facet should appear besides its name on `filter-navigator` | `false`           |
 | `blockClass`        | `String`       | Unique class name to be appended to block classes                                           | `""`              |
-| `showItemQuantityOnShowMoreButton`        | `Boolean`       |         controls if the quantity of products on the page and total quantity of items in a search result are displayed on the `show more` button.  | `false`              |
+| `showQuantityOnShowMoreButton`        | `Boolean`       |         controls if the quantity of loaded products and total number of items of a search result are displayed on the `show more` button.  | `false`              |
 
 ##### QuerySchema
 

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ These properties can be changed in the `blocks.json` file of your theme.
 | `mobileLayout`      | `MobileLayout` | Control mobile layout                                                                       | N/A               |
 | `showFacetQuantity` | `Boolean`      | If quantity of items filtered by facet should appear besides its name on `filter-navigator` | `false`           |
 | `blockClass`        | `String`       | Unique class name to be appended to block classes                                           | `""`              |
-| `showQuantityOnShowMoreButton`        | `Boolean`       |         controls if the quantity of loaded products and total number of items of a search result are displayed on the `show more` button.  | `false`              |
+| `showProductsCount`        | `Boolean`       |         controls if the quantity of loaded products and total number of items of a search result are displayed under the `show more` button.  | `false`              |
 
 ##### QuerySchema
 
@@ -340,8 +340,8 @@ Below, we describe the namespaces that are defined in the search-result.
 | --------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------- |
 | `container`                       | The main container of search-result                        | [SearchResult](/react/components/SearchResult.js)                         |
 | `buttonShowMore`                  | Show the see more button                                   | [ShowMoreLoaderResult](/react/components/loaders/ShowMoreLoaderResult.js) |
-| `showMoreButtonText`                  | Text below the show mnore button                                | [ShowMoreLoaderResult](/react/components/loaders/ShowMoreLoaderResult.js) |
-| `showMoreButtonTextValue`                  | The range part of the text below the show more button                                  | [ShowMoreLoaderResult](/react/components/loaders/ShowMoreLoaderResult.js) |
+| `showingProducts`                  | Text below the show mnore button                                | [ShowMoreLoaderResult](/react/components/loaders/ShowMoreLoaderResult.js) |
+| `showingProductsCount`                  | The range part of the text below the show more button                                  | [ShowMoreLoaderResult](/react/components/loaders/ShowMoreLoaderResult.js) |
 | `switch`                          | Layout mode switcher container                             | [SearchResult](/react/components/SearchResult.js)                         |
 | `breadcrumb`                      | Breadcrumb container                                       | [SearchResult](/react/components/SearchResult.js)                         |
 | `filter`                          | Filter option container                                    | [FilterOptionTemplate](/react/components/FilterOptionTemplate.js)         |

--- a/messages/context.json
+++ b/messages/context.json
@@ -26,6 +26,7 @@
   "admin/editor.search-result.facet-quantity": "Show filter item quantity",
 
   "store/search-result.show-more-button": "Show more",
+  "store/search-result.show-more-button-with-quantity": "Show more ({itemQuantity, number}/{maxItems, number})",
   "store/search-result.filter-button.title": "Filters",
   "store/search-result.filter-breadcrumbs.primary": "Filters",
   "store/search-result.filter-button.apply": "Apply",

--- a/messages/context.json
+++ b/messages/context.json
@@ -26,7 +26,8 @@
   "admin/editor.search-result.facet-quantity": "Show filter item quantity",
 
   "store/search-result.show-more-button": "Show more",
-  "store/search-result.show-more-button-with-quantity": "Show more ({productsLoaded, number}/{total, number})",
+  "store/search-result.show-more-button-text": "Showing {value}",
+  "store/search-result.show-more-button-text-value": "{productsLoaded, number} of {total, number}",
   "store/search-result.filter-button.title": "Filters",
   "store/search-result.filter-breadcrumbs.primary": "Filters",
   "store/search-result.filter-button.apply": "Apply",

--- a/messages/context.json
+++ b/messages/context.json
@@ -26,7 +26,7 @@
   "admin/editor.search-result.facet-quantity": "Show filter item quantity",
 
   "store/search-result.show-more-button": "Show more",
-  "store/search-result.show-more-button-with-quantity": "Show more ({itemQuantity, number}/{maxItems, number})",
+  "store/search-result.show-more-button-with-quantity": "Show more ({productsLoaded, number}/{total, number})",
   "store/search-result.filter-button.title": "Filters",
   "store/search-result.filter-breadcrumbs.primary": "Filters",
   "store/search-result.filter-button.apply": "Apply",

--- a/messages/context.json
+++ b/messages/context.json
@@ -26,8 +26,8 @@
   "admin/editor.search-result.facet-quantity": "Show filter item quantity",
 
   "store/search-result.show-more-button": "Show more",
-  "store/search-result.show-more-button-text": "Showing {value}",
-  "store/search-result.show-more-button-text-value": "{productsLoaded, number} of {total, number}",
+  "store/search-result.showing-products": "Showing {value}",
+  "store/search-result.showing-products-count": "{productsLoaded, number} of {total, number}",
   "store/search-result.filter-button.title": "Filters",
   "store/search-result.filter-breadcrumbs.primary": "Filters",
   "store/search-result.filter-button.apply": "Apply",

--- a/messages/en.json
+++ b/messages/en.json
@@ -26,8 +26,8 @@
   "admin/editor.search-result.facet-quantity": "Show filter item quantity",
 
   "store/search-result.show-more-button": "Show more",
-  "store/search-result.show-more-button-text": "Showing {value}",
-  "store/search-result.show-more-button-text-value": "{productsLoaded, number} of {total, number}",  
+  "store/search-result.showing-products": "Showing {value}",
+  "store/search-result.showing-products-count": "{productsLoaded, number} of {total, number}",  
   "store/search-result.filter-button.title": "Filters",
   "store/search-result.filter-breadcrumbs.primary": "Filters",
   "store/search-result.filter-button.apply": "Apply",

--- a/messages/en.json
+++ b/messages/en.json
@@ -26,6 +26,7 @@
   "admin/editor.search-result.facet-quantity": "Show filter item quantity",
 
   "store/search-result.show-more-button": "Show more",
+  "store/search-result.show-more-button-with-quantity": "Show more ({itemQuantity, number}/{maxItems, number})",
   "store/search-result.filter-button.title": "Filters",
   "store/search-result.filter-breadcrumbs.primary": "Filters",
   "store/search-result.filter-button.apply": "Apply",

--- a/messages/en.json
+++ b/messages/en.json
@@ -26,7 +26,8 @@
   "admin/editor.search-result.facet-quantity": "Show filter item quantity",
 
   "store/search-result.show-more-button": "Show more",
-  "store/search-result.show-more-button-with-quantity": "Show more ({productsLoaded, number}/{total, number})",
+  "store/search-result.show-more-button-text": "Showing {value}",
+  "store/search-result.show-more-button-text-value": "{productsLoaded, number} of {total, number}",  
   "store/search-result.filter-button.title": "Filters",
   "store/search-result.filter-breadcrumbs.primary": "Filters",
   "store/search-result.filter-button.apply": "Apply",

--- a/messages/en.json
+++ b/messages/en.json
@@ -26,7 +26,7 @@
   "admin/editor.search-result.facet-quantity": "Show filter item quantity",
 
   "store/search-result.show-more-button": "Show more",
-  "store/search-result.show-more-button-with-quantity": "Show more ({itemQuantity, number}/{maxItems, number})",
+  "store/search-result.show-more-button-with-quantity": "Show more ({productsLoaded, number}/{total, number})",
   "store/search-result.filter-button.title": "Filters",
   "store/search-result.filter-breadcrumbs.primary": "Filters",
   "store/search-result.filter-button.apply": "Apply",

--- a/messages/es.json
+++ b/messages/es.json
@@ -26,7 +26,7 @@
   "admin/editor.search-result.facet-quantity": "Mostrar la cantidad de filtros",
 
   "store/search-result.show-more-button": "Mostrar más",
-  "store/search-result.show-more-button-with-quantity": "Mostrar más ({itemQuantity, number}/{maxItems, number})",
+  "store/search-result.show-more-button-with-quantity": "Mostrar más ({productsLoaded, number}/{total, number})",
   "store/search-result.filter-button.title": "Filtros",
   "store/search-result.filter-breadcrumbs.primary": "Filtros",
   "store/search-result.filter-button.apply": "Aplicar",

--- a/messages/es.json
+++ b/messages/es.json
@@ -26,6 +26,7 @@
   "admin/editor.search-result.facet-quantity": "Mostrar la cantidad de filtros",
 
   "store/search-result.show-more-button": "Mostrar más",
+  "store/search-result.show-more-button-with-quantity": "Mostrar más ({itemQuantity, number}/{maxItems, number})",
   "store/search-result.filter-button.title": "Filtros",
   "store/search-result.filter-breadcrumbs.primary": "Filtros",
   "store/search-result.filter-button.apply": "Aplicar",

--- a/messages/es.json
+++ b/messages/es.json
@@ -26,8 +26,8 @@
   "admin/editor.search-result.facet-quantity": "Mostrar la cantidad de filtros",
 
   "store/search-result.show-more-button": "Mostrar más",
-  "store/search-result.show-more-button-text": "Mostrando {value}",
-  "store/search-result.show-more-button-text-value": "{productsLoaded, number} de {total, number}",
+  "store/search-result.showing-products": "Mostrando {value}",
+  "store/search-result.showing-products-count": "{productsLoaded, number} de {total, number}",
  "store/search-result.filter-button.title": "Filtros",
   "store/search-result.filter-breadcrumbs.primary": "Filtros",
   "store/search-result.filter-button.apply": "Aplicar",

--- a/messages/es.json
+++ b/messages/es.json
@@ -26,8 +26,9 @@
   "admin/editor.search-result.facet-quantity": "Mostrar la cantidad de filtros",
 
   "store/search-result.show-more-button": "Mostrar más",
-  "store/search-result.show-more-button-with-quantity": "Mostrar más ({productsLoaded, number}/{total, number})",
-  "store/search-result.filter-button.title": "Filtros",
+  "store/search-result.show-more-button-text": "Mostrando {value}",
+  "store/search-result.show-more-button-text-value": "{productsLoaded, number} de {total, number}",
+ "store/search-result.filter-button.title": "Filtros",
   "store/search-result.filter-breadcrumbs.primary": "Filtros",
   "store/search-result.filter-button.apply": "Aplicar",
   "store/search-result.filter-button.clear": "Limpiar",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -26,7 +26,7 @@
   "admin/editor.search-result.facet-quantity": "Mostrar quantidade dos filtros",
 
   "store/search-result.show-more-button": "Mostrar mais",
-  "store/search-result.show-more-button-with-quantity": "Mostrar mais ({itemQuantity, number}/{maxItems, number})",
+  "store/search-result.show-more-button-with-quantity": "Mostrar mais ({productsLoaded, number}/{total, number})",
   "store/search-result.filter-button.title": "Filtros",
   "store/search-result.filter-breadcrumbs.primary": "Filtros",
   "store/search-result.filter-button.apply": "Aplicar",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -26,6 +26,7 @@
   "admin/editor.search-result.facet-quantity": "Mostrar quantidade dos filtros",
 
   "store/search-result.show-more-button": "Mostrar mais",
+  "store/search-result.show-more-button-with-quantity": "Mostrar mais ({itemQuantity, number}/{maxItems, number})",
   "store/search-result.filter-button.title": "Filtros",
   "store/search-result.filter-breadcrumbs.primary": "Filtros",
   "store/search-result.filter-button.apply": "Aplicar",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -26,8 +26,8 @@
   "admin/editor.search-result.facet-quantity": "Mostrar quantidade dos filtros",
 
   "store/search-result.show-more-button": "Mostrar mais",
-  "store/search-result.show-more-button-with-quantity": "Mostrar mais ({productsLoaded, number}/{total, number})",
-  "store/search-result.filter-button.title": "Filtros",
+  "store/search-result.show-more-button-text": "Mostrando {value}",
+  "store/search-result.show-more-button-text-value": "{productsLoaded, number} de {total, number}",  "store/search-result.filter-button.title": "Filtros",
   "store/search-result.filter-breadcrumbs.primary": "Filtros",
   "store/search-result.filter-button.apply": "Aplicar",
   "store/search-result.filter-button.clear": "Limpar",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -26,8 +26,8 @@
   "admin/editor.search-result.facet-quantity": "Mostrar quantidade dos filtros",
 
   "store/search-result.show-more-button": "Mostrar mais",
-  "store/search-result.show-more-button-text": "Mostrando {value}",
-  "store/search-result.show-more-button-text-value": "{productsLoaded, number} de {total, number}",  "store/search-result.filter-button.title": "Filtros",
+  "store/search-result.showing-products": "Mostrando {value}",
+  "store/search-result.showing-products-count": "{productsLoaded, number} de {total, number}",  "store/search-result.filter-button.title": "Filtros",
   "store/search-result.filter-breadcrumbs.primary": "Filtros",
   "store/search-result.filter-button.apply": "Aplicar",
   "store/search-result.filter-button.clear": "Limpar",

--- a/react/components/loaders/ShowMoreLoaderResult.js
+++ b/react/components/loaders/ShowMoreLoaderResult.js
@@ -16,7 +16,7 @@ const ShowMoreLoaderResult = props => {
     recordsFiltered,
     onFetchMore,
     fetchMoreLoading,
-    showQuantityOnShowMoreButton,
+    showProductsCount,
   } = props
 
   return (
@@ -34,20 +34,18 @@ const ShowMoreLoaderResult = props => {
           </Button>
         )}
       </div>
-      {showQuantityOnShowMoreButton && (
+      {showProductsCount && (
         <div
-          className={`${
-            searchResult.showMoreButtonText
-          } tc t-small pt3 c-muted-2`}
+          className={`${searchResult.showingProducts} tc t-small pt3 c-muted-2`}
         >
           <FormattedMessage
-            id="store/search-result.show-more-button-text"
+            id="store/search-result.showing-products"
             tagName="span"
             values={{
               value: (
-                <span className={`${searchResult.showMoreButtonTextValue} b`}>
+                <span className={`${searchResult.showingProductsCount} b`}>
                   <FormattedMessage
-                    id="store/search-result.show-more-button-text-value"
+                    id="store/search-result.showing-products-count"
                     values={{
                       productsLoaded: products.length,
                       total: recordsFiltered,

--- a/react/components/loaders/ShowMoreLoaderResult.js
+++ b/react/components/loaders/ShowMoreLoaderResult.js
@@ -11,7 +11,13 @@ import searchResult from '../../searchResult.css'
  * Search Result Component.
  */
 const ShowMoreLoaderResult = props => {
-  const { products, recordsFiltered, onFetchMore, fetchMoreLoading } = props
+  const {
+    products,
+    recordsFiltered,
+    onFetchMore,
+    fetchMoreLoading,
+    showItemQuantityOnShowMoreButton,
+  } = props
 
   return (
     <SearchResult {...props}>
@@ -24,7 +30,17 @@ const ShowMoreLoaderResult = props => {
             isLoading={fetchMoreLoading}
             size="small"
           >
-            <FormattedMessage id="store/search-result.show-more-button" />
+            {showItemQuantityOnShowMoreButton ? (
+              <FormattedMessage
+                id="store/search-result.show-more-button-with-quantity"
+                values={{
+                  itemQuantity: products.length,
+                  maxItems: recordsFiltered,
+                }}
+              />
+            ) : (
+              <FormattedMessage id="store/search-result.show-more-button" />
+            )}
           </Button>
         )}
       </div>

--- a/react/components/loaders/ShowMoreLoaderResult.js
+++ b/react/components/loaders/ShowMoreLoaderResult.js
@@ -16,7 +16,7 @@ const ShowMoreLoaderResult = props => {
     recordsFiltered,
     onFetchMore,
     fetchMoreLoading,
-    showItemQuantityOnShowMoreButton,
+    showQuantityOnShowMoreButton,
   } = props
 
   return (
@@ -30,12 +30,12 @@ const ShowMoreLoaderResult = props => {
             isLoading={fetchMoreLoading}
             size="small"
           >
-            {showItemQuantityOnShowMoreButton ? (
+            {showQuantityOnShowMoreButton ? (
               <FormattedMessage
                 id="store/search-result.show-more-button-with-quantity"
                 values={{
-                  itemQuantity: products.length,
-                  maxItems: recordsFiltered,
+                  productsLoaded: products.length,
+                  total: recordsFiltered,
                 }}
               />
             ) : (

--- a/react/components/loaders/ShowMoreLoaderResult.js
+++ b/react/components/loaders/ShowMoreLoaderResult.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Button } from 'vtex.styleguide'
-import { FormattedMessage } from 'react-intl'
+import { FormattedMessage, FormattedHTMLMessage } from 'react-intl'
 
 import SearchResult from '../SearchResult'
 import { loaderPropTypes } from '../../constants/propTypes'
@@ -30,20 +30,35 @@ const ShowMoreLoaderResult = props => {
             isLoading={fetchMoreLoading}
             size="small"
           >
-            {showQuantityOnShowMoreButton ? (
-              <FormattedMessage
-                id="store/search-result.show-more-button-with-quantity"
-                values={{
-                  productsLoaded: products.length,
-                  total: recordsFiltered,
-                }}
-              />
-            ) : (
-              <FormattedMessage id="store/search-result.show-more-button" />
-            )}
+            <FormattedMessage id="store/search-result.show-more-button" />
           </Button>
         )}
       </div>
+      {showQuantityOnShowMoreButton && (
+        <div
+          className={`${
+            searchResult.showMoreButtonText
+          } tc t-small pt3 c-muted-2`}
+        >
+          <FormattedMessage
+            id="store/search-result.show-more-button-text"
+            tagName="span"
+            values={{
+              value: (
+                <span className={`${searchResult.showMoreButtonTextValue} b`}>
+                  <FormattedMessage
+                    id="store/search-result.show-more-button-text-value"
+                    values={{
+                      productsLoaded: products.length,
+                      total: recordsFiltered,
+                    }}
+                  />
+                </span>
+              ),
+            }}
+          />
+        </div>
+      )}
     </SearchResult>
   )
 }

--- a/react/components/loaders/ShowMoreLoaderResult.js
+++ b/react/components/loaders/ShowMoreLoaderResult.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Button } from 'vtex.styleguide'
-import { FormattedMessage, FormattedHTMLMessage } from 'react-intl'
+import { FormattedMessage } from 'react-intl'
 
 import SearchResult from '../SearchResult'
 import { loaderPropTypes } from '../../constants/propTypes'

--- a/react/searchResult.css
+++ b/react/searchResult.css
@@ -27,6 +27,12 @@
   align-self: center;
 }
 
+.showMoreButtonText{
+}
+
+.showMoreButtonTextValue{
+}
+
 .switch {
   -ms-grid-row: 1;
   -ms-grid-column: 6;

--- a/react/searchResult.css
+++ b/react/searchResult.css
@@ -27,10 +27,10 @@
   align-self: center;
 }
 
-.showMoreButtonText{
+.showingProducts{
 }
 
-.showMoreButtonTextValue{
+.showingProductsCount{
 }
 
 .switch {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Added `showProductsCount` prop that controls if the number of products on the page and total quantity of items in a search result is displayed under the `show more` button.

#### How should this be manually tested?

[Workspace](https://iaronaraujo--storecomponents.myvtex.com/top?map=ft)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/8443580/63189405-4b91e700-c03a-11e9-8fea-3eb9fe8effe9.png)


#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Requires change to documentation, which has been updated accordingly.
