### PR TITLE
Feat/separate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Separate product search query from facets query.
 
 ## [3.35.9] - 2019-10-31
 ### Changed

--- a/react/FilterNavigatorFlexible.js
+++ b/react/FilterNavigatorFlexible.js
@@ -17,6 +17,7 @@ const withSearchPageContextProps = Component => () => {
     showFacets,
     showContentLoader,
     preventRouteChange,
+    facetsLoading,
   } = useSearchPage()
 
   const facets = pathOr({}, ['data', 'facets'], searchQuery)
@@ -25,6 +26,8 @@ const withSearchPageContextProps = Component => () => {
   if (showFacets === false || !map) {
     return null
   }
+
+  console.log('teste facetsLoading FLEX', facetsLoading)
 
   return (
     <div className={styles['filters--layout']}>
@@ -36,7 +39,7 @@ const withSearchPageContextProps = Component => () => {
         priceRanges={priceRanges}
         specificationFilters={specificationFilters}
         tree={categoriesTrees}
-        loading={showContentLoader}
+        loading={facetsLoading && showContentLoader}
         filters={filters}
         hiddenFacets={hiddenFacets}
       />

--- a/react/FilterNavigatorFlexible.js
+++ b/react/FilterNavigatorFlexible.js
@@ -27,8 +27,6 @@ const withSearchPageContextProps = Component => () => {
     return null
   }
 
-  console.log('teste facetsLoading FLEX', facetsLoading)
-
   return (
     <div className={styles['filters--layout']}>
       <Component

--- a/react/SearchResultFlexible.js
+++ b/react/SearchResultFlexible.js
@@ -52,9 +52,7 @@ const SearchResultFlexible = ({
   orderBy,
   page,
   facetsLoading,
-  // ...rest
 }) => {
-  // console.log('teste rest: ', rest)
   //This makes infinite scroll unavailable.
   //Infinite scroll was deprecated and we have
   //removed it since the flexible search release

--- a/react/SearchResultFlexible.js
+++ b/react/SearchResultFlexible.js
@@ -51,7 +51,10 @@ const SearchResultFlexible = ({
   priceRange,
   orderBy,
   page,
+  facetsLoading,
+  // ...rest
 }) => {
+  // console.log('teste rest: ', rest)
   //This makes infinite scroll unavailable.
   //Infinite scroll was deprecated and we have
   //removed it since the flexible search release
@@ -114,6 +117,7 @@ const SearchResultFlexible = ({
       filters,
       showProductsCount,
       preventRouteChange,
+      facetsLoading,
     }),
     [
       hiddenFacets,
@@ -130,6 +134,7 @@ const SearchResultFlexible = ({
       filters,
       showProductsCount,
       preventRouteChange,
+      facetsLoading,
     ]
   )
 
@@ -152,6 +157,7 @@ const SearchResultFlexible = ({
               hiddenFacets={hiddenFacets}
               orderBy={orderBy}
               page={page}
+              facetsLoading={facetsLoading}
             >
               {
                 <LoadingOverlay loading={state.isFetchingMore}>

--- a/react/components/LocalQuery.js
+++ b/react/components/LocalQuery.js
@@ -63,6 +63,7 @@ const LocalQuery = props => {
           page: extraParams.page,
           from: extraParams.from,
           to: extraParams.to,
+          facetsLoading: extraParams.facetsLoading,
           maxItemsPerPage,
         })
       }}

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -74,7 +74,7 @@ const useCombinedRefetch = (productRefetch, facetsRefetch) => {
       return {
         ...searchRefetchResult,
         data: {
-          ...searchRefetchResult.data,
+          ...(searchRefetchResult.data || {}),
           facets: facetsRefetchResult.data && facetsRefetchResult.data.facets,
         },
         errors: searchRefetchResult.errors || facetsRefetchResult.errors,

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -7,6 +7,8 @@ import {
   facets as facetsQuery,
 } from 'vtex.store-resources/Queries'
 
+console.log('teste facetsQuery:', facetsQuery)
+
 const DEFAULT_PAGE = 1
 
 const QUERY_SEPARATOR = '/'
@@ -130,7 +132,8 @@ const useQueries = (variables, facetsArgs) => {
   const refetch = useCombinedRefetch(searchRefetch, facetsRefetch)
 
   return {
-    loading: searchLoading || facetsLoading,
+    loading: searchLoading,
+    facetsLoading,
     data: {
       productSearch:
         productSearchResult.data && productSearchResult.data.productSearch,
@@ -178,19 +181,24 @@ const SearchQuery = ({
       withFacets: false,
     }
   }, [query, map, orderBy, priceRange, from, to, hideUnavailableItems])
+
+  const {
+    data,
+    loading,
+    refetch,
+    productSearchResult,
+    facetsLoading,
+  } = useQueries(variables, facetsArgs)
+
   const extraParams = useMemo(() => {
     return {
       ...variables,
       ...facetsArgs,
       maxItemsPerPage,
       page,
+      facetsLoading,
     }
-  }, [variables, facetsArgs, maxItemsPerPage, page])
-
-  const { data, loading, refetch, productSearchResult } = useQueries(
-    variables,
-    facetsArgs
-  )
+  }, [variables, facetsArgs, maxItemsPerPage, page, facetsLoading])
 
   const searchInfo = useMemo(
     () => ({

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -7,8 +7,6 @@ import {
   facets as facetsQuery,
 } from 'vtex.store-resources/Queries'
 
-console.log('teste facetsQuery:', facetsQuery)
-
 const DEFAULT_PAGE = 1
 
 const QUERY_SEPARATOR = '/'

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -132,7 +132,10 @@ class SearchResult extends Component {
       isMobile,
       pagination,
       infiniteScrollError,
+      facetsLoading,
     } = this.props
+
+    console.log('teste facetsLoading:', facetsLoading)
     const {
       mobileLayoutMode,
       recordsFiltered,
@@ -150,6 +153,7 @@ class SearchResult extends Component {
 
     const hideFacets = !map || !map.length
     const showLoading = loading && !fetchMoreLoading
+    const showFacetsContentLoader = facetsLoading && !fetchMoreLoading
     const showContentLoader = showLoading && !showLoadingAsOverlay
     const shouldDisplayLayoutSwitcher = !!mobileLayout.mode2
 
@@ -197,7 +201,7 @@ class SearchResult extends Component {
                 priceRanges={priceRanges}
                 specificationFilters={specificationFilters}
                 tree={tree}
-                loading={showContentLoader}
+                loading={showFacetsContentLoader}
                 filters={filters}
                 hiddenFacets={hiddenFacets}
               />

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -135,7 +135,6 @@ class SearchResult extends Component {
       facetsLoading,
     } = this.props
 
-    console.log('teste facetsLoading:', facetsLoading)
     const {
       mobileLayoutMode,
       recordsFiltered,

--- a/react/components/SearchResultContainer.js
+++ b/react/components/SearchResultContainer.js
@@ -34,8 +34,6 @@ const SearchResultContainer = props => {
     children,
   } = props
 
-  console.log('teste props: ', props)
-
   const queryData = {
     query,
     map,

--- a/react/components/SearchResultContainer.js
+++ b/react/components/SearchResultContainer.js
@@ -34,6 +34,8 @@ const SearchResultContainer = props => {
     children,
   } = props
 
+  console.log('teste props: ', props)
+
   const queryData = {
     query,
     map,


### PR DESCRIPTION
Separate facets and product search query.
Make filter navigator only show loader while facet is loading

#### How should this be manually tested?

https://facets--alssports.myvtex.com/clothing/swimwear/Womens?map=c,c,specificationFilter_7721
https://facets--storecomponents.myvtex.com/apparel---accessories/shoes/

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
