### PR TITLE
Removes facets arguments logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Removes facets args logic
 
 ## [3.38.2] - 2019-11-11
 ### Fixed

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -1,4 +1,3 @@
-import { zip, split, head, join, tail } from 'ramda'
 import { useMemo, useRef, useCallback } from 'react'
 import { useQuery } from 'react-apollo'
 import {
@@ -9,43 +8,8 @@ import {
 
 const DEFAULT_PAGE = 1
 
-const QUERY_SEPARATOR = '/'
-const MAP_SEPARATOR = ','
-
-const splitQuery = split(QUERY_SEPARATOR)
-const splitMap = split(MAP_SEPARATOR)
-const joinQuery = join(QUERY_SEPARATOR)
-const joinMap = join(MAP_SEPARATOR)
-
 const includeFacets = (map, query) =>
   !!(map && map.length > 0 && query && query.length > 0)
-
-const useFacetsArgs = (query, map) => {
-  return useMemo(() => {
-    const queryArray = splitQuery(query)
-    const mapArray = splitMap(map)
-    const queryAndMap = zip(queryArray, mapArray)
-    const relevantArgs = [
-      head(queryAndMap),
-      ...tail(queryAndMap).filter(
-        ([_, tupleMap]) => tupleMap === 'c' || tupleMap === 'ft'
-      ),
-    ]
-    const finalMap = []
-    const finalQuery = []
-    relevantArgs.forEach(([tupleQuery, tupleMap]) => {
-      finalQuery.push(tupleQuery)
-      finalMap.push(tupleMap)
-    })
-    const facetQuery = joinQuery(finalQuery)
-    const facetMap = joinMap(finalMap)
-    return {
-      facetQuery,
-      facetMap,
-      withFacets: includeFacets(facetMap, facetQuery),
-    }
-  }, [map, query])
-}
 
 const useCombinedRefetch = (productRefetch, facetsRefetch) => {
   return useCallback(
@@ -167,7 +131,11 @@ const SearchQuery = ({
   const from = (page - 1) * maxItemsPerPage
   const to = from + maxItemsPerPage - 1
 
-  const facetsArgs = useFacetsArgs(query, map)
+  const facetsArgs = {
+    facetQuery: query,
+    facetMap: map,
+    withFacets: includeFacets(map, query),
+  }
   const variables = useMemo(() => {
     return {
       query,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Since the logic to filter the facets arguments should be made for every facets query, we moved it to the resolver in `search-graphql` (https://github.com/vtex-apps/search-graphql/pull/23)

#### What problem is this solving?

#### How should this be manually tested?

https://facetslogic2--storecomponents.myvtex.com/apparel---accessories/clothing/

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
