### PR TITLE
Add allowed blocks for custom layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Added `search-blog-articles-list` to allowed blocks.
+- Added `search-blog-articles-list` and `tab-layout` to allowed blocks for custom layouts.
 
 ## [3.32.2] - 2019-09-19
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `search-blog-articles-list` to allowed blocks.
 
 ## [3.32.2] - 2019-09-19
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -32,6 +32,7 @@
     "vtex.device-detector": "0.x",
     "vtex.rich-text": "0.x",
     "vtex.flex-layout": "0.x",
+    "vtex.tab-layout": "0.x", 
     "vtex.search-page-context": "0.x",
     "vtex.blog-interfaces": "0.x"
   },

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -7,9 +7,7 @@
       "total-products",
       "order-by",
       "search-title",
-      "rich-text",
-      "search-blog-articles-preview",
-      "search-blog-articles-list"
+      "rich-text"
     ],
     "required": ["gallery"],
     "component": "index",
@@ -80,6 +78,7 @@
       "rich-text",
       "info-card",
       "flex-layout",
+      "tab-layout",
       "search-fetch-more",
       "search-content",
       "search-products-count-per-page",
@@ -99,6 +98,7 @@
       "rich-text",
       "info-card",
       "flex-layout",
+      "tab-layout",
       "search-layout-switcher",
       "search-fetch-more",
       "search-content",

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -79,6 +79,8 @@
       "info-card",
       "flex-layout",
       "tab-layout",
+      "tab-list",
+      "tab-content",
       "search-fetch-more",
       "search-content",
       "search-products-count-per-page",

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -7,7 +7,9 @@
       "total-products",
       "order-by",
       "search-title",
-      "rich-text"
+      "rich-text",
+      "search-blog-articles-preview",
+      "search-blog-articles-list"
     ],
     "required": ["gallery"],
     "component": "index",
@@ -81,7 +83,8 @@
       "search-fetch-more",
       "search-content",
       "search-products-count-per-page",
-      "search-blog-articles-preview"
+      "search-blog-articles-preview",
+      "search-blog-articles-list"
     ],
     "composition": "children",
     "component": "SearchResultFlexible"
@@ -100,7 +103,8 @@
       "search-fetch-more",
       "search-content",
       "search-products-count-per-page",
-      "search-blog-articles-preview"
+      "search-blog-articles-preview",
+      "search-blog-articles-list"
     ],
     "composition": "children",
     "component": "SearchResultFlexibleMobile"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add `search-blog-articles-list` and `tab-layout` as allowed blocks for custom layouts.

#### What problem is this solving?

In a previous release we added `search-blog-articles-preview` as an allowed block. Now that we have `vtex.tab-layout`, we can offer a full paginated list of article search results on the product search page and allow the user to tab between product results and article results.

#### How should this be manually tested?

See https://wordpress--worldwidegolf.myvtex.com/golf for a basic example

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
