### PR TITLE
Fixed fetch more buttons on edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `Show More` and `Show Previous` buttons vanishing before the results of the first or last pages were loaded.
 
 ## [3.35.7] - 2019-10-30
 ### Fixed

--- a/react/components/loaders/FetchMoreButton.js
+++ b/react/components/loaders/FetchMoreButton.js
@@ -4,6 +4,19 @@ import { FormattedMessage } from 'react-intl'
 
 import searchResult from '../../searchResult.css'
 
+const useShowButton = (to, products, loading, recordsFiltered) => {
+  const [showButton, setShowButton] = useState(
+    !!products && to + 1 < recordsFiltered
+  )
+  useEffect(() => {
+    if (!loading) {
+      setShowButton(!!products && to + 1 < recordsFiltered)
+    }
+  }, [to, products, loading, recordsFiltered])
+
+  return showButton
+}
+
 const FetchMoreButton = props => {
   const {
     products,
@@ -13,15 +26,7 @@ const FetchMoreButton = props => {
     loading,
     showProductsCount,
   } = props
-
-  const [showButton, setShowButton] = useState(
-    !!products && to + 1 < recordsFiltered
-  )
-  useEffect(() => {
-    if (!loading) {
-      setShowButton(!!products && to + 1 < recordsFiltered)
-    }
-  }, [to, products, loading, recordsFiltered])
+  const showButton = useShowButton(to, products, loading, recordsFiltered)
 
   return (
     <Fragment>

--- a/react/components/loaders/FetchMoreButton.js
+++ b/react/components/loaders/FetchMoreButton.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React, { Fragment, useState, useEffect } from 'react'
 import { Button } from 'vtex.styleguide'
 import { FormattedMessage } from 'react-intl'
 
@@ -14,12 +14,21 @@ const FetchMoreButton = props => {
     showProductsCount,
   } = props
 
+  const [showButton, setShowButton] = useState(
+    !!products && to + 1 < recordsFiltered
+  )
+  useEffect(() => {
+    if (!loading) {
+      setShowButton(!!products && to + 1 < recordsFiltered)
+    }
+  }, [to, products, loading, recordsFiltered])
+
   return (
     <Fragment>
       <div
         className={`${searchResult.buttonShowMore} w-100 flex justify-center`}
       >
-        {!!products && to + 1 < recordsFiltered && (
+        {showButton && (
           <Button onClick={onFetchMore} isLoading={loading} size="small">
             <FormattedMessage id="store/search-result.show-more-button" />
           </Button>

--- a/react/components/loaders/FetchPreviousButton.js
+++ b/react/components/loaders/FetchPreviousButton.js
@@ -4,8 +4,7 @@ import { FormattedMessage } from 'react-intl'
 
 import searchResult from '../../searchResult.css'
 
-const FetchPreviousButton = props => {
-  const { products, from, onFetchPrevious, loading } = props
+const useShowButton = (from, products, loading) => {
   const [showButton, setShowButton] = useState(
     !!products && from > 0 && products.length > 0
   )
@@ -14,6 +13,13 @@ const FetchPreviousButton = props => {
       setShowButton(!!products && from > 0 && products.length > 0)
     }
   }, [from, products, loading])
+
+  return showButton
+}
+
+const FetchPreviousButton = props => {
+  const { products, from, onFetchPrevious, loading } = props
+  const showButton = useShowButton(from, products, loading)
   return (
     <div className={`${searchResult.buttonShowMore} w-100 flex justify-center`}>
       {showButton && (

--- a/react/components/loaders/FetchPreviousButton.js
+++ b/react/components/loaders/FetchPreviousButton.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import { Button } from 'vtex.styleguide'
 import { FormattedMessage } from 'react-intl'
 
@@ -6,9 +6,17 @@ import searchResult from '../../searchResult.css'
 
 const FetchPreviousButton = props => {
   const { products, from, onFetchPrevious, loading } = props
+  const [showButton, setShowButton] = useState(
+    !!products && from > 0 && products.length > 0
+  )
+  useEffect(() => {
+    if (!loading) {
+      setShowButton(!!products && from > 0 && products.length > 0)
+    }
+  }, [from, products, loading])
   return (
     <div className={`${searchResult.buttonShowMore} w-100 flex justify-center`}>
-      {!!products && from > 0 && products.length > 0 && (
+      {showButton && (
         <Button onClick={onFetchPrevious} isLoading={loading} size="small">
           <FormattedMessage id="store/search-result.show-previous-button" />
         </Button>


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fixed `Show More` and `Show Previous` buttons vanishing before the results of the first or last pages were loaded.

#### How should this be manually tested?
 [Workspace](https://iaronaraujo--alssports.myvtex.com/clothing/Boys/jackets?map=c,specificationFilter_7721,c&page=1) - press the `Show More` and see that it will only disappear after the next page result is rendered.

[Workspace](https://iaronaraujo--alssports.myvtex.com/clothing/pants/Mens?map=c,c,specificationFilter_7721&page=2) - press the `Show Previous` and see that it will only disappear after the next page result is rendered.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
