### PR TITLE
Use custom distribution any time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for responsive values on `maxItemsPerRow` prop from `Gallery` component.
+
+### Fixed
+- Inverted icons on `LayoutModeSwitcher`.
 
 ## [3.38.0] - 2019-11-08
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -32,7 +32,8 @@
     "vtex.flex-layout": "0.x",
     "vtex.tab-layout": "0.x",
     "vtex.search-page-context": "0.x",
-    "vtex.blog-interfaces": "0.x"
+    "vtex.blog-interfaces": "0.x",
+    "vtex.responsive-values": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -5,9 +5,7 @@
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "scripts": {
     "postreleasy": "vtex publish --verbose"
   },

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -28,6 +28,7 @@ const Gallery = ({
   width,
   summary,
   showingFacets,
+  useDefaultDistribution = true
 }) => {
   const { isMobile } = useDevice()
 
@@ -38,7 +39,7 @@ const Gallery = ({
     return maxItemsPerRow <= maxItems ? maxItemsPerRow : maxItems
   }
 
-  const itemsPerRow =
+  const itemsPerRow = !useDefaultDistribution ? maxItemsPerRow :
     layoutMode === 'small'
       ? TWO_COLUMN_ITEMS
       : isMobile
@@ -90,6 +91,7 @@ Gallery.propTypes = {
   /** Min Item Width. */
   minItemWidth: PropTypes.number,
   showingFacets: PropTypes.bool,
+  useDefaultDistribution: PropTypes.bool
 }
 
 export default withResizeDetector(Gallery)

--- a/react/__mocks__/vtex.responsive-values.js
+++ b/react/__mocks__/vtex.responsive-values.js
@@ -1,0 +1,3 @@
+export function useResponsiveValue(values) {
+  return values.desktop
+}

--- a/react/__tests__/Gallery.test.js
+++ b/react/__tests__/Gallery.test.js
@@ -6,7 +6,7 @@ import { products, summary } from 'GalleryMocks'
 
 import Gallery from '../Gallery'
 
-describe('<OrderBy />', () => {
+describe('<Gallery />', () => {
   const renderComponent = customProps => {
     const props = {
       products,

--- a/react/__tests__/__snapshots__/Gallery.test.js.snap
+++ b/react/__tests__/__snapshots__/Gallery.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<OrderBy /> should match snapshot 1`] = `
+exports[`<Gallery /> should match snapshot 1`] = `
 <DocumentFragment>
   <div
     style="position: absolute; width: 0px; height: 0px; visibility: hidden; display: none;"

--- a/react/components/LayoutModeSwitcher.js
+++ b/react/components/LayoutModeSwitcher.js
@@ -25,11 +25,11 @@ export const LAYOUT_MODE = [
 const LayoutIcon = ({ mode }) => {
   switch (mode) {
     case 'small':
-      return <IconGrid size={20} />
+      return <IconSingleGrid size={20} />
     case 'inline':
       return <IconInlineGrid size={20} />
     case 'normal':
-      return <IconSingleGrid size={20} />
+      return <IconGrid size={20} />
     default: {
       // eslint-disable-next-line no-undef
       if (process.env.NODE_ENV === 'development') {


### PR DESCRIPTION
Variable creation to indicate if the default vtex distribution is used or if the distribution sent by the maxItemsPerRow field is always used

#### What is the purpose of this pull request?

Always be able to use the distribution indicated in the product gallery

#### What problem is this solving?

It is necessary that the distribution shown in the search-result is a defined one and not calculated according to the current screen

#### Screenshots or example usage

Send a property called useDefaultDistribution to always use the value of maxItemsPerRow

``` javascript
 return cloneElement(children, {
    maxItemsPerRow: dynamicDistribution,
    useDefaultDistribution: false
  });
```

`useDefaultDistribution` by default is true

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
