### PR TITLE
Add preventRouteChange to filter-navigator.v2 and filter-navigator.v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Prop `preventRouteChange` to `filter-navigator.v2` to prevent changing the route when filters are selected, changing just the query string instead. This is intended for `search-result` blocks inserted on custom pages with static routes.
+- Prop `preventRouteChange` to `filter-navigator.v2` and `filter-navigator.v3` to prevent changing the route when filters are selected, changing just the query string instead. This is intended for `search-result` blocks inserted on custom pages with static routes.
 
 ## [3.33.4] - 2019-10-10
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Prop `preventRouteChange` to `filter-navigator.v2` to prevent changing the route when filters are selected, changing just the query string instead. This is intended for `search-result` blocks inserted on custom pages with static routes.
 
 ## [3.33.4] - 2019-10-10
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -398,6 +398,13 @@ Notice that the default behavior for your store will be the one defined by the `
 | -------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
 | `preventRouteChange` | `Boolean` | Prevents route change when selecting filters, using the query string instead. Intended for `search-result` blocks inserted on custom pages with static routes. | `false`       |
 
+##### `filter-navigator.v2` block
+
+| Prop name            | Type      | Description                                                                                                                                                    | Default value |
+| -------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `preventRouteChange` | `Boolean` | Prevents route change when selecting filters, using the query string instead. Intended for `search-result` blocks inserted on custom pages with static routes. | `false`       |
+
+
 Also, you can configure the product summary that is defined on search-result. See [here](https://github.com/vtex-apps/product-summary/blob/master/README.md#configuration) the Product Summary API.
 
 ### Styles API

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -33,6 +33,7 @@ const FilterNavigator = ({
   brands = [],
   loading = false,
   filters = [],
+  preventRouteChange = false,
   hiddenFacets = {},
 }) => {
   const { isMobile } = useDevice()
@@ -77,8 +78,15 @@ const FilterNavigator = ({
 
   if (isMobile) {
     return (
-      <div className={filterClasses}>
-        <FilterSidebar filters={filters} tree={tree} priceRange={priceRange} />
+      <div className={styles.filters}>
+        <div className={filterClasses}>
+          <FilterSidebar
+            filters={filters}
+            tree={tree}
+            priceRange={priceRange}
+            preventRouteChange={preventRouteChange}
+          />
+        </div>
       </div>
     )
   }
@@ -95,14 +103,22 @@ const FilterNavigator = ({
             <FormattedMessage id="store/search-result.filter-button.title" />
           </h5>
         </div>
-        <SelectedFilters filters={selectedFilters} />
+        <SelectedFilters
+          filters={selectedFilters}
+          preventRouteChange={preventRouteChange}
+        />
         <DepartmentFilters
           title={CATEGORIES_TITLE}
           tree={tree}
           isVisible={!hiddenFacets.categories}
           onCategorySelect={navigateToFacet}
+          preventRouteChange={preventRouteChange}
         />
-        <AvailableFilters filters={filters} priceRange={priceRange} />
+        <AvailableFilters
+          filters={filters}
+          priceRange={priceRange}
+          preventRouteChange={preventRouteChange}
+        />
       </div>
       <ExtensionPoint id="shop-review-summary" />
     </Fragment>

--- a/react/FilterNavigatorFlexible.js
+++ b/react/FilterNavigatorFlexible.js
@@ -16,6 +16,7 @@ const withSearchPageContextProps = Component => () => {
     filters,
     showFacets,
     showContentLoader,
+    preventRouteChange,
   } = useSearchPage()
 
   const facets = pathOr({}, ['data', 'facets'], searchQuery)
@@ -28,6 +29,7 @@ const withSearchPageContextProps = Component => () => {
   return (
     <div className={styles['filters--layout']}>
       <Component
+        preventRouteChange={preventRouteChange}
         brands={brands}
         params={params}
         priceRange={priceRange}

--- a/react/SearchResultFlexible.js
+++ b/react/SearchResultFlexible.js
@@ -42,6 +42,7 @@ const SearchResultFlexible = ({
   mobileLayout = { mode1: 'normal' },
   showProductsCount,
   blockClass,
+  preventRouteChange = false,
   // Below are set by SearchContext
   searchQuery,
   maxItemsPerPage,
@@ -112,21 +113,23 @@ const SearchResultFlexible = ({
       showFacets,
       filters,
       showProductsCount,
+      preventRouteChange,
     }),
     [
       hiddenFacets,
-      map,
-      maxItemsPerPage,
-      mobileLayout,
-      orderBy,
       pagination,
+      mobileLayout,
+      searchQuery,
+      page,
+      maxItemsPerPage,
+      map,
       params,
       priceRange,
-      searchQuery,
+      orderBy,
       showFacets,
       filters,
       showProductsCount,
-      page,
+      preventRouteChange,
     ]
   )
 

--- a/react/components/AvailableFilters.js
+++ b/react/components/AvailableFilters.js
@@ -4,7 +4,11 @@ import PropTypes from 'prop-types'
 import SearchFilter from './SearchFilter'
 import PriceRange from './PriceRange'
 
-const AvailableFilters = ({ filters = [], priceRange }) =>
+const AvailableFilters = ({
+  filters = [],
+  priceRange,
+  preventRouteChange = false,
+}) =>
   filters.map(filter => {
     const { type, title, facets, oneSelectedCollapse = false } = filter
 
@@ -16,6 +20,7 @@ const AvailableFilters = ({ filters = [], priceRange }) =>
             title={title}
             facets={facets}
             priceRange={priceRange}
+            preventRouteChange={preventRouteChange}
           />
         )
       default:
@@ -25,6 +30,7 @@ const AvailableFilters = ({ filters = [], priceRange }) =>
             title={title}
             facets={facets}
             oneSelectedCollapse={oneSelectedCollapse}
+            preventRouteChange={preventRouteChange}
           />
         )
     }
@@ -41,6 +47,8 @@ AvailableFilters.propTypes = {
   ),
   /** Price range query parameter */
   priceRange: PropTypes.string,
+  /** Prevent route changes */
+  preventRouteChange: PropTypes.boolean,
 }
 
 export default AvailableFilters

--- a/react/components/CategoryFilter.js
+++ b/react/components/CategoryFilter.js
@@ -28,7 +28,12 @@ const getSelectedCategories = rootCategory => {
   return selectedCategories
 }
 
-const CategoryFilter = ({ category, shallow = false, onCategorySelect }) => {
+const CategoryFilter = ({
+  category,
+  shallow = false,
+  onCategorySelect,
+  preventRouteChange = false,
+}) => {
   const { map } = useContext(QueryContext)
 
   const selectedCategories = getSelectedCategories(category)
@@ -36,7 +41,7 @@ const CategoryFilter = ({ category, shallow = false, onCategorySelect }) => {
   const handleUnselectCategories = index => {
     const categoriesToRemove = selectedCategories.slice(index)
 
-    onCategorySelect(categoriesToRemove)
+    onCategorySelect(categoriesToRemove, preventRouteChange)
   }
 
   const lastSelectedCategory = selectedCategories[selectedCategories.length - 1]

--- a/react/components/DepartmentFilters.js
+++ b/react/components/DepartmentFilters.js
@@ -13,6 +13,7 @@ const DepartmentFilters = ({
   isVisible,
   tree,
   onCategorySelect,
+  preventRouteChange = false,
   hideBorder = false,
 }) => {
   if (!isVisible) {
@@ -60,6 +61,7 @@ const DepartmentFilters = ({
                   category={category}
                   shallow
                   onCategorySelect={onCategorySelect}
+                  preventRouteChange={preventRouteChange}
                 />
               )}
             />
@@ -68,6 +70,7 @@ const DepartmentFilters = ({
           <CategoryFilter
             category={tree.find(category => category.selected)}
             onCategorySelect={onCategorySelect}
+            preventRouteChange={preventRouteChange}
           />
         )}
       </div>

--- a/react/components/FacetItem.js
+++ b/react/components/FacetItem.js
@@ -7,7 +7,7 @@ import useFacetNavigation from '../hooks/useFacetNavigation'
 
 import styles from '../searchResult.css'
 
-const FacetItem = ({ facet, className }) => {
+const FacetItem = ({ facet, className, preventRouteChange = false }) => {
   const { showFacetQuantity } = useContext(SettingsContext)
 
   const navigateToFacet = useFacetNavigation()
@@ -32,7 +32,7 @@ const FacetItem = ({ facet, className }) => {
           showFacetQuantity ? `${facet.name} (${facet.quantity})` : facet.name
         }
         name={facet.name}
-        onChange={() => navigateToFacet(facet)}
+        onChange={() => navigateToFacet(facet, preventRouteChange)}
         value={facet.name}
       />
     </div>

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -20,7 +20,7 @@ import useFacetNavigation, {
 
 import searchResult from '../searchResult.css'
 
-const FilterSidebar = ({ filters, tree, priceRange }) => {
+const FilterSidebar = ({ filters, tree, priceRange, preventRouteChange }) => {
   const queryContext = useContext(QueryContext)
   const [open, setOpen] = useState(false)
 
@@ -54,7 +54,7 @@ const FilterSidebar = ({ filters, tree, priceRange }) => {
   }
 
   const handleApply = () => {
-    navigateToFacet(filterOperations)
+    navigateToFacet(filterOperations, preventRouteChange)
   }
 
   const handleUpdateCategories = maybeCategories => {

--- a/react/components/SearchFilter.js
+++ b/react/components/SearchFilter.js
@@ -12,7 +12,12 @@ import useSelectedFilters from '../hooks/useSelectedFilters'
 /**
  * Search Filter Component.
  */
-const SearchFilter = ({ title = 'Default Title', facets = [], intl }) => {
+const SearchFilter = ({
+  title = 'Default Title',
+  facets = [],
+  intl,
+  preventRouteChange = false,
+}) => {
   const filtersWithSelected = useSelectedFilters(facets)
 
   const sampleFacet = facets && facets.length > 0 ? facets[0] : null
@@ -23,7 +28,13 @@ const SearchFilter = ({ title = 'Default Title', facets = [], intl }) => {
       title={getFilterTitle(title, intl)}
       filters={filtersWithSelected}
     >
-      {facet => <FacetItem key={facet.name} facet={facet} />}
+      {facet => (
+        <FacetItem
+          key={facet.name}
+          facet={facet}
+          preventRouteChange={preventRouteChange}
+        />
+      )}
     </FilterOptionTemplate>
   )
 }
@@ -35,6 +46,8 @@ SearchFilter.propTypes = {
   facets: PropTypes.arrayOf(facetOptionShape),
   /** Intl instance. */
   intl: intlShape.isRequired,
+  /** Prevent route changes */
+  preventRouteChange: PropTypes.boolean,
 }
 
 export default injectIntl(SearchFilter)

--- a/react/components/SearchFilter.js
+++ b/react/components/SearchFilter.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import { injectIntl, intlShape } from 'react-intl'
-import classNames from 'classnames'
 
 import FilterOptionTemplate from './FilterOptionTemplate'
 import FacetItem from './FacetItem'

--- a/react/components/SelectedFilters.js
+++ b/react/components/SelectedFilters.js
@@ -10,7 +10,11 @@ import styles from '../searchResult.css'
 /**
  * Search Filter Component.
  */
-const SelectedFilters = ({ filters = [], intl }) => {
+const SelectedFilters = ({
+  filters = [],
+  intl,
+  preventRouteChange = false,
+}) => {
   if (!filters.length) {
     return null
   }
@@ -29,6 +33,7 @@ const SelectedFilters = ({ filters = [], intl }) => {
           key={facet.name}
           facet={facet}
           className={styles.selectedFilterItem}
+          preventRouteChange={preventRouteChange}
         />
       )}
     </FilterOptionTemplate>
@@ -40,6 +45,8 @@ SelectedFilters.propTypes = {
   filters: PropTypes.arrayOf(facetOptionShape).isRequired,
   /** Intl instance. */
   intl: intlShape,
+  /** Prevent route changes */
+  preventRouteChange: PropTypes.boolean,
 }
 
 export default injectIntl(SelectedFilters)

--- a/react/hooks/useFacetNavigation.js
+++ b/react/hooks/useFacetNavigation.js
@@ -47,11 +47,11 @@ export const buildQueryAndMap = (inputQuery, inputMap, facets) =>
   )
 
 const useFacetNavigation = () => {
-  const { navigate } = useRuntime()
+  const { navigate, setQuery } = useRuntime()
   const { query, map } = useContext(QueryContext)
 
   const navigateToFacet = useCallback(
-    maybeFacets => {
+    (maybeFacets, preventRouteChange = false) => {
       const facets = Array.isArray(maybeFacets) ? maybeFacets : [maybeFacets]
 
       const { query: currentQuery, map: currentMap } = buildQueryAndMap(
@@ -59,6 +59,14 @@ const useFacetNavigation = () => {
         map,
         facets
       )
+
+      if (preventRouteChange) {
+        setQuery({
+          map: `${currentMap}`,
+          query: `/${currentQuery}`,
+        })
+        return
+      }
 
       const urlParams = new URLSearchParams(window.location.search)
 
@@ -71,7 +79,7 @@ const useFacetNavigation = () => {
         scrollOptions,
       })
     },
-    [navigate, query, map]
+    [query, map, navigate, setQuery]
   )
 
   return navigateToFacet


### PR DESCRIPTION
#### What is the purpose of this pull request?

Continuation of PR https://github.com/vtex-apps/search-result/pull/214.

Implementing the same feature for `filter-navigator.v2` and `filter-navigator.v3`.

#### How should this be manually tested?

## `v2`

### Prop ON
I created a custom page with a layout that have a custom `search-result` and `filter-navigator.v2` using the prop `preventRouteChange`. Also added a rich-text with the text "Top Special".

See:
https://preventroute--storecomponents.myvtex.com/top-special

Now, click on a facet. Check that the `/top-special` never gets removed from the URL and the rich-text "Top Special" still on the screen.


### Prop OFF

I created another custom page with the same layout but with the prop `preventRouteChange` as `false`.

See:
https://preventroute--storecomponents.myvtex.com/top-special-off

Now, click on a facet. Check that the `/top-special` is not on the URL anymore and it goes to a ordinary search page (with no rich-text on the top). 

### Caveat

This doesn't work if the `filter-navigator.v2` shows `categories`. When clicked on a category, it goes to an ordinary search page. In the example above I used the `hiddenFilters` > `categories` prop.

## `v3`

There's a custom page with a custom `search-result-layout` (new flexible `search-result`) and `filter-navigator.v3` using the prop `preventRouteChange`. Notice that there is a `rich-text` with the text "help".

See:
https://preventroutechangev3--storecomponents.myvtex.com/top-deals

Now, click on a facet. Check that the `/top-deals` never gets removed from the URL and the rich-text "help" still on the screen.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [X] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
