### PR TITLE
fix custom query fetch more button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fetch More button problem on `CustomQuery`.
 
 ## [3.38.2] - 2019-11-11
 ### Fixed

--- a/react/SearchResultLayoutCustomQuery.js
+++ b/react/SearchResultLayoutCustomQuery.js
@@ -34,6 +34,7 @@ const ExtensionPointWithProps = ({ id, parentProps, localSearchQueryData }) => (
     params={localSearchQueryData.params}
     priceRange={localSearchQueryData.priceRange}
     orderBy={localSearchQueryData.orderBy}
+    page={localSearchQueryData.page}
   />
 )
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says. Fixes this https://github.com/vtex-apps/store-discussion/issues/149

Before the fix:
![image](https://user-images.githubusercontent.com/8443580/69190256-ca496500-0afe-11ea-9b01-b56dd91e30fc.png)

After:
![image](https://user-images.githubusercontent.com/8443580/69190280-d6cdbd80-0afe-11ea-91e8-79622f2c4f53.png)


#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://iaronaraujo--paguemenos.myvtex.com/ofertas)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
