### PR TITLE
Add CSS handles to filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New CSS handles:
+  - `filterContainer`
+  - `filterContainer--title`
+  - `filterContainer--selectedFilters`
+  - `filterContainer--c`
+  - `filterContainer--b`
+  - `filterContainer--priceRange`
+  - `filterContainer--` + FACET_TYPE
+  - `filterItem--` + FACET_VALUE
 
 ## [3.28.0] - 2019-08-19
 

--- a/README.md
+++ b/README.md
@@ -377,11 +377,18 @@ Below, we describe the namespaces that are defined in the search-result.
 | `filterPopupContentContainerOpen` | Filter pop-up content container when it is open            | [Popup](/react/components/Popup.js)                                       |
 | `galleryItem`                     | Gallery item container                                     | [Gallery](/react/Gallery.js)                                              |
 | `searchNotFound`                  | Main container of Search Not Found                         | [NotFoundSearch](/react/NotFoundSearch.js)                                |
+| `filterContainer`                 | Filter container                                           | [FilterNavigator](/react/components/FilterNavigator.js)                   |
+| `filterContainer--title`          | Title's filter container                                   | [FilterNavigator](/react/components/FilterNavigator.js)                   |
+| `filterContainer--selected`       | Selected filters' filter container                         | [SelectedFilters](/react/components/SelectedFilters.js)                   |
+| `filterContainer--c`              | Department's filter container                              | [DepartmentFilters](/react/components/DepartmentFilters.js)               |
+| `filterContainer--priceRange`     | Price range's filter container                             | [PriceRange](/react/components/PriceRange.js)                             |
+| `filterContainer--` + FACET_TYPE  | FACET_TYPE's filter container                              | [FilterOptionTemplate](/react/components/FilterOptionTemplate.js)         |
 | `filterTitle`                     | Filter title container                                     | [FilterOptionTemplate](/react/components/FilterOptionTemplate.js)         |
 | `filterIcon`                      | Filter icon container                                      | [FilterOptionTemplate](/react/components/FilterOptionTemplate.js)         |
 | `galleryTitle`                    | Category name or search term title                         | [Title](/react/Title.js)                                                  |
-| `filterItem`                      | Checkbox and label for Filters (desktop only)              | [SearchFilter](/react/components/SearchFilter.js)                         |
-| `filterItem--selected`            | Checkbox and label for selected Filters (desktop only)     | [SearchFilter](/react/components/SearchFilter.js)                         |
+| `filterItem`                      | Checkbox and label for Filters (desktop only)              | [SearchFilter](/react/components/FacetItem.js)                            |
+| `filterItem--` + FACET_VALUE      | FACET_VALUE's checkbox and label for Filters (desktop only)| [SearchFilter](/react/components/FacetItem.js)                            |
+| `filterItem--selected`            | Checkbox and label for selected Filters (desktop only)     | [SearchFilter](/react/components/FacetItem.js)                            |
 | `selectedFilterItem`              | Checkbox and label for selected Filters (desktop only)     | [SelectedFilters](/react/components/SelectedFilters.js)                   |
 | `orderByButton`              | the "Sort By" button found on search results     | [SelectionListOrderBy](/react/components/SelectionListOrderBy.js)                   |
 | `orderByDropdown`              | the dropdown that appears when the "Sort By" button found on search results is pressed     | [SelectionListOrderBy](/react/components/SelectionListOrderBy.js)                   |

--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ Below, we describe the namespaces that are defined in the search-result.
 | `filterContainer--title`          | Title's filter container                                   | [FilterNavigator](/react/components/FilterNavigator.js)                   |
 | `filterContainer--selectedFilters`| Selected filters' filter container                         | [SelectedFilters](/react/components/SelectedFilters.js)                   |
 | `filterContainer--c`              | Department's filter container                              | [DepartmentFilters](/react/components/DepartmentFilters.js)               |
