### PR TITLE
Prevent 'normal' layout from showing more than 1 item on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Mobile layouts could be broken if `minItemWidth` prop at the `Gallery` component received a small value.
 
 ## [3.33.3] - 2019-10-08
 ### Deprecated

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -14,6 +14,8 @@ import GalleryRow from './components/GalleryRow'
 
 /** Layout with two column */
 const TWO_COLUMN_ITEMS = 2
+/** Layout with one column */
+const ONE_COLUMN_ITEMS = 1
 
 /**
  * Canonical gallery that displays a list of given products.
@@ -39,6 +41,8 @@ const Gallery = ({
   const itemsPerRow =
     layoutMode === 'small'
       ? TWO_COLUMN_ITEMS
+      : isMobile
+      ? ONE_COLUMN_ITEMS
       : getItemsPerRow() || maxItemsPerRow
 
   const rows = useMemo(() => splitEvery(itemsPerRow, products), [

--- a/react/__mocks__/vtex.device-detector.js
+++ b/react/__mocks__/vtex.device-detector.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 export const useDevice = () => {
-  return { isMobile: true }
+  return { isMobile: false }
 }
 
 export const withDevice = WrappedComponent => {

--- a/react/__mocks__/vtex.render-runtime.js
+++ b/react/__mocks__/vtex.render-runtime.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { PropTypes } from 'prop-types'
 
 const config = { isMobile: false }
 
@@ -9,6 +10,16 @@ export const withRuntimeContext = Comp => {
     render() {
       return <Comp runtime={this.runtime} {...this.props} />
     }
+  }
+}
+
+export class NoSSR extends React.Component {
+  static propTypes = {
+    children: PropTypes.element,
+  }
+
+  render() {
+    return this.props.children
   }
 }
 

--- a/react/__tests__/__snapshots__/FilterNavigator.test.js.snap
+++ b/react/__tests__/__snapshots__/FilterNavigator.test.js.snap
@@ -3,26 +3,171 @@
 exports[`<FilterNavigator /> should display related categories 1`] = `
 <DocumentFragment>
   <div
-    class="flex items-center justify-center flex-auto h-100"
+    class=""
   >
-    <button
-      class="filterPopupButton ph3 pv5 mv0 mv0 pointer flex justify-center items-center bn"
+    <div
+      class="filter__container filter__container--title bb b--muted-4"
     >
-      <span
-        class="filterPopupTitle c-on-base t-action--small ml-auto"
+      <h5
+        class="t-heading-5 mv5"
       >
         <span>
-          Filter
+          Filters
         </span>
-      </span>
-      <span
-        class="filterPopupArrowIcon ml-auto pl3 pt2"
+      </h5>
+    </div>
+    <div
+      class="filter__container filter__container--c bb b--muted-4"
+    >
+      <div
+        class="filter pt4"
       >
-        <div>
-          IconFilter
+        <div
+          class="filterTitle t-mini c-muted-2 flex items-center justify-between"
+        >
+          <span>
+            Departments
+          </span>
         </div>
-      </span>
-    </button>
+      </div>
+      <div
+        class="categoriesContainer pb5 flex flex-column"
+      >
+        <div
+          class="categoryGroup mt4"
+        >
+          <div
+            class="categoryParent flex items-center pointer"
+            role="button"
+            tabindex="-1"
+          >
+            <div
+              class="flex-grow-1 dim"
+            >
+              <span
+                class="categoryItemName f5 c-on-base"
+              >
+                Eletrônicos
+              </span>
+            </div>
+          </div>
+          <div
+            class="categoryItemChildrenContainer pl5 pl0-ns"
+          >
+            <div
+              class="mt2"
+            >
+              <div
+                class="categoryItemChildren ph5 ph3-ns pv5 pv1-ns lh-copy pointer hover-bg-muted-5 c-muted-1"
+                role="link"
+                tabindex="0"
+              >
+                Smartphones
+              </div>
+              <div
+                class="categoryItemChildren ph5 ph3-ns pv5 pv1-ns lh-copy pointer hover-bg-muted-5 c-muted-1"
+                role="link"
+                tabindex="0"
+              >
+                Videogames
+              </div>
+              <div
+                class="categoryItemChildren ph5 ph3-ns pv5 pv1-ns lh-copy pointer hover-bg-muted-5 c-muted-1"
+                role="link"
+                tabindex="0"
+              >
+                TVs
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="categoryGroup mt4"
+        >
+          <div
+            class="categoryParent flex items-center pointer"
+            role="button"
+            tabindex="-1"
+          >
+            <div
+              class="flex-grow-1 dim"
+            >
+              <span
+                class="categoryItemName f5 c-on-base"
+              >
+                Livros
+              </span>
+            </div>
+          </div>
+          <div
+            class="categoryItemChildrenContainer pl5 pl0-ns"
+          >
+            <div
+              class="mt2"
+            >
+              <div
+                class="categoryItemChildren ph5 ph3-ns pv5 pv1-ns lh-copy pointer hover-bg-muted-5 c-muted-1"
+                role="link"
+                tabindex="0"
+              >
+                HQs e Mangas
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="categoryGroup mt4"
+        >
+          <div
+            class="categoryParent flex items-center pointer"
+            role="button"
+            tabindex="-1"
+          >
+            <div
+              class="flex-grow-1 dim"
+            >
+              <span
+                class="categoryItemName f5 c-on-base"
+              >
+                Roupas
+              </span>
+            </div>
+          </div>
+          <div
+            class="categoryItemChildrenContainer pl5 pl0-ns"
+          >
+            <div
+              class="mt2"
+            >
+              <div
+                class="categoryItemChildren ph5 ph3-ns pv5 pv1-ns lh-copy pointer hover-bg-muted-5 c-muted-1"
+                role="link"
+                tabindex="0"
+              >
+                Blusas
+              </div>
+              <div
+                class="categoryItemChildren ph5 ph3-ns pv5 pv1-ns lh-copy pointer hover-bg-muted-5 c-muted-1"
+                role="link"
+                tabindex="0"
+              >
+                Calças
+              </div>
+              <div
+                class="categoryItemChildren ph5 ph3-ns pv5 pv1-ns lh-copy pointer hover-bg-muted-5 c-muted-1"
+                role="link"
+                tabindex="0"
+              >
+                Moletom
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+     Extension Point: shop-review-summary 
   </div>
 </DocumentFragment>
 `;
@@ -30,26 +175,171 @@ exports[`<FilterNavigator /> should display related categories 1`] = `
 exports[`<FilterNavigator /> should match snapshot with all 1`] = `
 <DocumentFragment>
   <div
-    class="flex items-center justify-center flex-auto h-100"
+    class=""
   >
-    <button
-      class="filterPopupButton ph3 pv5 mv0 mv0 pointer flex justify-center items-center bn"
+    <div
+      class="filter__container filter__container--title bb b--muted-4"
     >
-      <span
-        class="filterPopupTitle c-on-base t-action--small ml-auto"
+      <h5
+        class="t-heading-5 mv5"
       >
         <span>
-          Filter
+          Filters
         </span>
-      </span>
-      <span
-        class="filterPopupArrowIcon ml-auto pl3 pt2"
+      </h5>
+    </div>
+    <div
+      class="filter__container filter__container--c bb b--muted-4"
+    >
+      <div
+        class="filter pt4"
       >
-        <div>
-          IconFilter
+        <div
+          class="filterTitle t-mini c-muted-2 flex items-center justify-between"
+        >
+          <span>
+            Departments
+          </span>
         </div>
-      </span>
-    </button>
+      </div>
+      <div
+        class="categoriesContainer pb5 flex flex-column"
+      >
+        <div
+          class="categoryGroup mt4"
+        >
+          <div
+            class="categoryParent flex items-center pointer"
+            role="button"
+            tabindex="-1"
+          >
+            <div
+              class="flex-grow-1 dim"
+            >
+              <span
+                class="categoryItemName f5 c-on-base"
+              >
+                Eletrônicos
+              </span>
+            </div>
+          </div>
+          <div
+            class="categoryItemChildrenContainer pl5 pl0-ns"
+          >
+            <div
+              class="mt2"
+            >
+              <div
+                class="categoryItemChildren ph5 ph3-ns pv5 pv1-ns lh-copy pointer hover-bg-muted-5 c-muted-1"
+                role="link"
+                tabindex="0"
+              >
+                Smartphones
+              </div>
+              <div
+                class="categoryItemChildren ph5 ph3-ns pv5 pv1-ns lh-copy pointer hover-bg-muted-5 c-muted-1"
+                role="link"
+                tabindex="0"
+              >
+                Videogames
+              </div>
+              <div
+                class="categoryItemChildren ph5 ph3-ns pv5 pv1-ns lh-copy pointer hover-bg-muted-5 c-muted-1"
+                role="link"
+                tabindex="0"
+              >
+                TVs
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="categoryGroup mt4"
+        >
+          <div
+            class="categoryParent flex items-center pointer"
+            role="button"
+            tabindex="-1"
+          >
+            <div
+              class="flex-grow-1 dim"
+            >
+              <span
+                class="categoryItemName f5 c-on-base"
+              >
+                Livros
+              </span>
+            </div>
+          </div>
+          <div
+            class="categoryItemChildrenContainer pl5 pl0-ns"
+          >
+            <div
+              class="mt2"
+            >
+              <div
+                class="categoryItemChildren ph5 ph3-ns pv5 pv1-ns lh-copy pointer hover-bg-muted-5 c-muted-1"
+                role="link"
+                tabindex="0"
+              >
+                HQs e Mangas
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="categoryGroup mt4"
+        >
+          <div
+            class="categoryParent flex items-center pointer"
+            role="button"
+            tabindex="-1"
+          >
+            <div
+              class="flex-grow-1 dim"
+            >
+              <span
+                class="categoryItemName f5 c-on-base"
+              >
+                Roupas
+              </span>
+            </div>
+          </div>
+          <div
+            class="categoryItemChildrenContainer pl5 pl0-ns"
+          >
+            <div
+              class="mt2"
+            >
+              <div
+                class="categoryItemChildren ph5 ph3-ns pv5 pv1-ns lh-copy pointer hover-bg-muted-5 c-muted-1"
+                role="link"
+                tabindex="0"
+              >
+                Blusas
+              </div>
+              <div
+                class="categoryItemChildren ph5 ph3-ns pv5 pv1-ns lh-copy pointer hover-bg-muted-5 c-muted-1"
+                role="link"
+                tabindex="0"
+              >
+                Calças
+              </div>
+              <div
+                class="categoryItemChildren ph5 ph3-ns pv5 pv1-ns lh-copy pointer hover-bg-muted-5 c-muted-1"
+                role="link"
+                tabindex="0"
+              >
+                Moletom
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+     Extension Point: shop-review-summary 
   </div>
 </DocumentFragment>
 `;


### PR DESCRIPTION
#### What is the purpose of this pull request?

This should enforce the default behavior for mobile layouts:

- When set to `'normal'`, there should be one item per row.
- When set to `'small'`, there should be two items per row.

#### What problem is this solving?

If the user sets a `minItemWidth` value that is too small, more then two items would be displayed in the same row and the items would be too small and look broken. 

#### How should this be manually tested?

Use the layout switcher and notice that the layout is not broken :)

[workspace](https://searchresultfix--footnotes.myvtex.com/golden-goose?map=b)


#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
