### PR TITLE
Added tooltip to filters in navigator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Tooltip to filters
+
 ## [3.33.0] - 2019-10-02
 ### Added
 - Loading more results of a search result now changes the url. The back and forward feature is working properly to consider the page the user was last in.

--- a/react/components/FacetItem.js
+++ b/react/components/FacetItem.js
@@ -20,6 +20,10 @@ const FacetItem = ({ facet, className }) => {
     'lh-copy w-100'
   )
 
+  const facetLabel = showFacetQuantity
+    ? `${facet.name} (${facet.quantity})`
+    : facet.name
+
   return (
     <div
       className={classes}
@@ -28,9 +32,8 @@ const FacetItem = ({ facet, className }) => {
       <Checkbox
         id={facet.value}
         checked={facet.selected}
-        label={
-          showFacetQuantity ? `${facet.name} (${facet.quantity})` : facet.name
-        }
+        title={facetLabel}
+        label={facetLabel}
         name={facet.name}
         onChange={() => navigateToFacet(facet)}
         value={facet.name}


### PR DESCRIPTION
#### What is the purpose of this pull request?

To make filters have a tooltip

#### What problem is this solving?

This provides an accessibility feature to the filter navigator in stores. 

#### How should this be manually tested?

https://savio--storecomponents.myvtex.com/apparel---accessories/hats/
https://savio--worldwidegolf.myvtex.com/shoes/Womens?map=c,specificationFilter_258

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/18701182/66238281-98567d80-e6cd-11e9-9cab-32de2458dd36.png)
![image](https://user-images.githubusercontent.com/18701182/66238318-b45a1f00-e6cd-11e9-9871-4b58faca848a.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [X] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
