### PR TITLE
Blocks mobile validation of filter-navigator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Add a new props to `filter-navigator.v3` blocks the mobile validation
 
 ## [3.39.10] - 2019-12-23
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Add a new props to `filter-navigator.v3` blocks the mobile validation
+### Added
+- New prop `layout` to `filter-navigator.v3`.
+- Allow `drawer` on `search-result-layout.mobile`.
 
 ## [3.39.10] - 2019-12-23
 ### Changed

--- a/docs/README.md
+++ b/docs/README.md
@@ -423,6 +423,7 @@ Notice that the default behavior for your store will be the one defined by the `
 | `preventRouteChange`  | `Boolean` | Prevents route change when selecting filters, using the query string instead. Intended for `search-result` blocks inserted on custom pages with static routes. | `false`       |
 | `initiallyCollapsed`  | `Boolean` | Makes the search filters start out collapsed.                                                                                                                  | `false`       |
 | `alwaysOnDesktopView` | `Boolean` | Block filter's layout mode on Desktop.                                                                                                                         | `false`       |
+
 ##### `filter-navigator.v3` block
 
 | Prop name             | Type      | Description                            | Default value |

--- a/docs/README.md
+++ b/docs/README.md
@@ -370,11 +370,11 @@ These properties can be changed in the `blocks.json` file of your theme.
 | `skusFilter`           | `SkusFilterEnum` | Control SKUs returned for each product in the query. The less SKUs needed to be returned, the more performant your shelf query will be.                                                               | `"ALL_AVAILABLE"` |
 
 `SkusFilterEnum`:
-| Name | Value | Description |
-| ---- | ----- | ----------- |
+| Name            | Value             | Description                                                                                                                                            |
+| --------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | First Available | `FIRST_AVAILABLE` | Most performant, ideal if you do not have a SKU selector in your shelf. Will return only the first available SKU for that product in your shelf query. |
-| All Available | `ALL_AVAILABLE` | A bit better performace, will only return SKUs that are available, ideal if you have a SKU selector but still want a better performance. |
-| All | `ALL` | Returns all SKUs related to that product, least performant option. |
+| All Available   | `ALL_AVAILABLE`   | A bit better performace, will only return SKUs that are available, ideal if you have a SKU selector but still want a better performance.               |
+| All             | `ALL`             | Returns all SKUs related to that product, least performant option.                                                                                     |
 
 ##### HiddenFacets
 
@@ -422,6 +422,11 @@ Notice that the default behavior for your store will be the one defined by the `
 | -------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
 | `preventRouteChange` | `Boolean` | Prevents route change when selecting filters, using the query string instead. Intended for `search-result` blocks inserted on custom pages with static routes. | `false`       |
 | `initiallyCollapsed` | `Boolean` | Makes the search filters start out collapsed.                                                                                                                  | `false`       |
