### PR TITLE
Update logic to calculate itemsPerRow on Gallery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Mininum of items to be displayed on `small` mobile layout mode should be 2, and always 1 when on `normal` mode.
 
 ## [3.39.1] - 2019-11-13
 ### Fixed

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -58,7 +58,7 @@ const Gallery = ({
       : maxItemsPerMinWidth
   }
 
-  const itemsPerRow = getItemsPerRow() || ONE_COLUMN_LAYOUT
+  const itemsPerRow = getItemsPerRow() || responsiveMaxItemsPerRow
 
   const rows = useMemo(() => splitEvery(itemsPerRow, products), [
     itemsPerRow,

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -38,18 +38,27 @@ const Gallery = ({
   const layoutMode = isMobile ? mobileLayoutMode : 'normal'
 
   const getItemsPerRow = () => {
-    const maxItems = Math.floor(width / minItemWidth)
-    return responsiveMaxItemsPerRow <= maxItems
+    const maxItemsPerMinWidth = Math.floor(width / minItemWidth)
+
+    if (isMobile) {
+      if (layoutMode === 'normal') {
+        return ONE_COLUMN_LAYOUT
+      }
+
+      const maxItemsOnMobile =
+        maxItemsPerMinWidth >= 2 ? maxItemsPerMinWidth : 2
+
+      return responsiveMaxItemsPerRow <= maxItemsOnMobile
+        ? responsiveMaxItemsPerRow
+        : maxItemsOnMobile
+    }
+
+    return responsiveMaxItemsPerRow <= maxItemsPerMinWidth
       ? responsiveMaxItemsPerRow
-      : maxItems
+      : maxItemsPerMinWidth
   }
 
-  const itemsPerRow =
-    (layoutMode === 'small'
-      ? getItemsPerRow()
-      : isMobile
-      ? ONE_COLUMN_LAYOUT
-      : getItemsPerRow()) || responsiveMaxItemsPerRow
+  const itemsPerRow = getItemsPerRow() || ONE_COLUMN_LAYOUT
 
   const rows = useMemo(() => splitEvery(itemsPerRow, products), [
     itemsPerRow,


### PR DESCRIPTION
#### What is the purpose of this pull request?

Update the logic being used to calculate `itemsPerRow` on the Gallery component, and also make sure that `small` layout mode **always** renders at least 2 items.

#### How should this be manually tested?

[Workspace](https://searchresultfix--alssports.myvtex.com/sea%20to%20summit%20comfort%20plus?_q=Sea%20to%20Summit%20Comfort%20Plus&map=ft)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
