### PR TITLE
Clicking on `Apply` now closes mobile filter sidebar.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Clicking on the `Apply` button on the filter side bar on mobile now closes the sidebar.
 
 ## [3.39.4] - 2019-11-21
 ### Added

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -55,6 +55,7 @@ const FilterSidebar = ({ filters, tree, priceRange, preventRouteChange }) => {
 
   const handleApply = () => {
     navigateToFacet(filterOperations, preventRouteChange)
+    setOpen(false)
   }
 
   const handleUpdateCategories = maybeCategories => {


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says

#### How should this be manually tested?

[Workspace](https://iaronaraujo--storecomponents.myvtex.com/top?_q=top&map=ft)
Go on mobile, click on the filters, select a brand filter, click on apply and notice that the sidebar closed.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