+| `filterContainer--b`              | Brand's filter container                                   | [FilterOptionTemplate](/react/components/FilterOptionTemplate.js)         |
 | `filterContainer--priceRange`     | Price range's filter container                             | [PriceRange](/react/components/PriceRange.js)                             |
 | `filterContainer--` + FACET_TYPE  | FACET_TYPE's filter container                              | [FilterOptionTemplate](/react/components/FilterOptionTemplate.js)         |
 | `filterTitle`                     | Filter title container                                     | [FilterOptionTemplate](/react/components/FilterOptionTemplate.js)         |

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ Below, we describe the namespaces that are defined in the search-result.
 | `searchNotFound`                  | Main container of Search Not Found                         | [NotFoundSearch](/react/NotFoundSearch.js)                                |
 | `filterContainer`                 | Filter container                                           | [FilterNavigator](/react/components/FilterNavigator.js)                   |
 | `filterContainer--title`          | Title's filter container                                   | [FilterNavigator](/react/components/FilterNavigator.js)                   |
-| `filterContainer--selected`       | Selected filters' filter container                         | [SelectedFilters](/react/components/SelectedFilters.js)                   |
+| `filterContainer--selectedFilters`| Selected filters' filter container                         | [SelectedFilters](/react/components/SelectedFilters.js)                   |
 | `filterContainer--c`              | Department's filter container                              | [DepartmentFilters](/react/components/DepartmentFilters.js)               |
 | `filterContainer--priceRange`     | Price range's filter container                             | [PriceRange](/react/components/PriceRange.js)                             |
 | `filterContainer--` + FACET_TYPE  | FACET_TYPE's filter container                              | [FilterOptionTemplate](/react/components/FilterOptionTemplate.js)         |

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -99,7 +99,11 @@ const FilterNavigator = ({
   return (
     <div className={styles.filters}>
       <div className={filterClasses}>
-        <div className="bb b--muted-4">
+        <div
+          className={`${styles['filter__container']} ${
+            styles['filter__container--title']
+          } bb b--muted-4`}
+        >
           <h5 className="t-heading-5 mv5">
             <FormattedMessage id="store/search-result.filter-button.title" />
           </h5>

--- a/react/components/DepartmentFilters.js
+++ b/react/components/DepartmentFilters.js
@@ -21,8 +21,14 @@ const DepartmentFilters = ({
 
   const showAllDepartments = tree.every(category => !category.selected)
 
+  const containerClassName = classNames(
+    styles['filter__container'],
+    styles['filter__container'] + '--c',
+    { 'bb b--muted-4': !hideBorder }
+  )
+
   return (
-    <div className={classNames({ 'bb b--muted-4': !hideBorder })}>
+    <div className={containerClassName}>
       {title && (
         <div className={classNames(styles.filter, 'pt4')}>
           <div

--- a/react/components/FacetItem.js
+++ b/react/components/FacetItem.js
@@ -5,13 +5,26 @@ import classNames from 'classnames'
 import SettingsContext from './SettingsContext'
 import useFacetNavigation from '../hooks/useFacetNavigation'
 
+import styles from '../searchResult.css'
+
 const FacetItem = ({ facet, className }) => {
   const { showFacetQuantity } = useContext(SettingsContext)
 
   const navigateToFacet = useFacetNavigation()
 
+  const classes = classNames(
+    styles.filterItem,
+    `${styles.filterItem}--${facet.value}`,
+    { [`${styles.filterItem}--selected`]: facet.selected },
+    className,
+    'lh-copy w-100'
+  )
+
   return (
-    <div className={classNames(className, 'lh-copy w-100')} style={{hyphens: 'auto', wordBreak: 'break-word'}}>
+    <div
+      className={classes}
+      style={{ hyphens: 'auto', wordBreak: 'break-word' }}
+    >
       <Checkbox
         id={facet.value}
         checked={facet.selected}

--- a/react/components/FilterOptionTemplate.js
+++ b/react/components/FilterOptionTemplate.js
@@ -5,12 +5,13 @@ import classNames from 'classnames'
 
 import { IconCaret } from 'vtex.store-icons'
 
-import searchResult from '../searchResult.css'
+import style from '../searchResult.css'
 
 /**
  * Collapsable filters container
  */
 const FilterOptionTemplate = ({
+  id,
   selected = false,
   title,
   collapsable = true,
@@ -37,13 +38,19 @@ const FilterOptionTemplate = ({
     [collapsable, open]
   )
 
-  const containerClassName = classNames(searchResult.filter, 'pv5', {
-    [searchResult.filterSelected]: selected,
-    [searchResult.filterAvailable]: !selected,
+  const containerClassName = classNames(
+    style['filter__container'],
+    { [`${style['filter__container']}--${id}`]: id },
+    'bb b--muted-4'
+  )
+
+  const titleContainerClassName = classNames(style.filter, 'pv5', {
+    [style.filterSelected]: selected,
+    [style.filterAvailable]: !selected,
   })
 
   const titleClassName = classNames(
-    searchResult.filterTitle,
+    style.filterTitle,
     'f5 flex items-center justify-between',
     {
       ttu: selected,
@@ -51,8 +58,8 @@ const FilterOptionTemplate = ({
   )
 
   return (
-    <div className="bb b--muted-4">
-      <div className={containerClassName}>
+    <div className={containerClassName}>
+      <div className={titleContainerClassName}>
         <div
           role="button"
           tabIndex={collapsable ? 0 : undefined}
@@ -66,7 +73,7 @@ const FilterOptionTemplate = ({
             {collapsable && (
               <span
                 className={classNames(
-                  searchResult.filterIcon,
+                  style.filterIcon,
                   'flex items-center ph5 c-muted-3'
                 )}
               >
@@ -85,10 +92,7 @@ const FilterOptionTemplate = ({
         aria-hidden={!open}
       >
         {collapsable ? (
-          <Collapse
-            isOpened={open}
-            theme={{ content: searchResult.filterContent }}
-          >
+          <Collapse isOpened={open} theme={{ content: style.filterContent }}>
             {renderChildren()}
           </Collapse>
         ) : (
@@ -100,6 +104,8 @@ const FilterOptionTemplate = ({
 }
 
 FilterOptionTemplate.propTypes = {
+  /** Identifier to be used by CSS handles */
+  id: PropTypes.string,
   /** Filters to be shown, if no filter is provided, treat the children as simple node */
   filters: PropTypes.arrayOf(PropTypes.object),
   /** Function to handle filter rendering or node if no filter is provided */

--- a/react/components/FilterOptionTemplate.js
+++ b/react/components/FilterOptionTemplate.js
@@ -5,7 +5,7 @@ import classNames from 'classnames'
 
 import { IconCaret } from 'vtex.store-icons'
 
-import style from '../searchResult.css'
+import styles from '../searchResult.css'
 
 /**
  * Collapsable filters container
@@ -39,18 +39,18 @@ const FilterOptionTemplate = ({
   )
 
   const containerClassName = classNames(
-    style['filter__container'],
-    { [`${style['filter__container']}--${id}`]: id },
+    styles['filter__container'],
+    { [`${styles['filter__container']}--${id}`]: id },
     'bb b--muted-4'
   )
 
-  const titleContainerClassName = classNames(style.filter, 'pv5', {
-    [style.filterSelected]: selected,
-    [style.filterAvailable]: !selected,
+  const titleContainerClassName = classNames(styles.filter, 'pv5', {
+    [styles.filterSelected]: selected,
+    [styles.filterAvailable]: !selected,
   })
 
   const titleClassName = classNames(
-    style.filterTitle,
+    styles.filterTitle,
     'f5 flex items-center justify-between',
     {
       ttu: selected,
@@ -73,7 +73,7 @@ const FilterOptionTemplate = ({
             {collapsable && (
               <span
                 className={classNames(
-                  style.filterIcon,
+                  styles.filterIcon,
                   'flex items-center ph5 c-muted-3'
                 )}
               >
@@ -92,7 +92,7 @@ const FilterOptionTemplate = ({
         aria-hidden={!open}
       >
         {collapsable ? (
-          <Collapse isOpened={open} theme={{ content: style.filterContent }}>
+          <Collapse isOpened={open} theme={{ content: styles.filterContent }}>
             {renderChildren()}
           </Collapse>
         ) : (

--- a/react/components/PriceRange.js
+++ b/react/components/PriceRange.js
@@ -65,6 +65,7 @@ const PriceRange = ({ title, facets, intl, priceRange }) => {
 
   return (
     <FilterOptionTemplate
+      id="priceRange"
       title={getFilterTitle(title, intl)}
       collapsable={false}
     >

--- a/react/components/SearchFilter.js
+++ b/react/components/SearchFilter.js
@@ -9,28 +9,21 @@ import { facetOptionShape } from '../constants/propTypes'
 import { getFilterTitle } from '../constants/SearchHelpers'
 import useSelectedFilters from '../hooks/useSelectedFilters'
 
-import styles from '../searchResult.css'
-
 /**
  * Search Filter Component.
  */
 const SearchFilter = ({ title = 'Default Title', facets = [], intl }) => {
   const filtersWithSelected = useSelectedFilters(facets)
 
+  const sampleFacet = facets && facets.length > 0 ? facets[0] : null
+
   return (
     <FilterOptionTemplate
+      id={sampleFacet ? sampleFacet.map : null}
       title={getFilterTitle(title, intl)}
       filters={filtersWithSelected}
     >
-      {facet => (
-        <FacetItem
-          key={facet.name}
-          facet={facet}
-          className={classNames(styles.filterItem, {
-            [`${styles.filterItem}--selected`]: facet.selected,
-          })}
-        />
-      )}
+      {facet => <FacetItem key={facet.name} facet={facet} />}
     </FilterOptionTemplate>
   )
 }

--- a/react/components/SelectedFilters.js
+++ b/react/components/SelectedFilters.js
@@ -18,12 +18,19 @@ const SelectedFilters = ({ filters = [], intl }) => {
   const title = intl.formatMessage({ id: 'store/search.selected-filters' })
   return (
     <FilterOptionTemplate
+      id="selected"
       title={title}
       filters={filters}
       collapsable={false}
       selected
     >
-      {facet => <FacetItem key={facet.name} facet={facet} className={styles.selectedFilterItem} />}
+      {facet => (
+        <FacetItem
+          key={facet.name}
+          facet={facet}
+          className={styles.selectedFilterItem}
+        />
+      )}
     </FilterOptionTemplate>
   )
 }

--- a/react/components/SelectedFilters.js
+++ b/react/components/SelectedFilters.js
@@ -18,7 +18,7 @@ const SelectedFilters = ({ filters = [], intl }) => {
   const title = intl.formatMessage({ id: 'store/search.selected-filters' })
   return (
     <FilterOptionTemplate
-      id="selected"
+      id="selectedFilters"
       title={title}
       filters={filters}
       collapsable={false}

--- a/react/searchResult.css
+++ b/react/searchResult.css
@@ -62,6 +62,8 @@
   grid-row: filters;
 }
 
+.filter__container {}
+.filter__container--title {}
 .filter {
 }
 


### PR DESCRIPTION
Fix https://github.com/vtex-apps/store-discussion/issues/31

#### What is the purpose of this pull request?

Add CSS handles to many elements of the filter-navigator.v2.

![image](https://user-images.githubusercontent.com/284515/63370568-e5b69f80-c358-11e9-99c7-8facf4fd6d35.png)
![image](https://user-images.githubusercontent.com/284515/63370608-f6ffac00-c358-11e9-8a8e-a15f51172908.png)

Or in Als:
![image](https://user-images.githubusercontent.com/284515/63370982-9cb31b00-c359-11e9-8e0a-7e2ae7375e53.png)

**Important:** As you can see I used the map param instead of the name. Example: `specificationFilter_7721` instead of "Gender". I did this so this feature can be used in translatable stores.


#### What problem is this solving?

CSS customisation of some filters.

#### How should this be manually tested?

Storecomponents: https://breno--storecomponents.myvtex.com/Electronics/LG/Sony?map=c%2Cb%2Cb
Als: https://breno--alssports.myvtex.com/north/Clothing/Hoodies---Sweatshirts/The-North-Face?map=ft%2Cc%2Cc%2Cb

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
