### PR TITLE
Added `search-blog-articles-preview` as allowed block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- Added `blog-search-preview` to allowed blocks.
+- Added `search-blog-articles-preview` to allowed blocks.
 
 ## [3.31.3] - 2019-09-12
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Added `blog-search-preview` to allowed blocks.
+
 ## [3.31.3] - 2019-09-12
 ### Fixed
 - Stop skipping the search metatada query.

--- a/manifest.json
+++ b/manifest.json
@@ -32,7 +32,8 @@
     "vtex.device-detector": "0.x",
     "vtex.rich-text": "0.x",
     "vtex.flex-layout": "0.x",
-    "vtex.search-page-context": "0.x"
+    "vtex.search-page-context": "0.x",
+    "vtex.blog-interfaces": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -80,7 +80,8 @@
       "flex-layout",
       "search-fetch-more",
       "search-content",
-      "search-products-count-per-page"
+      "search-products-count-per-page",
+      "blog-search-preview"
     ],
     "composition": "children",
     "component": "SearchResultFlexible"
@@ -98,7 +99,8 @@
       "search-layout-switcher",
       "search-fetch-more",
       "search-content",
-      "search-products-count-per-page"
+      "search-products-count-per-page",
+      "blog-search-preview"
     ],
     "composition": "children",
     "component": "SearchResultFlexibleMobile"

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -81,7 +81,7 @@
       "search-fetch-more",
       "search-content",
       "search-products-count-per-page",
-      "blog-search-preview"
+      "search-blog-articles-preview"
     ],
     "composition": "children",
     "component": "SearchResultFlexible"
@@ -100,7 +100,7 @@
       "search-fetch-more",
       "search-content",
       "search-products-count-per-page",
-      "blog-search-preview"
+      "search-blog-articles-preview"
     ],
     "composition": "children",
     "component": "SearchResultFlexibleMobile"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add `search-blog-articles-preview` as allowed block on custom search layouts.

#### What problem is this solving?

Allows article search results to be displayed on product search page.

#### How should this be manually tested?

See https://wordpress--worldwidegolf.myvtex.com/shoes?_q=shoes&map=ft

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
