### PR TITLE
Update itemsPerRow calculation on Gallery component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fix
+- Distribute space equally around products rendered by `Gallery` component when displaying less products than `maxItemsPerRow`.
 
 ## [3.35.1] - 2019-10-15
+### Fix
+- Changes on price-range in the current search would not trigger a reload and would not provide any feedback to the user, resulting in bad UX.
+- If a change on price-range was made in a certain search-result page, the pagination would not reset.
 
 ## [3.35.0] - 2019-10-11
 ### Added

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -30,12 +30,17 @@ const Gallery = ({
   showingFacets,
 }) => {
   const { isMobile } = useDevice()
+  const hasMultipleRows = products.length > maxItemsPerRow
 
   const layoutMode = isMobile ? mobileLayoutMode : 'normal'
 
   const getItemsPerRow = () => {
     const maxItems = Math.floor(width / minItemWidth)
-    return maxItemsPerRow <= maxItems ? maxItemsPerRow : maxItems
+    return hasMultipleRows
+      ? maxItemsPerRow <= maxItems
+        ? maxItemsPerRow
+        : maxItems
+      : products.length
   }
 
   const itemsPerRow =


### PR DESCRIPTION
#### What is the purpose of this pull request?

Check if the `Gallery` rendered by `SeachResult` has multiple rows.
If it doesn't, use the `products.length` value to determine how many items a row should have.

#### What problem is this solving?

This is necessary to distribute space equally around the items in the search-result grid.

#### How should this be manually tested?

This is an example with 2 products returned from a search:

https://searchresultfix--storecomponents.myvtex.com/apparel---accessories/bags/

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
