### PR TITLE
Refactored `useFetchMore`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Refactored `useFetchMore` to use `useReducer`.
 
 ## [3.35.5] - 2019-10-29
 ### Fixed

--- a/react/hooks/useFetchMore.js
+++ b/react/hooks/useFetchMore.js
@@ -12,7 +12,7 @@ export const FETCH_TYPE = {
 }
 
 function reducer(state, action) {
-  const { maxItemsPerPage, to, from } = action.args
+  const { maxItemsPerPage, to, from, rollbackState } = action.args
   switch (action.type) {
     case 'RESET':
       return {
@@ -38,9 +38,7 @@ function reducer(state, action) {
       }
 
     case 'ROLLBACK':
-      return {
-        ...state,
-      }
+      return rollbackState
   }
 }
 
@@ -170,6 +168,7 @@ export const useFetchMore = props => {
   }, [maxItemsPerPage, query, map, orderBy, priceRange])
 
   const handleFetchMoreNext = async () => {
+    const rollbackState = pageState
     const from = pageState.to + 1
     const to = min(recordsFiltered, from + maxItemsPerPage) - 1
     setInfiniteScrollError(false)
@@ -187,7 +186,7 @@ export const useFetchMore = props => {
     )
     //if error, rollback
     if (promiseResult && updateQueryError.current) {
-      pageDispatch({ type: 'ROLLBACK' })
+      pageDispatch({ type: 'ROLLBACK', args: { rollbackState } })
       setQuery({ page: pageState.page }, { replace: true })
       setInfiniteScrollError(true)
       updateQueryError.current = false
@@ -195,6 +194,7 @@ export const useFetchMore = props => {
   }
 
   const handleFetchMorePrevious = async () => {
+    const rollbackState = pageState
     const to = pageState.from - 1
     const from = max(0, to - maxItemsPerPage + 1)
     setInfiniteScrollError(false)
@@ -212,7 +212,7 @@ export const useFetchMore = props => {
     )
     //if error, rollback
     if (promiseResult && updateQueryError.current) {
-      pageDispatch({ type: 'ROLLBACK' })
+      pageDispatch({ type: 'ROLLBACK', args: { rollbackState } })
       setQuery({ page: pageState.page }, { replace: true, merge: true })
       setInfiniteScrollError(true)
       updateQueryError.current = false


### PR DESCRIPTION
#### What is the purpose of this pull request?

Previously every page related data had an `useState`. This PR refactors this logic to use an `useReducer` instead!

#### How should this be manually tested?

[Workspace](https://iaronaraujo--alssports.myvtex.com/clothing/pants?map=c,c&order=OrderByNameASC)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
