### PR TITLE
Fix/gallery products width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `product-summary` blocks rendered by `Gallery` would be stretched and result in a weird clickable area.
+
+### Added
+- New `maxItemWidth` prop to `Gallery` component.
 
 ## [3.35.3] - 2019-10-16
 ### Fixed

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -25,6 +25,7 @@ const Gallery = ({
   mobileLayoutMode = LAYOUT_MODE[0].value,
   maxItemsPerRow = 5,
   minItemWidth = 240,
+  maxItemWidth = 280,
   width,
   summary,
   showingFacets,
@@ -57,7 +58,7 @@ const Gallery = ({
 
   const galleryClasses = classNames(
     searchResult.gallery,
-    'flex flex-row flex-wrap items-stretch bn ph1 na4',
+    'flex flex-row flex-wrap justify-around items-stretch bn ph1 na4',
     {
       'justify-center': !showingFacets,
       'pl9-l': showingFacets,
@@ -69,6 +70,7 @@ const Gallery = ({
       {rows.map((rowProducts, index) => (
         <GalleryRow
           key={index.toString()}
+          maxItemWidth={maxItemWidth}
           widthAvailable={width != null}
           products={rowProducts}
           summary={summary}
@@ -94,6 +96,8 @@ Gallery.propTypes = {
   mobileLayoutMode: PropTypes.oneOf(pluck('value', LAYOUT_MODE)),
   /** Min Item Width. */
   minItemWidth: PropTypes.number,
+  /** Max Item Width. */
+  maxItemWidth: PropTypes.number,
   showingFacets: PropTypes.bool,
 }
 

--- a/react/__tests__/__snapshots__/Gallery.test.js.snap
+++ b/react/__tests__/__snapshots__/Gallery.test.js.snap
@@ -6,11 +6,11 @@ exports[`<OrderBy /> should match snapshot 1`] = `
     style="position: absolute; width: 0px; height: 0px; visibility: hidden; display: none;"
   />
   <div
-    class="gallery flex flex-row flex-wrap items-stretch bn ph1 na4 justify-center"
+    class="gallery flex flex-row flex-wrap justify-around items-stretch bn ph1 na4 justify-center"
   >
     <div
       class="galleryItem pa4"
-      style="flex-basis: 20%; max-width: 20%;"
+      style="flex-basis: 20%; max-width: 280px;"
     >
       <div>
          Extension Point: product-summary 
@@ -18,7 +18,7 @@ exports[`<OrderBy /> should match snapshot 1`] = `
     </div>
     <div
       class="galleryItem pa4"
-      style="flex-basis: 20%; max-width: 20%;"
+      style="flex-basis: 20%; max-width: 280px;"
     >
       <div>
          Extension Point: product-summary 
@@ -26,7 +26,7 @@ exports[`<OrderBy /> should match snapshot 1`] = `
     </div>
     <div
       class="galleryItem pa4"
-      style="flex-basis: 20%; max-width: 20%;"
+      style="flex-basis: 20%; max-width: 280px;"
     >
       <div>
          Extension Point: product-summary 
@@ -34,7 +34,7 @@ exports[`<OrderBy /> should match snapshot 1`] = `
     </div>
     <div
       class="galleryItem pa4"
-      style="flex-basis: 20%; max-width: 20%;"
+      style="flex-basis: 20%; max-width: 280px;"
     >
       <div>
          Extension Point: product-summary 
@@ -42,7 +42,7 @@ exports[`<OrderBy /> should match snapshot 1`] = `
     </div>
     <div
       class="galleryItem pa4"
-      style="flex-basis: 20%; max-width: 20%;"
+      style="flex-basis: 20%; max-width: 280px;"
     >
       <div>
          Extension Point: product-summary 
@@ -50,7 +50,7 @@ exports[`<OrderBy /> should match snapshot 1`] = `
     </div>
     <div
       class="galleryItem pa4"
-      style="flex-basis: 20%; max-width: 20%;"
+      style="flex-basis: 20%; max-width: 280px;"
     >
       <div>
          Extension Point: product-summary 
@@ -58,7 +58,7 @@ exports[`<OrderBy /> should match snapshot 1`] = `
     </div>
     <div
       class="galleryItem pa4"
-      style="flex-basis: 20%; max-width: 20%;"
+      style="flex-basis: 20%; max-width: 280px;"
     >
       <div>
          Extension Point: product-summary 
@@ -66,7 +66,7 @@ exports[`<OrderBy /> should match snapshot 1`] = `
     </div>
     <div
       class="galleryItem pa4"
-      style="flex-basis: 20%; max-width: 20%;"
+      style="flex-basis: 20%; max-width: 280px;"
     >
       <div>
          Extension Point: product-summary 

--- a/react/components/GalleryRow.js
+++ b/react/components/GalleryRow.js
@@ -50,6 +50,7 @@ const GalleryRow = ({
   rowIndex,
   widthAvailable,
   itemsPerRow,
+  maxItemWidth,
 }) => {
   const [ref, inView] = useInView({
     // inView will be true when at least 10% of the row is viewed by user
@@ -62,7 +63,7 @@ const GalleryRow = ({
   })
   const style = {
     flexBasis: `${100 / itemsPerRow}%`,
-    maxWidth: `${100 / itemsPerRow}%`,
+    maxWidth: `${maxItemWidth}px`,
   }
   return products.map(product => {
     return (


### PR DESCRIPTION
#### What is the purpose of this pull request?

- Fix a bug where `product-summary` blocks rendered by `Gallery` would be stretched and result in a weird clickable area.

- Add a new `maxItemWidth` prop to `Gallery` component.

#### How should this be manually tested?

https://lists--storecomponents.myvtex.com/apparel---accessories

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
