### PR TITLE
Make render strategy client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Make shelf render strategy `client`, i.e. component assets are fetched client-side with same priority as server-side blocks.
+
 ## [3.31.0] - 2019-09-10
 
 ## [3.30.2] - 2019-09-09

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -11,7 +11,7 @@
     ],
     "required": ["gallery"],
     "component": "index",
-    "render": "lazy"
+    "render": "client"
   },
   "filter-navigator": {
     "component": "FilterNavigatorLegacy"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Make assets subject to asset bundling and therefore load faster, instead of waiting for asset discovery during tree hydration.

#### What problem is this solving?

Lazy is supposed to be used for components that might not be rendered.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
