### PR TITLE
stop skipping search metadata query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Stop skipping the search metatada query.
 
 ## [3.31.2] - 2019-09-11
 ### Fix

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -16,16 +16,11 @@ const splitMap = split(MAP_SEPARATOR)
 const joinQuery = join(QUERY_SEPARATOR)
 const joinMap = join(MAP_SEPARATOR)
 
-const shouldSkipMetadata = map => {
-  const firstMap = head((map || '').split(','))
-  return firstMap !== 'c' && firstMap !== 'b'
-}
-
 const ParallelQueries = ({
   children,
   extraParams,
   productSearch,
-  searchMetadata = {}, //would be undefined when skipped
+  searchMetadata,
 }) => {
   // We need to do this to keep the same format as when we were using the Query component.
   const searchInfo = useMemo(
@@ -52,7 +47,6 @@ const productSearchHOC = graphql(productSearch, {
 
 const searchMetadataHOC = graphql(searchMetadata, {
   name: 'searchMetadata',
-  skip: props => props.skipSearchMetadata,
   options: props => ({
     variables: { query: props.variables.query, map: props.variables.map },
   }),
@@ -137,11 +131,7 @@ const SearchQuery = ({
   }, [variables, maxItemsPerPage, page])
 
   return (
-    <EnhancedParallelQueries
-      variables={variables}
-      extraParams={extraParams}
-      skipSearchMetadata={shouldSkipMetadata(map)}
-    >
+    <EnhancedParallelQueries variables={variables} extraParams={extraParams}>
       {children}
     </EnhancedParallelQueries>
   )


### PR DESCRIPTION
#### What is the purpose of this pull request?

We would skip the search metadata query in certain ocasions, but now it is used more often and returns more types of results, we should always do it.

#### How should this be manually tested?

https://test--storecomponents.myvtex.com/shirt/apparel---accessories/clothing/kawasaki?_q=shirt&map=ft,c,c,b

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
