### PR TITLE
Trigger reload on price-range change and reset pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fix
+- Changes on price-range in the current search would not trigger a reload and would not provide any feedback to the user, resulting in bad UX.
+- If a change on price-range was made in a certain search-result page, the pagination would not reset.
 
 ## [3.34.0] - 2019-10-10
 ### Added

--- a/react/components/PriceRange.js
+++ b/react/components/PriceRange.js
@@ -13,7 +13,7 @@ const DEBOUNCE_TIME = 500 // ms
 
 /** Price range slider component */
 const PriceRange = ({ title, facets, intl, priceRange }) => {
-  const { culture, setQuery } = useRuntime()
+  const { culture, navigate } = useRuntime()
 
   const navigateTimeoutId = useRef()
 
@@ -23,7 +23,14 @@ const PriceRange = ({ title, facets, intl, priceRange }) => {
     }
 
     navigateTimeoutId.current = setTimeout(() => {
-      setQuery({ priceRange: `${left} TO ${right}`, page: undefined })
+      const urlParams = new URLSearchParams(window.location.search)
+      urlParams.set('priceRange', `${left} TO ${right}`)
+      urlParams.delete('page')
+
+      navigate({
+        to: window.location.pathname,
+        query: urlParams.toString(),
+      })
     }, DEBOUNCE_TIME)
   }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix undesired behavior regarding updates to the `price-range` in a `search-result` page. 

#### What problem is this solving?

- Changes in price-range in the current search would not trigger a reload and would not provide any feedback to the user, resulting in bad UX.
- If a change in price-range was made on a certain search-result page, the pagination would not reset.

#### How should this be manually tested?

Change the `price-range` and see that a reload is triggered and a new search is made.

https://loadingpricerange--storecomponents.myvtex.com/apparel---accessories

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
