### PR TITLE
change layout component render values to client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Change flexible layout render values to `client`.
 
 ## [3.39.9] - 2019-12-12
 ### Changed

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -47,7 +47,7 @@
       "search-not-found-layout"
     ],
     "component": "SearchResultLayout",
-    "render": "lazy"
+    "render": "client"
   },
   "search-result-layout.customQuery": {
     "allowed": [
@@ -56,7 +56,7 @@
       "search-not-found-layout"
     ],
     "component": "SearchResultLayoutCustomQuery",
-    "render": "lazy"
+    "render": "client"
   },
   "search-layout-switcher": {
     "component": "LayoutModeSwitcherFlexible"


### PR DESCRIPTION
#### What is the purpose of this pull request?

- with the lazy value, we are showing the grey square when switching pages even with the optimized render-runtime

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
