### PR TITLE
Add ignoreSpecificationFilters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `ignoreSpecificationFilters` on `SearchQuery`.
+- `facetsBehavior` on `SearchQuery`.
 
 ## [3.40.0] - 2019-12-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `ignoreSpecificationFilters` on `SearchQuery`.
 
 ## [3.40.0] - 2019-12-27
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,6 +56,7 @@ To pass parameters to the search displayed at `search-result-layout` you should 
         "context": {
            "orderByField": "OrderByReleaseDateDESC",
             "hideUnavailableItems": true,
+            "ignoreSpecificationFilters": false,
             "maxItemsPerPage": 8,
             "skusFilter": "FIRST_AVAILABLE"
         }
@@ -78,6 +79,7 @@ If you want to use the `.customQuery`:
     "querySchema": {
       "orderByField": "OrderByReleaseDateDESC",
       "hideUnavailableItems": true,
+      "ignoreSpecificationFilters": false,
       "maxItemsPerPage": 8,
       "queryField": "clothing",
       "mapField": "c",
@@ -137,6 +139,7 @@ In case of (a) we can configure the search parameters in a search context in the
         "context": {
            "orderByField": "OrderByReleaseDateDESC",
             "hideUnavailableItems": true,
+            "ignoreSpecificationFilters": false,
             "maxItemsPerPage": 8,
             "skusFilter": "FIRST_AVAILABLE"
         }
@@ -150,6 +153,7 @@ In case of (a) we can configure the search parameters in a search context in the
         "context": {
            "orderByField": "OrderByReleaseDateDESC",
             "hideUnavailableItems": true,
+            "ignoreSpecificationFilters": false,
             "maxItemsPerPage": 8,
             "skusFilter": "FIRST_AVAILABLE"
         }
@@ -163,6 +167,7 @@ In case of (a) we can configure the search parameters in a search context in the
         "context": {
            "orderByField": "OrderByReleaseDateDESC",
             "hideUnavailableItems": true,
+            "ignoreSpecificationFilters": false,
             "maxItemsPerPage": 8,
             "skusFilter": "FIRST_AVAILABLE"
         }
@@ -176,6 +181,7 @@ In case of (a) we can configure the search parameters in a search context in the
         "context": {
            "orderByField": "OrderByReleaseDateDESC",
             "hideUnavailableItems": true,
+            "ignoreSpecificationFilters": false,
             "maxItemsPerPage": 8,
             "skusFilter": "FIRST_AVAILABLE"
         }
@@ -189,6 +195,7 @@ In case of (a) we can configure the search parameters in a search context in the
         "context": {
            "orderByField": "OrderByReleaseDateDESC",
             "hideUnavailableItems": true,
+            "ignoreSpecificationFilters": false,
             "maxItemsPerPage": 8,
             "skusFilter": "FIRST_AVAILABLE"
         }
@@ -233,6 +240,7 @@ Now, to change the search done by this block, we must pass its parameters direct
     "querySchema": {
       "orderByField": "OrderByReleaseDateDESC",
       "hideUnavailableItems": true,
+      "ignoreSpecificationFilters": false,
       "maxItemsPerPage": 8,
       "skusFilter": "FIRST_AVAILABLE"
     }
@@ -366,6 +374,7 @@ These properties can be changed in the `blocks.json` file of your theme.
 | `restField`            | `String`         | Other Query Strings                                                                                                                                                                                   | N/A               |
 | `orderByField`         | `Enum`           | Order by field (values: `OrderByTopSaleDESC`, `OrderByReleaseDateDESC`, `OrderByBestDiscountDESC`, `OrderByPriceDESC`, `OrderByPriceASC`, `OrderByNameASC`, `OrderByNameDESC` or `''` (by relevance)) | `''`              |
 | `hideUnavailableItems` | `Boolean`        | Set if unavailable items should show on search                                                                                                                                                        | `false`           |
+| `ignoreSpecificationFilters` | `Boolean`        | Set if specificationFilters will be ignored when getting the facets. If set to `true`, you will be able to filter your search result with facets of the same specification filters, making it possible to make an `or` filter. If set to `false`, you won't be able to filter by `or` but the facets will be smarter and will only show the facets that will have at least one result.                                                                                                                                                        | `true`           |
 | `skusFilter`           | `SkusFilterEnum` | Control SKUs returned for each product in the query. The less SKUs needed to be returned, the more performant your shelf query will be.                                                               | `"ALL_AVAILABLE"` |
 
 `SkusFilterEnum`:

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,7 +56,7 @@ To pass parameters to the search displayed at `search-result-layout` you should 
         "context": {
            "orderByField": "OrderByReleaseDateDESC",
             "hideUnavailableItems": true,
-            "ignoreSpecificationFilters": false,
+            "facetsBehavior": "Dynamic",
             "maxItemsPerPage": 8,
             "skusFilter": "FIRST_AVAILABLE"
         }
@@ -79,7 +79,7 @@ If you want to use the `.customQuery`:
     "querySchema": {
       "orderByField": "OrderByReleaseDateDESC",
       "hideUnavailableItems": true,
-      "ignoreSpecificationFilters": false,
+      "facetsBehavior": "Dynamic",
       "maxItemsPerPage": 8,
       "queryField": "clothing",
       "mapField": "c",
@@ -139,7 +139,7 @@ In case of (a) we can configure the search parameters in a search context in the
         "context": {
            "orderByField": "OrderByReleaseDateDESC",
             "hideUnavailableItems": true,
-            "ignoreSpecificationFilters": false,
+            "facetsBehavior": "Dynamic",
             "maxItemsPerPage": 8,
             "skusFilter": "FIRST_AVAILABLE"
         }
@@ -153,7 +153,7 @@ In case of (a) we can configure the search parameters in a search context in the
         "context": {
            "orderByField": "OrderByReleaseDateDESC",
             "hideUnavailableItems": true,
-            "ignoreSpecificationFilters": false,
+            "facetsBehavior": "Dynamic",
             "maxItemsPerPage": 8,
             "skusFilter": "FIRST_AVAILABLE"
         }
@@ -167,7 +167,7 @@ In case of (a) we can configure the search parameters in a search context in the
         "context": {
            "orderByField": "OrderByReleaseDateDESC",
             "hideUnavailableItems": true,
-            "ignoreSpecificationFilters": false,
+            "facetsBehavior": "Dynamic",
             "maxItemsPerPage": 8,
             "skusFilter": "FIRST_AVAILABLE"
         }
@@ -181,7 +181,7 @@ In case of (a) we can configure the search parameters in a search context in the
         "context": {
            "orderByField": "OrderByReleaseDateDESC",
             "hideUnavailableItems": true,
-            "ignoreSpecificationFilters": false,
+            "facetsBehavior": "Dynamic",
             "maxItemsPerPage": 8,
             "skusFilter": "FIRST_AVAILABLE"
         }
@@ -195,7 +195,7 @@ In case of (a) we can configure the search parameters in a search context in the
         "context": {
            "orderByField": "OrderByReleaseDateDESC",
             "hideUnavailableItems": true,
-            "ignoreSpecificationFilters": false,
+            "facetsBehavior": "Dynamic",
             "maxItemsPerPage": 8,
             "skusFilter": "FIRST_AVAILABLE"
         }
@@ -240,7 +240,7 @@ Now, to change the search done by this block, we must pass its parameters direct
     "querySchema": {
       "orderByField": "OrderByReleaseDateDESC",
       "hideUnavailableItems": true,
-      "ignoreSpecificationFilters": false,
+      "facetsBehavior": "Dynamic",
       "maxItemsPerPage": 8,
       "skusFilter": "FIRST_AVAILABLE"
     }
@@ -374,7 +374,7 @@ These properties can be changed in the `blocks.json` file of your theme.
 | `restField`            | `String`         | Other Query Strings                                                                                                                                                                                   | N/A               |
 | `orderByField`         | `Enum`           | Order by field (values: `OrderByTopSaleDESC`, `OrderByReleaseDateDESC`, `OrderByBestDiscountDESC`, `OrderByPriceDESC`, `OrderByPriceASC`, `OrderByNameASC`, `OrderByNameDESC` or `''` (by relevance)) | `''`              |
 | `hideUnavailableItems` | `Boolean`        | Set if unavailable items should show on search                                                                                                                                                        | `false`           |
-| `ignoreSpecificationFilters` | `Boolean`        | Set if specificationFilters will be ignored when getting the facets. If set to `true`, you will be able to filter your search result with facets of the same specification filters, making it possible to make an `or` filter. If set to `false`, you won't be able to filter by `or` but the facets will be smarter and will only show the facets that will have at least one result.                                                                                                                                                        | `true`           |
+| `facetsBehavior` | `String`        | Set if specificationFilters will be ignored when getting the facets. If set to `Static`, you will be able to filter your search result with facets of the same specification filters, making it possible to make an `or` filter. If set to `Dynamic`, you won't be able to filter by `or` but the facets will be smarter and will only show the facets that will have at least one result.                                                                                                                                                        | `Static`           |
 | `skusFilter`           | `SkusFilterEnum` | Control SKUs returned for each product in the query. The less SKUs needed to be returned, the more performant your shelf query will be.                                                               | `"ALL_AVAILABLE"` |
 
 `SkusFilterEnum`:

--- a/react/SearchResultLayoutCustomQuery.js
+++ b/react/SearchResultLayoutCustomQuery.js
@@ -69,6 +69,7 @@ const SearchResultLayoutCustomQuery = props => {
           })}
       orderByField={props.querySchema.orderByField}
       hideUnavailableItems={props.querySchema.hideUnavailableItems}
