### PR TITLE
Revert change to default value of `minItemWidth` prop on Gallery component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Default value for `minItemWidth` prop should be `240`.
 
 ## [3.39.0] - 2019-11-12
 ### Added

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -27,7 +27,7 @@ const Gallery = ({
     tablet: 3,
     phone: 2,
   },
-  minItemWidth = 170,
+  minItemWidth = 240,
   width,
   summary,
   showingFacets,


### PR DESCRIPTION
#### What is the purpose of this pull request?

Revert change to default value of `minItemWidth` prop on Gallery component back to 240px.

#### What problem is this solving?

The change in default value caused some layout issues.

#### How should this be manually tested?

[Workspace](https://searchresult--gama.myvtex.com/productos/cuidados-del-cabello)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
