### PR TITLE
Handle errors in the fetchMore promise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+-  problems with the `fetchMore` that is used on the useFetchMore by handling possible errors
 
 ## [3.33.0] - 2019-10-02
 ### Added

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -131,6 +131,7 @@ class SearchResult extends Component {
       mobileLayout,
       isMobile,
       pagination,
+      infiniteScrollError,
     } = this.props
     const {
       mobileLayoutMode,
@@ -234,7 +235,7 @@ class SearchResult extends Component {
                 <ExtensionPoint id="not-found" />
               </div>
             )}
-            {pagination === PAGINATION_TYPE.SHOW_MORE ? (
+            {pagination === PAGINATION_TYPE.SHOW_MORE || infiniteScrollError ? (
               <FetchMoreButton
                 products={products}
                 to={to}

--- a/react/components/SearchResultContainer.js
+++ b/react/components/SearchResultContainer.js
@@ -39,6 +39,7 @@ const SearchResultContainer = props => {
     loading: fetchMoreLoading,
     from,
     to,
+    infiniteScrollError,
   } = useFetchMore(page, recordsFiltered, maxItemsPerPage, fetchMore, products)
 
   const resultComponent = children || (
@@ -59,6 +60,7 @@ const SearchResultContainer = props => {
       tree={categoriesTrees}
       to={to}
       from={from}
+      infiniteScrollError={infiniteScrollError}
     />
   )
 

--- a/react/hooks/useFetchMore.js
+++ b/react/hooks/useFetchMore.js
@@ -121,7 +121,7 @@ export const useFetchMore = (
   errors when the search result uses infinite scroll. 
   This should be removed once infinite scrolling is removed */
   const [infiniteScrollError, setInfiniteScrollError] = useState(false)
-  const updateQueryError = useRef(false)
+  const updateQueryError = useRef(false) //TODO: refactor this ref
 
   const handleFetchMoreNext = async () => {
     const from = currentTo + 1

--- a/react/hooks/useFetchMore.js
+++ b/react/hooks/useFetchMore.js
@@ -11,6 +11,8 @@ export const FETCH_TYPE = {
   PREVIOUS: 'previous',
 }
 
+let updateQueryError = false
+
 const handleFetchMore = async (
   from,
   to,
@@ -40,7 +42,8 @@ const handleFetchMore = async (
       fetchMoreLocked.current = false
 
       if (!prevResult || !fetchMoreResult) {
-        return { error: 'Error in prevResult or fetchMoreResult' }
+        updateQueryError = true
+        return
       }
 
       // backwards compatibility
@@ -80,6 +83,7 @@ const handleFetchMore = async (
   }).catch(error => {
     setLoading(false)
     fetchMoreLocked.current = false
+    updateQueryError = true
     return { error: error }
   })
 }
@@ -134,15 +138,17 @@ export const useFetchMore = (
       fetchMoreLocked,
       setLoading,
       fetchMore,
-      products
+      products,
+      updateQueryError
     )
     //if error, rollback
-    if (promiseResult && promiseResult.error) {
+    if (promiseResult && updateQueryError) {
       setCurrentTo(currentTo)
       setCurrentPage(currentPage)
       setNextPage(nextPage)
       setQuery({ page: currentPage }, { replace: true })
       setInfiniteScrollError(true)
+      updateQueryError = false
     }
   }
 
@@ -161,14 +167,17 @@ export const useFetchMore = (
       fetchMoreLocked,
       setLoading,
       fetchMore,
-      products
+      products,
+      updateQueryError
     )
     //if error, rollback
-    if (promiseResult && promiseResult.error) {
+    if (promiseResult && updateQueryError) {
       setCurrentFrom(currentFrom)
       setCurrentPage(currentPage)
       setPreviousPage(previousPage)
       setQuery({ page: currentPage }, { replace: true, merge: true })
+      setInfiniteScrollError(true)
+      updateQueryError = false
     }
   }
 

--- a/react/hooks/useFetchMore.js
+++ b/react/hooks/useFetchMore.js
@@ -11,8 +11,6 @@ export const FETCH_TYPE = {
   PREVIOUS: 'previous',
 }
 
-let updateQueryError = false
-
 const handleFetchMore = async (
   from,
   to,
@@ -20,7 +18,8 @@ const handleFetchMore = async (
   fetchMoreLocked,
   setLoading,
   fetchMore,
-  products
+  products,
+  updateQueryError
 ) => {
   if (fetchMoreLocked.current || products.length === 0) {
     return
@@ -42,7 +41,7 @@ const handleFetchMore = async (
       fetchMoreLocked.current = false
 
       if (!prevResult || !fetchMoreResult) {
-        updateQueryError = true
+        updateQueryError.current = true
         return
       }
 
@@ -83,7 +82,7 @@ const handleFetchMore = async (
   }).catch(error => {
     setLoading(false)
     fetchMoreLocked.current = false
-    updateQueryError = true
+    updateQueryError.current = true
     return { error: error }
   })
 }
@@ -122,6 +121,7 @@ export const useFetchMore = (
   errors when the search result uses infinite scroll. 
   This should be removed once infinite scrolling is removed */
   const [infiniteScrollError, setInfiniteScrollError] = useState(false)
+  const updateQueryError = useRef(false)
 
   const handleFetchMoreNext = async () => {
     const from = currentTo + 1
@@ -142,13 +142,13 @@ export const useFetchMore = (
       updateQueryError
     )
     //if error, rollback
-    if (promiseResult && updateQueryError) {
+    if (promiseResult && updateQueryError.current) {
       setCurrentTo(currentTo)
       setCurrentPage(currentPage)
       setNextPage(nextPage)
       setQuery({ page: currentPage }, { replace: true })
       setInfiniteScrollError(true)
-      updateQueryError = false
+      updateQueryError.current = false
     }
   }
 
@@ -171,13 +171,13 @@ export const useFetchMore = (
       updateQueryError
     )
     //if error, rollback
-    if (promiseResult && updateQueryError) {
+    if (promiseResult && updateQueryError.current) {
       setCurrentFrom(currentFrom)
       setCurrentPage(currentPage)
       setPreviousPage(previousPage)
       setQuery({ page: currentPage }, { replace: true, merge: true })
       setInfiniteScrollError(true)
-      updateQueryError = false
+      updateQueryError.current = false
     }
   }
 

--- a/react/hooks/useFetchMore.js
+++ b/react/hooks/useFetchMore.js
@@ -127,7 +127,7 @@ export const useFetchMore = (
     setNextPage(nextPage + 1)
     setQuery({ page: nextPage }, { replace: true })
     const promiseResult = await handleFetchMore(
-      from + 3000,
+      from,
       to,
       FETCH_TYPE.NEXT,
       fetchMoreLocked,

--- a/react/hooks/useFetchMore.js
+++ b/react/hooks/useFetchMore.js
@@ -39,6 +39,10 @@ const handleFetchMore = async (
       setLoading(false)
       fetchMoreLocked.current = false
 
+      if (!prevResult || !fetchMoreResult) {
+        return { error: 'Error in prevResult or fetchMoreResult' }
+      }
+
       // backwards compatibility
       if (prevResult.search) {
         return {

--- a/react/hooks/useFetchMore.js
+++ b/react/hooks/useFetchMore.js
@@ -74,7 +74,6 @@ const handleFetchMore = async (
       }
     },
   }).catch(error => {
-    //console.log('ERROR!!!!!!!!!!')
     setLoading(false)
     fetchMoreLocked.current = false
     return { error: error }
@@ -111,17 +110,15 @@ export const useFetchMore = (
   const [currentTo, setCurrentTo] = useState(currentFrom + maxItemsPerPage - 1)
   const [loading, setLoading] = useFetchingMore()
   const fetchMoreLocked = useRef(false) // prevents the user from sending two requests at once
-
-  // console.log('CHECK STATES')
-  // console.log('nextPage', nextPage)
-  // console.log('previousPage', previousPage)
-  // console.log('currentPage', currentPage)
-  // console.log('currentFrom', currentFrom)
-  // console.log('currentTo', currentTo)
+  /* this is a temporary solution to deal with unexpected 
+  errors when the search result uses infinite scroll. 
+  This should be removed once infinite scrolling is removed */
+  const [infiniteScrollError, setInfiniteScrollError] = useState(false)
 
   const handleFetchMoreNext = async () => {
     const from = currentTo + 1
     const to = min(recordsFiltered, from + maxItemsPerPage) - 1
+    setInfiniteScrollError(false)
     setCurrentTo(to)
     setCurrentPage(nextPage)
     setNextPage(nextPage + 1)
@@ -141,12 +138,14 @@ export const useFetchMore = (
       setCurrentPage(currentPage)
       setNextPage(nextPage)
       setQuery({ page: currentPage }, { replace: true })
+      setInfiniteScrollError(true)
     }
   }
 
   const handleFetchMorePrevious = async () => {
     const to = currentFrom - 1
     const from = max(0, to - maxItemsPerPage + 1)
+    setInfiniteScrollError(false)
     setCurrentFrom(from)
     setCurrentPage(previousPage)
     setPreviousPage(previousPage - 1)
@@ -175,5 +174,6 @@ export const useFetchMore = (
     loading,
     from: currentFrom,
     to: currentTo,
+    infiniteScrollError,
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Sometimes when scrolling through search results an error would happen, making the page load indefinitely or by showing the user a "products not found" page. These errors were caused by the `fetchMore` promise that was called on some `useFetchMore`'s methods that are used on the fetch more buttons and infinite scrolling spinner. This PR handles possible exceptions thrown by this promise, making these errors almost unnoticeable by the users.

#### How should this be manually tested?

The error is very hard to reproduce since it happens randomly when you open a new search result and try browsing through the results, but here is the [workspace](https://iaronaraujo--alssports.myvtex.com/clothing/pants?map=c,c&order=OrderByPriceASC&page=8)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
