### PR TITLE
Revert grid items adjusting their width according to the number of products to show

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Revert changes made on v3.35.2: Distribute space equally around products rendered by `Gallery` component when displaying less products than `maxItemsPerRow`.
 
 ## [3.35.6] - 2019-10-30
 ### Changed

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -30,17 +30,12 @@ const Gallery = ({
   showingFacets,
 }) => {
   const { isMobile } = useDevice()
-  const hasMultipleRows = products.length > maxItemsPerRow
 
   const layoutMode = isMobile ? mobileLayoutMode : 'normal'
 
   const getItemsPerRow = () => {
     const maxItems = Math.floor(width / minItemWidth)
-    return hasMultipleRows
-      ? maxItemsPerRow <= maxItems
-        ? maxItemsPerRow
-        : maxItems
-      : products.length
+    return maxItemsPerRow <= maxItems ? maxItemsPerRow : maxItems
   }
 
   const itemsPerRow =


### PR DESCRIPTION
#### What is the purpose of this pull request?

Basically, revert what was done on https://github.com/vtex-apps/search-result/pull/254

#### What problem is this solving?

The layout was looking kind of weird, maybe we need a better solution for this.

#### How should this be manually tested?

https://searchresultlayoutfix--storecomponents.myvtex.com/apparel---accessories/shoes/

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