+      ignoreSpecificationFilters={props.querySchema.ignoreSpecificationFilters}
       skusFilter={props.querySchema.skusFilter}
       query={props.query}
       render={localSearchQueryData => {

--- a/react/SearchResultLayoutCustomQuery.js
+++ b/react/SearchResultLayoutCustomQuery.js
@@ -69,7 +69,7 @@ const SearchResultLayoutCustomQuery = props => {
           })}
       orderByField={props.querySchema.orderByField}
       hideUnavailableItems={props.querySchema.hideUnavailableItems}
-      ignoreSpecificationFilters={props.querySchema.ignoreSpecificationFilters}
+      facetsBehavior={props.querySchema.facetsBehavior}
       skusFilter={props.querySchema.skusFilter}
       query={props.query}
       render={localSearchQueryData => {

--- a/react/components/LocalQuery.js
+++ b/react/components/LocalQuery.js
@@ -14,7 +14,7 @@ const LocalQuery = props => {
     mapField = '',
     orderByField = SORT_OPTIONS[0].value,
     hideUnavailableItems,
-    ignoreSpecificationFilters,
+    facetsBehavior,
     skusFilter,
     query: {
       order: orderBy = orderByField,
@@ -35,7 +35,7 @@ const LocalQuery = props => {
       orderBy={orderBy}
       priceRange={priceRange}
       hideUnavailableItems={hideUnavailableItems}
-      ignoreSpecificationFilters={ignoreSpecificationFilters}
+      facetsBehavior={facetsBehavior}
       pageQuery={pageQuery}
       skusFilter={skusFilter}
     >

--- a/react/components/LocalQuery.js
+++ b/react/components/LocalQuery.js
@@ -14,6 +14,7 @@ const LocalQuery = props => {
     mapField = '',
     orderByField = SORT_OPTIONS[0].value,
     hideUnavailableItems,
+    ignoreSpecificationFilters,
     skusFilter,
     query: {
       order: orderBy = orderByField,
@@ -34,6 +35,7 @@ const LocalQuery = props => {
       orderBy={orderBy}
       priceRange={priceRange}
       hideUnavailableItems={hideUnavailableItems}
+      ignoreSpecificationFilters={ignoreSpecificationFilters}
       pageQuery={pageQuery}
       skusFilter={skusFilter}
     >

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -149,7 +149,7 @@ const SearchQuery = ({
       from,
       to,
       hideUnavailableItems: !!hideUnavailableItems,
-      facetsBehavior: !!facetsBehavior,
+      facetsBehavior,
       withFacets: false,
       skusFilter: skusFilter || DEFAULT_SKU_FILTER,
     }

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -32,8 +32,7 @@ const useCombinedRefetch = (productRefetch, facetsRefetch) => {
                   query: refetchVariables.facetQuery,
                   map: refetchVariables.facetMap,
                   hideUnavailableItems: refetchVariables.hideUnavailableItems,
-                  ignoreSpecificationFilters:
-                    refetchVariables.ignoreSpecificationFilters,
+                  behavior: refetchVariables.facetsBehavior,
                 }
               : undefined
           ),
@@ -89,7 +88,7 @@ const useQueries = (variables, facetsArgs) => {
       query: facetsArgs.facetQuery,
       map: facetsArgs.facetMap,
       hideUnavailableItems: variables.hideUnavailableItems,
-      ignoreSpecificationFilters: variables.ignoreSpecificationFilters,
+      behavior: variables.facetsBehavior,
     },
     skip: !facetsArgs.withFacets,
     ssr: false,
@@ -118,7 +117,7 @@ const SearchQuery = ({
   orderBy,
   priceRange,
   hideUnavailableItems,
-  ignoreSpecificationFilters,
+  facetsBehavior,
   pageQuery,
   skusFilter,
   children,
@@ -150,7 +149,7 @@ const SearchQuery = ({
       from,
       to,
       hideUnavailableItems: !!hideUnavailableItems,
-      ignoreSpecificationFilters: !!ignoreSpecificationFilters,
+      facetsBehavior: !!facetsBehavior,
       withFacets: false,
       skusFilter: skusFilter || DEFAULT_SKU_FILTER,
     }
@@ -162,7 +161,7 @@ const SearchQuery = ({
     from,
     to,
     hideUnavailableItems,
-    ignoreSpecificationFilters,
+    facetsBehavior,
     skusFilter,
   ])
 

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -32,6 +32,8 @@ const useCombinedRefetch = (productRefetch, facetsRefetch) => {
                   query: refetchVariables.facetQuery,
                   map: refetchVariables.facetMap,
                   hideUnavailableItems: refetchVariables.hideUnavailableItems,
+                  ignoreSpecificationFilters:
+                    refetchVariables.ignoreSpecificationFilters,
                 }
               : undefined
           ),
@@ -87,6 +89,7 @@ const useQueries = (variables, facetsArgs) => {
       query: facetsArgs.facetQuery,
       map: facetsArgs.facetMap,
       hideUnavailableItems: variables.hideUnavailableItems,
+      ignoreSpecificationFilters: variables.ignoreSpecificationFilters,
     },
     skip: !facetsArgs.withFacets,
     ssr: false,
@@ -115,6 +118,7 @@ const SearchQuery = ({
   orderBy,
   priceRange,
   hideUnavailableItems,
+  ignoreSpecificationFilters,
   pageQuery,
   skusFilter,
   children,
@@ -146,6 +150,7 @@ const SearchQuery = ({
       from,
       to,
       hideUnavailableItems: !!hideUnavailableItems,
+      ignoreSpecificationFilters: !!ignoreSpecificationFilters,
       withFacets: false,
       skusFilter: skusFilter || DEFAULT_SKU_FILTER,
     }
@@ -157,6 +162,7 @@ const SearchQuery = ({
     from,
     to,
     hideUnavailableItems,
+    ignoreSpecificationFilters,
     skusFilter,
   ])
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add facetsBehavior to the SearchQuery. With this variable, you can control which kind of facets will appear. If set to `Static`, you will be able to filter your search result with facets of the same specification filters, making it possible to make an `or` filter. If set to `Dynamic`, you won't be able to filter by `or` but the facets will be smarter and will only show the facets that will have at least one result. 

Works along with:
https://github.com/vtex-apps/store-resources/pull/83
https://github.com/vtex-apps/store/pull/398
https://github.com/vtex-apps/search-graphql/pull/39

#### How should this be manually tested?

[Workspace](https://iaronaraujo--storecomponents.myvtex.com/apparel---accessories/clothing/Black?map=c,c,specificationFilter_52)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/8443580/71531754-e810a380-28ce-11ea-8343-c626d8a1e288.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
