### PR TITLE
Allow search-bar on search-not-found-layout block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+ - The `search-bar` on whitelist in the `search-not-found-layout`
+
 ## [3.39.3] - 2019-11-19
 ### Fixed
 - Fetch More button problem on `CustomQuery`.

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -123,7 +123,8 @@
       "rich-text",
       "info-card",
       "flex-layout",
-      "not-found"
+      "not-found",
+      "search-bar"
     ],
     "composition": "children",
     "component": "NotFoundLayout"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Allow search-bar on search-not-found-layout block

#### What problem is this solving?
Allow search bar in stores that want search bar on page not found

<!--- What is the motivation and context for this change? -->
I'm creating a theme for the pentru animale store, I'm replicating the current site for vtex io.
Not found page: https://pentruanimale.ro/produse?c=aoijdhaoad
#### How should this be manually tested?
Link this code and add search-bar in your theme on search-not-found-layout block

#### Screenshots or example usage
```
"search-not-found-layout": {
    "children": ["flex-layout.row#searchbread", "flex-layout.row#notfound"]
  },

  "flex-layout.row#notfound": {
    "children": ["flex-layout.col#not-found-tips", "search-bar"], // Put the search-bar here when allow search-bar in search-result-layout
    "props": {
      "blockClass": "not-found"
    }
  }
```

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [X] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