+##### `filter-navigator.v3` block
+
+| Prop name             | Type      | Description                            | Default value |
+| --------------------- | --------- | -------------------------------------- | ------------- |
+| `alwaysOnDesktopView` | `Boolean` | Block filter's layout mode on Desktop. | `false`       |
 
 Also, you can configure the product summary that is defined on search-result. See [here](https://github.com/vtex-apps/product-summary/blob/master/README.md#configuration) the Product Summary API.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -418,10 +418,11 @@ Notice that the default behavior for your store will be the one defined by the `
 
 ##### `filter-navigator.v2` block
 
-| Prop name            | Type      | Description                                                                                                                                                    | Default value |
-| -------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `preventRouteChange` | `Boolean` | Prevents route change when selecting filters, using the query string instead. Intended for `search-result` blocks inserted on custom pages with static routes. | `false`       |
-| `initiallyCollapsed` | `Boolean` | Makes the search filters start out collapsed.                                                                                                                  | `false`       |
+| Prop name             | Type      | Description                                                                                                                                                    | Default value |
+| --------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `preventRouteChange`  | `Boolean` | Prevents route change when selecting filters, using the query string instead. Intended for `search-result` blocks inserted on custom pages with static routes. | `false`       |
+| `initiallyCollapsed`  | `Boolean` | Makes the search filters start out collapsed.                                                                                                                  | `false`       |
+| `alwaysOnDesktopView` | `Boolean` | Block filter's layout mode on Desktop.                                                                                                                         | `false`       |
 ##### `filter-navigator.v3` block
 
 | Prop name             | Type      | Description                            | Default value |

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://api.travis-ci.org/vtex-apps/search-result.svg?branch=master)](https://travis-ci.org/vtex-apps/search-result) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)<!-- ALL-CONTRIBUTORS-BADGE:END -->
 
-
 ## Description
 
 The VTEX Search Result app is a store component that handles with the result of our [_Search API_](https://documenter.getpostman.com/view/845/vtex-search-api/Hs43#8b71745e-00f9-6c98-b776-f4468ecb7a5e), and this app is used by store theme.
@@ -370,11 +369,11 @@ These properties can be changed in the `blocks.json` file of your theme.
 | `skusFilter`           | `SkusFilterEnum` | Control SKUs returned for each product in the query. The less SKUs needed to be returned, the more performant your shelf query will be.                                                               | `"ALL_AVAILABLE"` |
 
 `SkusFilterEnum`:
-| Name            | Value             | Description                                                                                                                                            |
+| Name | Value | Description |
 | --------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | First Available | `FIRST_AVAILABLE` | Most performant, ideal if you do not have a SKU selector in your shelf. Will return only the first available SKU for that product in your shelf query. |
-| All Available   | `ALL_AVAILABLE`   | A bit better performace, will only return SKUs that are available, ideal if you have a SKU selector but still want a better performance.               |
-| All             | `ALL`             | Returns all SKUs related to that product, least performant option.                                                                                     |
+| All Available | `ALL_AVAILABLE` | A bit better performace, will only return SKUs that are available, ideal if you have a SKU selector but still want a better performance. |
+| All | `ALL` | Returns all SKUs related to that product, least performant option. |
 
 ##### HiddenFacets
 
@@ -426,9 +425,9 @@ Notice that the default behavior for your store will be the one defined by the `
 
 ##### `filter-navigator.v3` block
 
-| Prop name             | Type      | Description                            | Default value |
-| --------------------- | --------- | -------------------------------------- | ------------- |
-| `alwaysOnDesktopView` | `Boolean` | Block filter's layout mode on Desktop. | `false`       |
+| Prop name | Type                      | Description                                                                                       | Default value |
+| --------- | ------------------------- | ------------------------------------------------------------------------------------------------- | ------------- |
+| `layout`  | `responsive` or `desktop` | Which layout should it use. One might use `desktop` when adding filter-navigator inside a drawer. | `responsive`  |
 
 Also, you can configure the product summary that is defined on search-result. See [here](https://github.com/vtex-apps/product-summary/blob/master/README.md#configuration) the Product Summary API.
 
@@ -475,7 +474,7 @@ To use this CSS API, you must add the `styles` builder and create an app styling
 
 #### Customization
 
-| CSS handles                           | 
+| CSS handles                           |
 | ------------------------------------- |
 | `container`                           |
 | `buttonShowMore`                      |
@@ -547,7 +546,7 @@ To use this CSS API, you must add the `styles` builder and create an app styling
 | `loadingOverlay`                      |
 | `searchResultContainer`               |
 | `loadingSpinnerOuterContainer`        |
-| `loadingSpinnerInnerContainer`        | 
+| `loadingSpinnerInnerContainer`        |
 
 ## Troubleshooting
 
@@ -576,6 +575,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/manifest.json
+++ b/manifest.json
@@ -36,7 +36,8 @@
     "vtex.search-page-context": "0.x",
     "vtex.blog-interfaces": "0.x",
     "vtex.responsive-values": "0.x",
-    "vtex.css-handles": "0.x"
+    "vtex.css-handles": "0.x",
+    "vtex.store-drawer": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -39,6 +39,7 @@ const FilterNavigator = ({
   preventRouteChange = false,
   hiddenFacets = {},
   initiallyCollapsed = false,
+  alwaysOnDesktopView = false,
 }) => {
   const { isMobile } = useDevice()
   const handles = useCssHandles(CSS_HANDLES)
@@ -81,7 +82,7 @@ const FilterNavigator = ({
     )
   }
 
-  if (isMobile) {
+  if (isMobile && !alwaysOnDesktopView) {
     return (
       <div className={styles.filters}>
         <div className={filterClasses}>

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -24,6 +24,11 @@ import { CATEGORIES_TITLE } from './utils/getFilters'
 
 const CSS_HANDLES = ['filter__container']
 
+const LAYOUT_TYPES = {
+  responsive: 'responsive',
+  desktop: 'desktop',
+}
+
 /**
  * Wrapper around the filters (selected and available) as well
  * as the popup filters that appear on mobile devices
@@ -39,10 +44,13 @@ const FilterNavigator = ({
   preventRouteChange = false,
   hiddenFacets = {},
   initiallyCollapsed = false,
-  alwaysOnDesktopView = false,
+  layout = LAYOUT_TYPES.responsive,
 }) => {
   const { isMobile } = useDevice()
   const handles = useCssHandles(CSS_HANDLES)
+  const mobileLayout =
+    (isMobile && layout === LAYOUT_TYPES.responsive) ||
+    layout === LAYOUT_TYPES.mobile
 
   const navigateToFacet = useFacetNavigation()
 
@@ -59,10 +67,10 @@ const FilterNavigator = ({
   ).filter(facet => facet.selected)
 
   const filterClasses = classNames({
-    'flex items-center justify-center flex-auto h-100': isMobile,
+    'flex items-center justify-center flex-auto h-100': mobileLayout,
   })
 
-  if (loading && !isMobile) {
+  if (loading && !mobileLayout) {
     return (
       <ContentLoader
         style={{
@@ -82,7 +90,7 @@ const FilterNavigator = ({
     )
   }
 
-  if (isMobile && !alwaysOnDesktopView) {
+  if (mobileLayout) {
     return (
       <div className={styles.filters}>
         <div className={filterClasses}>
@@ -153,6 +161,7 @@ FilterNavigator.propTypes = {
   priceRange: PropTypes.string,
   /** Loading indicator */
   loading: PropTypes.bool,
+  layout: PropTypes.oneOf(Object.values(LAYOUT_TYPES)),
   initiallyCollapsed: PropTypes.bool,
   ...hiddenFacetsSchema,
 }

--- a/react/FilterNavigatorFlexible.js
+++ b/react/FilterNavigatorFlexible.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
+import { useDevice } from 'vtex.device-detector'
 import { pathOr } from 'ramda'
 
 import FilterNavigator from './FilterNavigator'
@@ -19,6 +20,7 @@ const withSearchPageContextProps = Component => ({ layout }) => {
     preventRouteChange,
     facetsLoading,
   } = useSearchPage()
+  const { isMobile } = useDevice()
 
   const facets = pathOr({}, ['data', 'facets'], searchQuery)
   const { brands, priceRanges, specificationFilters, categoriesTrees } = facets
@@ -28,7 +30,11 @@ const withSearchPageContextProps = Component => ({ layout }) => {
   }
 
   return (
-    <div className={styles['filters--layout']}>
+    <div
+      className={`${styles['filters--layout']} ${
+        layout === 'desktop' && isMobile ? 'w-100 mh5' : ''
+      }`}
+    >
       <Component
         preventRouteChange={preventRouteChange}
         brands={brands}

--- a/react/FilterNavigatorFlexible.js
+++ b/react/FilterNavigatorFlexible.js
@@ -6,7 +6,7 @@ import FilterNavigator from './FilterNavigator'
 
 import styles from './searchResult.css'
 
-const withSearchPageContextProps = Component => () => {
+const withSearchPageContextProps = Component => ({ alwaysOnDesktopView }) => {
   const {
     searchQuery,
     map,
@@ -40,6 +40,7 @@ const withSearchPageContextProps = Component => () => {
         loading={facetsLoading && showContentLoader}
         filters={filters}
         hiddenFacets={hiddenFacets}
+        alwaysOnDesktopView={alwaysOnDesktopView}
       />
     </div>
   )

--- a/react/FilterNavigatorFlexible.js
+++ b/react/FilterNavigatorFlexible.js
@@ -6,7 +6,7 @@ import FilterNavigator from './FilterNavigator'
 
 import styles from './searchResult.css'
 
-const withSearchPageContextProps = Component => ({ alwaysOnDesktopView }) => {
+const withSearchPageContextProps = Component => ({ layout }) => {
   const {
     searchQuery,
     map,
@@ -40,7 +40,7 @@ const withSearchPageContextProps = Component => ({ alwaysOnDesktopView }) => {
         loading={facetsLoading && showContentLoader}
         filters={filters}
         hiddenFacets={hiddenFacets}
-        alwaysOnDesktopView={alwaysOnDesktopView}
+        layout={layout}
       />
     </div>
   )

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -105,6 +105,7 @@
       "info-card",
       "flex-layout",
       "tab-layout",
+      "drawer",
       "search-layout-switcher",
       "search-fetch-previous",
       "search-fetch-more",


### PR DESCRIPTION
#### What is the purpose of this pull request?
Makes `filter-navigator` more customizable on mobile view if new possibilities to use with `drawer`, `flex-layout` and all others interfaces of search-result.

#### What problem is this solving?
On layout's mobile view have the same desktop functionallity and layout but inside of a ´drawer´. The `isMobile` validation makes impossible to keep the same behavior and results in an unexpected layout.


#### How should this be manually tested?
There is a workspace without CSS rules: https://alwaysondesktop--unimarcdev.myvtex.com/search?_query=leche
Its just test on a mobile device to check the same behavior of desktop mode.

#### Screenshots or example usage
Layout:
![image](https://user-images.githubusercontent.com/49173685/71324598-6e884800-24bf-11ea-950f-d3c21afdc5af.png)

With the new props:
![image](https://user-images.githubusercontent.com/49173685/71324674-7ac0d500-24c0-11ea-83f2-387e7fbea390.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
