### PR TITLE
allow-custom-options-in-order-by

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `customOptions` to `OrderBy`
+- `hiddenOptions` to `OrderBy`
 
 ### Changed
 - The title in `SelectionListOrderBy` now returns `''` instead of an error when the value is not found.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `hiddenOptions` to `OrderBy`
+- `hiddenOptions` prop to `OrderBy`.
 
 ### Changed
 - The title in `SelectionListOrderBy` now returns `''` instead of an error when the value is not found.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `customOptions` to `OrderBy`
+
+### Changed
+- The title in `SelectionListOrderBy` now returns `''` instead of an error when the value is not found.
 
 ## [3.37.1] - 2019-11-08
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -419,55 +419,22 @@ Also, you can configure the product summary that is defined on search-result. Se
 
 ##### `order-by` block
 
-| Prop name       | Type                                       | Description                                                                                  | Default value |
-| --------------- | ------------------------------------------ | -------------------------------------------------------------------------------------------- | ------------- |
-| `customOptions` | `Array(`[OrderByOption](#orderbyoption)`)` | Array of options available in OrderBy. If `null`, [SORT_OPTIONS](#sort_options) will be used | -             |
-
-###### `OrderByOption`
-
-| Prop name | Type      | Description                                                | Default value |
-| --------- | --------- | ---------------------------------------------------------- | ------------- |
-| `value`   | `String!` | String used in query string                                | -             |
-| `label`   | `String!` | String shown in the selection menu. It can be an `intl` id | -             |
+| Prop name       | Type            | Description                                                                                                  | Default value |
+| --------------- | --------------- | ------------------------------------------------------------------------------------------------------------ | ------------- |
+| `hiddenOptions` | `Array(String)` | Indicates which [sort options](#sort_options) will be hidden. (e.g. `["OrderByNameASC", "OrderByNameDESC"]`) | `[]`          |
 
 ###### `SORT_OPTIONS`
 
-```
-SORT_OPTIONS = [
-  {
-    value: '',
-    label: 'store/ordenation.relevance',
-  },
-  {
-    value: 'OrderByTopSaleDESC',
-    label: 'store/ordenation.sales',
-  },
-  {
-    value: 'OrderByReleaseDateDESC',
-    label: 'store/ordenation.release.date',
-  },
-  {
-    value: 'OrderByBestDiscountDESC',
-    label: 'store/ordenation.discount',
-  },
-  {
-    value: 'OrderByPriceDESC',
-    label: 'store/ordenation.price.descending',
-  },
-  {
-    value: 'OrderByPriceASC',
-    label: 'store/ordenation.price.ascending',
-  },
-  {
-    value: 'OrderByNameASC',
-    label: 'store/ordenation.name.ascending',
-  },
-  {
-    value: 'OrderByNameDESC',
-    label: 'store/ordenation.name.descending',
-  },
-]
-```
+| Option                   | Value                       |
+| ------------------------ | --------------------------- |
+| Relevance                | `""`                        |
+| Top Sales Descending     | `"OrderByTopSaleDESC"`      |
+| Release Date Descending  | `"OrderByReleaseDateDESC"`  |
+| Best Discount Descending | `"OrderByBestDiscountDESC"` |
+| Price Descending         | `"OrderByPriceDESC"`        |
+| Price Ascending          | `"OrderByPriceASC"`         |
+| Name Ascending           | `"OrderByNameASC"`          |
+| Name Descending          | `"OrderByNameDESC"`         |
 
 ### Styles API
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -417,6 +417,58 @@ Notice that the default behavior for your store will be the one defined by the `
 
 Also, you can configure the product summary that is defined on search-result. See [here](https://github.com/vtex-apps/product-summary/blob/master/README.md#configuration) the Product Summary API.
 
+##### `order-by` block
+
+| Prop name       | Type                                       | Description                                                                                  | Default value |
+| --------------- | ------------------------------------------ | -------------------------------------------------------------------------------------------- | ------------- |
+| `customOptions` | `Array(`[OrderByOption](#orderbyoption)`)` | Array of options available in OrderBy. If `null`, [SORT_OPTIONS](#sort_options) will be used | -             |
+
+###### `OrderByOption`
+
+| Prop name | Type      | Description                                                | Default value |
+| --------- | --------- | ---------------------------------------------------------- | ------------- |
+| `value`   | `String!` | String used in query string                                | -             |
+| `label`   | `String!` | String shown in the selection menu. It can be an `intl` id | -             |
+
+###### `SORT_OPTIONS`
+
+```
+SORT_OPTIONS = [
+  {
+    value: '',
+    label: 'store/ordenation.relevance',
+  },
+  {
+    value: 'OrderByTopSaleDESC',
+    label: 'store/ordenation.sales',
+  },
+  {
+    value: 'OrderByReleaseDateDESC',
+    label: 'store/ordenation.release.date',
+  },
+  {
+    value: 'OrderByBestDiscountDESC',
+    label: 'store/ordenation.discount',
+  },
+  {
+    value: 'OrderByPriceDESC',
+    label: 'store/ordenation.price.descending',
+  },
+  {
+    value: 'OrderByPriceASC',
+    label: 'store/ordenation.price.ascending',
+  },
+  {
+    value: 'OrderByNameASC',
+    label: 'store/ordenation.name.ascending',
+  },
+  {
+    value: 'OrderByNameDESC',
+    label: 'store/ordenation.name.descending',
+  },
+]
+```
+
 ### Styles API
 
 This app provides some CSS classes as an API for style customization.

--- a/react/OrderBy.js
+++ b/react/OrderBy.js
@@ -39,17 +39,17 @@ export const SORT_OPTIONS = [
   },
 ]
 
-const OrderBy = ({ orderBy, intl, customOptions }) => {
+const OrderBy = ({ orderBy, intl, hiddenOptions = [] }) => {
   const sortingOptions = useMemo(() => {
-    const options = customOptions || SORT_OPTIONS
-
-    return options.map(({ value, label }) => {
+    return SORT_OPTIONS.filter(
+      option => !hiddenOptions.includes(option.value)
+    ).map(({ value, label }) => {
       return {
         value: value,
         label: intl.formatMessage({ id: label }),
       }
     })
-  }, [intl, customOptions])
+  }, [intl, hiddenOptions])
 
   return <SelectionListOrderBy orderBy={orderBy} options={sortingOptions} />
 }
@@ -59,13 +59,8 @@ OrderBy.propTypes = {
   orderBy: PropTypes.string,
   /** Intl instance. */
   intl: intlShape,
-  /** Custom sort options. */
-  customOptions: PropTypes.arrayOf(
-    PropTypes.shape({
-      label: PropTypes.string.isRequired,
-      value: PropTypes.string.isRequired,
-    })
-  ),
+  /** Options to be hidden. (e.g. `["OrderByNameASC", "OrderByNameDESC"]`) */
+  hiddenOptions: PropTypes.arrayOf(PropTypes.string),
 }
 
 export default injectIntl(OrderBy)

--- a/react/OrderBy.js
+++ b/react/OrderBy.js
@@ -39,15 +39,17 @@ export const SORT_OPTIONS = [
   },
 ]
 
-const OrderBy = ({ orderBy, intl }) => {
+const OrderBy = ({ orderBy, intl, customOptions }) => {
   const sortingOptions = useMemo(() => {
-    return SORT_OPTIONS.map(({ value, label }) => {
+    const options = customOptions || SORT_OPTIONS
+
+    return options.map(({ value, label }) => {
       return {
         value: value,
         label: intl.formatMessage({ id: label }),
       }
     })
-  }, [intl])
+  }, [intl, customOptions])
 
   return <SelectionListOrderBy orderBy={orderBy} options={sortingOptions} />
 }
@@ -57,6 +59,13 @@ OrderBy.propTypes = {
   orderBy: PropTypes.string,
   /** Intl instance. */
   intl: intlShape,
+  /** Custom sort options. */
+  customOptions: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      value: PropTypes.string.isRequired,
+    })
+  ),
 }
 
 export default injectIntl(OrderBy)

--- a/react/OrderByFlexible.js
+++ b/react/OrderByFlexible.js
@@ -5,7 +5,7 @@ import OrderBy from './OrderBy'
 
 import styles from './searchResult.css'
 
-const withSearchPageContextProps = Component => () => {
+const withSearchPageContextProps = Component => (props) => {
   const { orderBy } = useSearchPage()
   if (orderBy == null) {
     return null
@@ -13,7 +13,7 @@ const withSearchPageContextProps = Component => () => {
 
   return (
     <div className={styles['orderBy--layout']}>
-      <Component orderBy={orderBy} />
+      <Component {...props} orderBy={orderBy} />
     </div>
   )
 }

--- a/react/components/SelectionListOrderBy.js
+++ b/react/components/SelectionListOrderBy.js
@@ -40,7 +40,10 @@ const SelectionListOrderBy = ({ intl, orderBy, options }) => {
   }
 
   const getOptionTitle = useCallback(
-    option => find(propEq('value', option), options).label,
+    option => {
+      const selectedOption = find(propEq('value', option), options)
+      return selectedOption ? selectedOption.label : ''
+    },
     [options]
   )
 


### PR DESCRIPTION
#### What problem is this solving?

The sort options in `OrderBy` are hard coded. This PR aims to offer the `customOptions` prop to allow custom options.

It is also related to https://github.com/vtex-apps/store-discussion/issues/101

#### How should this be manually tested?

[workspace](https://customorderbyoptions--biggy.myvtex.com/)

#### Screenshots or example usage
In this example only three options are available.

```
"order-by.v2#custom": {
    "props": {
      "customOptions": [
        {
          "value": "",
          "label": "store/ordenation.release.date"
        },
        {
          "value": "OrderByTopSaleDESC",
          "label": "store/ordenation.sales"
        },
        {
          "value": "OrderByReleaseDateDESC",
          "label": "store/ordenation.release.date"
        }
      ]
    }
  }
```
![image](https://user-images.githubusercontent.com/40380674/65729276-15fa0800-e094-11e9-90ea-69e5638aedaf.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
