### PR TITLE
Feature query without simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Makes productSearch query without simulation if quickSearch is enabled
 
 ## [3.35.9] - 2019-10-31
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "3.35.9",
+  "version": "3.35.10-beta.0",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -133,7 +133,11 @@ const SearchQuery = ({
     variables,
   })
 
-  if (quickSearch && productSearchNoSimulationsResult.data) {
+  if (
+    quickSearch &&
+    productSearchNoSimulationsResult.data &&
+    productSearchResult.data
+  ) {
     productSearchResult.data.productSearch = {
       ...productSearchResult.data.productSearch,
       breadcrumb: path(
@@ -152,8 +156,9 @@ const SearchQuery = ({
 
   const searchInfo = useMemo(
     () => ({
-      ...(productSearchResult || {}),
-      ...(productSearchNoSimulationsResult || {}),
+      ...(quickSearch
+        ? productSearchNoSimulationsResult || {}
+        : productSearchResult || {}),
       data: {
         productSearch:
           path(['data', 'productSearch'], productSearchResult) ||
@@ -165,7 +170,12 @@ const SearchQuery = ({
         searchMetadata,
       },
     }),
-    [productSearchResult, searchMetadata, productSearchNoSimulationsResult]
+    [
+      productSearchResult,
+      searchMetadata,
+      productSearchNoSimulationsResult,
+      quickSearch,
+    ]
   )
 
   return children(searchInfo, extraParams)

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -1,4 +1,4 @@
-import { zip, split, head, join, tail } from 'ramda'
+import { path, zip, split, head, join, tail } from 'ramda'
 import { useMemo, useRef } from 'react'
 import { useQuery } from 'react-apollo'
 import {
@@ -98,6 +98,7 @@ const SearchQuery = ({
       to,
       hideUnavailableItems,
       ...facetsArgs,
+      skipBreadcrumbs: quickSearch,
     }
   }, [
     query,
@@ -108,6 +109,7 @@ const SearchQuery = ({
     to,
     hideUnavailableItems,
     facetsArgs,
+    quickSearch,
   ])
   const extraParams = useMemo(() => {
     return {
@@ -130,6 +132,16 @@ const SearchQuery = ({
     ssr: false,
     variables,
   })
+
+  if (quickSearch && productSearchNoSimulationsResult.data) {
+    productSearchResult.data.productSearch = {
+      ...productSearchResult.data.productSearch,
+      breadcrumb: path(
+        ['data', 'productSearchNoSimulations', 'breadcrumb'],
+        productSearchNoSimulationsResult
+      ),
+    }
+  }
 
   const { data: { searchMetadata } = {} } = useQuery(searchMetadataQuery, {
     variables: {

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -3,8 +3,8 @@ import { useMemo, useRef } from 'react'
 import { useQuery } from 'react-apollo'
 import {
   productSearchV2 as productSearchQuery,
-  productSearchNoSimulations,
   searchMetadata as searchMetadataQuery,
+  productSearchNoSimulations,
 } from 'vtex.store-resources/Queries'
 
 const DEFAULT_PAGE = 1
@@ -140,26 +140,19 @@ const SearchQuery = ({
 
   const searchInfo = useMemo(
     () => ({
-      ...(productSearchNoSimulationsResult || {}),
       ...(productSearchResult || {}),
+      ...(productSearchNoSimulationsResult || {}),
       data: {
         productSearch:
-          productSearchResult.data && productSearchResult.data.productSearch,
+          (productSearchResult.data &&
+            productSearchResult.data.productSearch) ||
+          (productSearchNoSimulationsResult.data &&
+            productSearchNoSimulationsResult.data),
         facets: productSearchResult.data && productSearchResult.data.facets,
         searchMetadata,
-        simulated: !!(
-          quickSearch &&
-          productSearchNoSimulationsResult.data &&
-          !productSearchResult.data
-        ),
       },
     }),
-    [
-      productSearchResult,
-      searchMetadata,
-      productSearchNoSimulationsResult,
-      quickSearch,
-    ]
+    [productSearchResult, searchMetadata, productSearchNoSimulationsResult]
   )
 
   return children(searchInfo, extraParams)

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -157,7 +157,10 @@ const SearchQuery = ({
       data: {
         productSearch:
           path(['data', 'productSearch'], productSearchResult) ||
-          path(['data', 'productSearchNoSimulations'], productSearchResult),
+          path(
+            ['data', 'productSearchNoSimulations'],
+            productSearchNoSimulationsResult
+          ),
         facets: productSearchResult.data && productSearchResult.data.facets,
         searchMetadata,
       },

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -156,10 +156,8 @@ const SearchQuery = ({
       ...(productSearchNoSimulationsResult || {}),
       data: {
         productSearch:
-          (productSearchResult.data &&
-            productSearchResult.data.productSearch) ||
-          (productSearchNoSimulationsResult.data &&
-            productSearchNoSimulationsResult.data),
+          path(['data', 'productSearch'], productSearchResult) ||
+          path(['data', 'productSearchNoSimulations'], productSearchResult),
         facets: productSearchResult.data && productSearchResult.data.facets,
         searchMetadata,
       },


### PR DESCRIPTION
#### What is the purpose of this pull request?

Makes productSearch query without simulation if `quickSearch` is enabled

#### What problem is this solving?

Improves performance, since simulations take too long.

#### How should this be manually tested?

Workspace with changes but not quickSearch:
https://querynosim--storecomponents.myvtex.com/apparel---accessories/clothing/

Workspace with changes and quickSearch:
https://querynosim2--storecomponents.myvtex.com/apparel---accessories/clothing/


#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
