### PR TITLE
Fixed pagination with `setQuery`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - Search result pagination to work properly with `setQuery`.
-- Loading interface on flexible SR when an operation used `setQUery`.
+- Loading interface on flexible Search Result when an operation used `setQUery`.
 
 ## [3.35.4] - 2019-10-23
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - Search result pagination to work properly with `setQuery`.
+- Loading interface on flexible SR when an operation used `setQUery`.
 
 ## [3.35.4] - 2019-10-23
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Search result pagination to work properly with `setQuery`.
 
 ## [3.35.4] - 2019-10-23
 ### Fixed

--- a/react/FetchMore.js
+++ b/react/FetchMore.js
@@ -22,6 +22,7 @@ const FetchMore = () => {
     query: path(['variables', 'query'], searchQuery),
     map: path(['variables', 'map'], searchQuery),
     orderBy: path(['variables', 'orderBy'], searchQuery),
+    priceRange: path(['variables', 'priceRange'], searchQuery),
   }
 
   const { handleFetchMoreNext, loading, to } = useFetchMore(

--- a/react/FetchMore.js
+++ b/react/FetchMore.js
@@ -25,14 +25,14 @@ const FetchMore = () => {
     priceRange: path(['variables', 'priceRange'], searchQuery),
   }
 
-  const { handleFetchMoreNext, loading, to } = useFetchMore(
+  const { handleFetchMoreNext, loading, to } = useFetchMore({
     page,
     recordsFiltered,
     maxItemsPerPage,
     fetchMore,
     products,
-    queryData
-  )
+    queryData,
+  })
 
   const isShowMore = pagination === PAGINATION_TYPE.SHOW_MORE
 

--- a/react/FetchMore.js
+++ b/react/FetchMore.js
@@ -18,13 +18,19 @@ const FetchMore = () => {
     searchQuery
   )
   const fetchMore = path(['fetchMore'], searchQuery)
+  const queryData = {
+    query: path(['variables', 'query'], searchQuery),
+    map: path(['variables', 'map'], searchQuery),
+    orderBy: path(['variables', 'orderBy'], searchQuery),
+  }
 
   const { handleFetchMoreNext, loading, to } = useFetchMore(
     page,
     recordsFiltered,
     maxItemsPerPage,
     fetchMore,
-    products
+    products,
+    queryData
   )
 
   const isShowMore = pagination === PAGINATION_TYPE.SHOW_MORE

--- a/react/FetchPrevious.js
+++ b/react/FetchPrevious.js
@@ -23,14 +23,14 @@ const FetchPrevious = () => {
     priceRange: path(['variables', 'priceRange'], searchQuery),
   }
 
-  const { handleFetchMorePrevious, loading, from } = useFetchMore(
+  const { handleFetchMorePrevious, loading, from } = useFetchMore({
     page,
     recordsFiltered,
     maxItemsPerPage,
     fetchMore,
     products,
-    queryData
-  )
+    queryData,
+  })
 
   return (
     <div

--- a/react/FetchPrevious.js
+++ b/react/FetchPrevious.js
@@ -16,13 +16,19 @@ const FetchPrevious = () => {
   )
 
   const fetchMore = path(['fetchMore'], searchQuery)
+  const queryData = {
+    query: path(['variables', 'query'], searchQuery),
+    map: path(['variables', 'map'], searchQuery),
+    orderBy: path(['variables', 'orderBy'], searchQuery),
+  }
 
   const { handleFetchMorePrevious, loading, from } = useFetchMore(
     page,
     recordsFiltered,
     maxItemsPerPage,
     fetchMore,
-    products
+    products,
+    queryData
   )
 
   return (

--- a/react/FetchPrevious.js
+++ b/react/FetchPrevious.js
@@ -20,6 +20,7 @@ const FetchPrevious = () => {
     query: path(['variables', 'query'], searchQuery),
     map: path(['variables', 'map'], searchQuery),
     orderBy: path(['variables', 'orderBy'], searchQuery),
+    priceRange: path(['variables', 'priceRange'], searchQuery),
   }
 
   const { handleFetchMorePrevious, loading, from } = useFetchMore(

--- a/react/components/PriceRange.js
+++ b/react/components/PriceRange.js
@@ -13,7 +13,7 @@ const DEBOUNCE_TIME = 500 // ms
 
 /** Price range slider component */
 const PriceRange = ({ title, facets, intl, priceRange }) => {
-  const { culture, navigate } = useRuntime()
+  const { culture, setQuery } = useRuntime()
 
   const navigateTimeoutId = useRef()
 
@@ -23,14 +23,7 @@ const PriceRange = ({ title, facets, intl, priceRange }) => {
     }
 
     navigateTimeoutId.current = setTimeout(() => {
-      const urlParams = new URLSearchParams(window.location.search)
-      urlParams.set('priceRange', `${left} TO ${right}`)
-      urlParams.delete('page')
-
-      navigate({
-        to: window.location.pathname,
-        query: urlParams.toString(),
-      })
+      setQuery({ priceRange: `${left} TO ${right}`, page: undefined })
     }, DEBOUNCE_TIME)
   }
 

--- a/react/components/SearchResultContainer.js
+++ b/react/components/SearchResultContainer.js
@@ -26,12 +26,18 @@ const SearchResultContainer = props => {
         productSearch: { products = [], recordsFiltered, breadcrumb = [] } = {},
       } = {},
       loading,
-      variables: { query },
+      variables: { query, map, orderBy },
     },
     pagination,
     page,
     children,
   } = props
+
+  const queryData = {
+    query,
+    map,
+    orderBy,
+  }
 
   const {
     handleFetchMoreNext,
@@ -40,7 +46,14 @@ const SearchResultContainer = props => {
     from,
     to,
     infiniteScrollError,
-  } = useFetchMore(page, recordsFiltered, maxItemsPerPage, fetchMore, products)
+  } = useFetchMore(
+    page,
+    recordsFiltered,
+    maxItemsPerPage,
+    fetchMore,
+    products,
+    queryData
+  )
 
   const resultComponent = children || (
     <SearchResult

--- a/react/components/SearchResultContainer.js
+++ b/react/components/SearchResultContainer.js
@@ -26,7 +26,7 @@ const SearchResultContainer = props => {
         productSearch: { products = [], recordsFiltered, breadcrumb = [] } = {},
       } = {},
       loading,
-      variables: { query, map, orderBy },
+      variables: { query, map, orderBy, priceRange },
     },
     pagination,
     page,
@@ -37,6 +37,7 @@ const SearchResultContainer = props => {
     query,
     map,
     orderBy,
+    priceRange,
   }
 
   const {

--- a/react/components/SearchResultContainer.js
+++ b/react/components/SearchResultContainer.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import InfiniteScroll from 'react-infinite-scroll-component'
 
 import { PopupProvider } from './Popup'
@@ -7,6 +7,7 @@ import { searchResultContainerPropTypes } from '../constants/propTypes'
 import { useFetchMore } from '../hooks/useFetchMore'
 import { PAGINATION_TYPE } from '../constants/paginationType'
 import { Container } from 'vtex.store-components'
+import { useSearchPageStateDispatch } from 'vtex.search-page-context/SearchPageContext'
 
 /**
  * Search Result Container Component.
@@ -55,6 +56,12 @@ const SearchResultContainer = props => {
     products,
     queryData
   )
+
+  const dispatch = useSearchPageStateDispatch()
+
+  useEffect(() => {
+    dispatch({ type: 'SET_FETCHING_MORE', args: { isFetchingMore: loading } })
+  }, [loading, dispatch])
 
   const resultComponent = children || (
     <SearchResult

--- a/react/components/SearchResultContainer.js
+++ b/react/components/SearchResultContainer.js
@@ -40,7 +40,6 @@ const SearchResultContainer = props => {
     orderBy,
     priceRange,
   }
-
   const {
     handleFetchMoreNext,
     handleFetchMorePrevious,
@@ -48,14 +47,14 @@ const SearchResultContainer = props => {
     from,
     to,
     infiniteScrollError,
-  } = useFetchMore(
+  } = useFetchMore({
     page,
     recordsFiltered,
     maxItemsPerPage,
     fetchMore,
     products,
-    queryData
-  )
+    queryData,
+  })
 
   const dispatch = useSearchPageStateDispatch()
 

--- a/react/components/SelectionListItem.js
+++ b/react/components/SelectionListItem.js
@@ -4,22 +4,11 @@ import classNames from 'classnames'
 import searchResult from '../searchResult.css'
 
 const SelectionListItem = ({ option, onItemClick, selected }) => {
-  const { navigate } = useRuntime()
+  const { setQuery } = useRuntime()
 
   const handleOptionClick = () => {
     onItemClick()
-    const urlParams = new URLSearchParams(window.location.search)
-    urlParams.set('order', option.value)
-    urlParams.delete('page')
-    /* Ideally this should be a setQuery since it behaves better in terms of
-    UX and performance, but right now this is not possible because the setQuery
-    alone does not reset the values of useFetchMore, which causes a bug on the
-    fetch more/previous buttons behaviour.
-    */
-    navigate({
-      to: window.location.pathname,
-      query: urlParams.toString(),
-    })
+    setQuery({ order: option.value, page: undefined })
   }
 
   const highlight = selected ? 'bg-light-gray' : 'hover-bg-muted-5 bg-base'

--- a/react/hooks/useFacetNavigation.js
+++ b/react/hooks/useFacetNavigation.js
@@ -64,6 +64,7 @@ const useFacetNavigation = () => {
         setQuery({
           map: `${currentMap}`,
           query: `/${currentQuery}`,
+          page: undefined,
         })
         return
       }

--- a/react/hooks/useFetchMore.js
+++ b/react/hooks/useFetchMore.js
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from 'react'
+import { useState, useRef, useCallback, useEffect } from 'react'
 import { min, max } from 'ramda'
 import { useRuntime } from 'vtex.render-runtime'
 import {
@@ -107,7 +107,8 @@ export const useFetchMore = (
   recordsFiltered,
   maxItemsPerPage,
   fetchMore,
-  products
+  products,
+  queryData
 ) => {
   const { setQuery } = useRuntime()
   const [currentPage, setCurrentPage] = useState(page)
@@ -116,12 +117,24 @@ export const useFetchMore = (
   const [currentFrom, setCurrentFrom] = useState((page - 1) * maxItemsPerPage)
   const [currentTo, setCurrentTo] = useState(currentFrom + maxItemsPerPage - 1)
   const [loading, setLoading] = useFetchingMore()
+  const isFirstRender = useRef(true)
   const fetchMoreLocked = useRef(false) // prevents the user from sending two requests at once
   /* this is a temporary solution to deal with unexpected 
   errors when the search result uses infinite scroll. 
   This should be removed once infinite scrolling is removed */
   const [infiniteScrollError, setInfiniteScrollError] = useState(false)
   const updateQueryError = useRef(false) //TODO: refactor this ref
+
+  useEffect(() => {
+    if (!isFirstRender.current) {
+      setCurrentPage(1)
+      setNextPage(2)
+      setPreviousPage(0)
+      setCurrentFrom(0)
+      setCurrentTo(maxItemsPerPage - 1)
+    }
+    isFirstRender.current = false
+  }, [queryData.query, queryData.map, queryData.orderBy, maxItemsPerPage])
 
   const handleFetchMoreNext = async () => {
     const from = currentTo + 1

--- a/react/hooks/useFetchMore.js
+++ b/react/hooks/useFetchMore.js
@@ -102,14 +102,15 @@ const useFetchingMore = () => {
   return [stateValue, setFetchMore]
 }
 
-export const useFetchMore = (
-  page,
-  recordsFiltered,
-  maxItemsPerPage,
-  fetchMore,
-  products,
-  queryData
-) => {
+export const useFetchMore = props => {
+  const {
+    page,
+    recordsFiltered,
+    maxItemsPerPage,
+    fetchMore,
+    products,
+    queryData: { query, map, orderBy, priceRange },
+  } = props
   const { setQuery } = useRuntime()
   const [currentPage, setCurrentPage] = useState(page)
   const [nextPage, setNextPage] = useState(page + 1)
@@ -134,13 +135,7 @@ export const useFetchMore = (
       setCurrentTo(maxItemsPerPage - 1)
     }
     isFirstRender.current = false
-  }, [
-    queryData.query,
-    queryData.map,
-    queryData.orderBy,
-    queryData.priceRange,
-    maxItemsPerPage,
-  ])
+  }, [maxItemsPerPage, query, map, orderBy, priceRange])
 
   const handleFetchMoreNext = async () => {
     const from = currentTo + 1

--- a/react/hooks/useFetchMore.js
+++ b/react/hooks/useFetchMore.js
@@ -134,7 +134,13 @@ export const useFetchMore = (
       setCurrentTo(maxItemsPerPage - 1)
     }
     isFirstRender.current = false
-  }, [queryData.query, queryData.map, queryData.orderBy, maxItemsPerPage])
+  }, [
+    queryData.query,
+    queryData.map,
+    queryData.orderBy,
+    queryData.priceRange,
+    maxItemsPerPage,
+  ])
 
   const handleFetchMoreNext = async () => {
     const from = currentTo + 1


### PR DESCRIPTION
#### What is the purpose of this pull request?

Make the pagination work properly with `setQuery` and make `SelectedFilters` and `PriceRange` use `setQuery` again.

#### What problem is this solving?

Previously every time you changed the ordination type or the price range of a search result the page would have to be fully reloaded. This happened because the pagination in the search result wasn't behaving correctly with the smooth loading of the `setQuery`. This problem is now fixed!

This also fixes the loading behavior when using a setQuery. Previously, the loading spinner would not appear on flexible search result when the price range or ordination type changed.

#### How should this be manually tested?

[Workspace without flexible Search Result](https://iaronaraujo--alssports.myvtex.com/clothing/pants/Mens?map=c,c,specificationFilter_7721)
[Workspace with flexible Search Result](https://iaronaraujo--worldwidegolf.myvtex.com/apparel/Mens?map=c,specificationFilter_526)
[Workspace with price range](https://storecomponents.myvtex.com/apparel---accessories/clothing/)
- Go to page 2
- Reload the page
- Change the ordination type and check that you are back to page 1 with the correct items being displayed.


#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
