### PR TITLE
Feature/initially collapsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Prop `initiallyCollapsed`, to `filter-navigators`, to make filters start out collapsed.
 
 ## [3.34.0] - 2019-10-10
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -397,12 +397,14 @@ Notice that the default behavior for your store will be the one defined by the `
 | Prop name            | Type      | Description                                                                                                                                                    | Default value |
 | -------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
 | `preventRouteChange` | `Boolean` | Prevents route change when selecting filters, using the query string instead. Intended for `search-result` blocks inserted on custom pages with static routes. | `false`       |
+| `initiallyCollapsed` | `Boolean` | Makes the search filters start out collapsed. | `false`       |
 
 ##### `filter-navigator.v2` block
 
 | Prop name            | Type      | Description                                                                                                                                                    | Default value |
 | -------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
 | `preventRouteChange` | `Boolean` | Prevents route change when selecting filters, using the query string instead. Intended for `search-result` blocks inserted on custom pages with static routes. | `false`       |
+| `initiallyCollapsed` | `Boolean` | Makes the search filters start out collapsed. | `false`       |
 
 
 Also, you can configure the product summary that is defined on search-result. See [here](https://github.com/vtex-apps/product-summary/blob/master/README.md#configuration) the Product Summary API.

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -35,6 +35,7 @@ const FilterNavigator = ({
   filters = [],
   preventRouteChange = false,
   hiddenFacets = {},
+  initiallyCollapsed = false,
 }) => {
   const { isMobile } = useDevice()
 
@@ -118,6 +119,7 @@ const FilterNavigator = ({
           filters={filters}
           priceRange={priceRange}
           preventRouteChange={preventRouteChange}
+          initiallyCollapsed={initiallyCollapsed}
         />
       </div>
       <ExtensionPoint id="shop-review-summary" />

--- a/react/components/AvailableFilters.js
+++ b/react/components/AvailableFilters.js
@@ -8,6 +8,7 @@ const AvailableFilters = ({
   filters = [],
   priceRange,
   preventRouteChange = false,
+  initiallyCollapsed = false,
 }) =>
   filters.map(filter => {
     const { type, title, facets, oneSelectedCollapse = false } = filter
@@ -31,6 +32,7 @@ const AvailableFilters = ({
             facets={facets}
             oneSelectedCollapse={oneSelectedCollapse}
             preventRouteChange={preventRouteChange}
+            initiallyCollapsed={initiallyCollapsed}
           />
         )
     }

--- a/react/components/FilterNavigator/legacy/index.js
+++ b/react/components/FilterNavigator/legacy/index.js
@@ -42,6 +42,7 @@ const FilterNavigator = ({
   loading = false,
   hiddenFacets = {},
   preventRouteChange = false,
+  initiallyCollapsed = false,
 }) => {
   const { isMobile } = useDevice()
 
@@ -117,6 +118,7 @@ const FilterNavigator = ({
         filters={filters}
         priceRange={priceRange}
         preventRouteChange={preventRouteChange}
+        initiallyCollapsed={initiallyCollapsed}
       />
     </div>
   )

--- a/react/components/FilterOptionTemplate.js
+++ b/react/components/FilterOptionTemplate.js
@@ -17,8 +17,9 @@ const FilterOptionTemplate = ({
   collapsable = true,
   children,
   filters,
+  initiallyCollapsed = false,
 }) => {
-  const [open, setOpen] = useState(true)
+  const [open, setOpen] = useState(!initiallyCollapsed)
 
   const renderChildren = () => {
     if (typeof children !== 'function') {
@@ -116,6 +117,7 @@ FilterOptionTemplate.propTypes = {
   collapsable: PropTypes.bool,
   /** Whether it represents the selected filters */
   selected: PropTypes.bool,
+  initiallyCollapsed: PropTypes.bool,
 }
 
 export default FilterOptionTemplate

--- a/react/components/SearchFilter.js
+++ b/react/components/SearchFilter.js
@@ -16,6 +16,7 @@ const SearchFilter = ({
   facets = [],
   intl,
   preventRouteChange = false,
+  initiallyCollapsed = false,
 }) => {
   const filtersWithSelected = useSelectedFilters(facets)
 
@@ -26,6 +27,7 @@ const SearchFilter = ({
       id={sampleFacet ? sampleFacet.map : null}
       title={getFilterTitle(title, intl)}
       filters={filtersWithSelected}
+      initiallyCollapsed={initiallyCollapsed}
     >
       {facet => (
         <FacetItem
@@ -47,6 +49,7 @@ SearchFilter.propTypes = {
   intl: intlShape.isRequired,
   /** Prevent route changes */
   preventRouteChange: PropTypes.boolean,
+  initiallyCollapsed: PropTypes.boolean,
 }
 
 export default injectIntl(SearchFilter)


### PR DESCRIPTION
#### What is the purpose of this pull request?
Adds prop `initiallyCollapsed` to `filter-navigators`, to make filters start out collapsed.

(This was requested by boticario)


<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

https://lbebber--alssports.myvtex.com/clothing/shirts/Mens?map=c,c,specificationFilter_7721


#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
