### PR TITLE
 Make search query run only on client-side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Make search query run only on client-side
 
 ## [3.29.2] - 2019-08-29
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "3.29.2",
+  "version": "3.30.0-beta.0",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -91,6 +91,7 @@ const SearchQuery = ({
        * https://github.com/apollographql/react-apollo/issues/2202 */
       key={variables.query}
       query={productSearchV2}
+      ssr={false}
       variables={variables}
       notifyOnNetworkStatusChange
       partialRefetch


### PR DESCRIPTION
#### What is the purpose of this pull request?
Make search query run only on client-side.

#### What problem is this solving?
This is a temporary solution to prevent the long time taken to server side render the search pages.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
