### PR TITLE
add facet sort, search and fix showFacetQuantity bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- Search input for facets.
-- Prop `orderFacetsBy` to `SearchResultFlexible`.
+- Facets are now searchable.
+- Facets ordering.
 
 ### Fixed
 - `showFacetQuantity` was not working on mobile.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Search input for facets.
+- Prop `orderFacetsBy` to `SearchResultFlexible`.
+
+### Fixed
+- `showFacetQuantity` was not working on mobile.
+
 ## [3.45.1] - 2020-01-28
 ### Changed
 - Ordination value of "Relevance" from empty string to `OrderByScoreDESC`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -361,8 +361,19 @@ These properties can be changed in the `blocks.json` file of your theme.
 | `pagination`        | `Enum`         | Pagination type (values: 'show-more' or 'infinite-scroll')                                                                           | `infinity-scroll` |
 | `mobileLayout`      | `MobileLayout` | Control mobile layout                                                                                                                | N/A               |
 | `showFacetQuantity` | `Boolean`      | If quantity of items filtered by facet should appear besides its name on `filter-navigator`                                          | `false`           |
+| `showFacetSearch`   | `Boolean`      | If true, a search input will be shown for each filter                                                                                | `false`           |
+| `orderFacetsBy`     | `String`       | Indicates which [facet sort option](#facet-sort-options) will be used                                                                | N/A               |
 | `blockClass`        | `String`       | Unique class name to be appended to block classes                                                                                    | `""`              |
 | `showProductsCount` | `Boolean`      | controls if the quantity of loaded products and total number of items of a search result are displayed under the `show more` button. | `false`           |
+
+##### Facet sort options
+
+| Option              | Value          |
+| ------------------- | -------------- |
+| Name Ascending      | `NameASC`      |
+| Name Descending     | `NameDESC`     |
+| Quantity Ascending  | `QuantityASC`  |
+| Quantity Descending | `QuantityDESC` |
 
 ##### QuerySchema
 

--- a/messages/context.json
+++ b/messages/context.json
@@ -52,6 +52,7 @@
   "store/filter.less-items": "See less",
   "store/search.filter.title.brands": "Brands",
   "store/search.filter.title.price-ranges": "Price Ranges",
+  "store/search.filter.search-placeholder": "Search by {filterName}",
   "store/search.text": "Showing {from}-{to} from {recordsFiltered} records",
   "store/search.selected-filters": "Filter by:",
   "store/search.total-products": "{recordsFiltered} <span class=\"c-muted-2\">{recordsFiltered, plural, one {Product} other {Products}}</span>",

--- a/messages/en.json
+++ b/messages/en.json
@@ -52,6 +52,7 @@
   "store/filter.less-items": "See less",
   "store/search.filter.title.brands": "Brands",
   "store/search.filter.title.price-ranges": "Price Ranges",
+  "store/search.filter.search-placeholder": "Search by {filterName}",
   "store/search.text": "Showing {from}-{to} from {recordsFiltered} records",
   "store/search.selected-filters": "Filter by:",
   "store/search.total-products": "{recordsFiltered} <span class=\"c-muted-2\">{recordsFiltered, plural, one {Product} other {Products}}</span>",

--- a/messages/es.json
+++ b/messages/es.json
@@ -52,6 +52,7 @@
   "store/filter.less-items": "Ver menos",
   "store/search.filter.title.brands": "Marcas",
   "store/search.filter.title.price-ranges": "Gama de Precios",
+  "store/search.filter.search-placeholder": "Buscar por {filterName}",
   "store/search.text": "Mostrar {from}-{to} de {recordsFiltered} resultados",
   "store/search.selected-filters": "Filtrado por:",
   "store/search.total-products": "{recordsFiltered} <span class=\"c-muted-2\">{recordsFiltered, plural, one {Producto} other {Productos}}</span>",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -52,6 +52,7 @@
   "store/filter.less-items": "Ver menos",
   "store/search.filter.title.brands": "Marcas",
   "store/search.filter.title.price-ranges": "Faixa de Preço",
+  "store/search.filter.search-placeholder": "Busque por {filterName}",
   "store/search.text": "Exibindo {from}-{to} de {recordsFiltered} resultados",
   "store/search.selected-filters": "Filtrar por:",
   "store/search.total-products": "{recordsFiltered} <span class=\"c-muted-2\">{recordsFiltered, plural, one {Produto} other {Produtos}}</span>",

--- a/react/SearchResultFlexible.js
+++ b/react/SearchResultFlexible.js
@@ -57,7 +57,6 @@ const SearchResultFlexible = ({
   orderBy,
   page,
   facetsLoading,
-  showFacetQuantity = false,
   showFacetSearch = false,
   orderFacetsBy,
 }) => {

--- a/react/SearchResultFlexible.js
+++ b/react/SearchResultFlexible.js
@@ -57,6 +57,9 @@ const SearchResultFlexible = ({
   orderBy,
   page,
   facetsLoading,
+  showFacetQuantity = false,
+  showFacetSearch = false,
+  orderFacetsBy,
 }) => {
   //This makes infinite scroll unavailable.
   //Infinite scroll was deprecated and we have
@@ -103,8 +106,17 @@ const SearchResultFlexible = ({
       pagination,
       mobileLayout,
       showFacetQuantity,
+      orderFacetsBy,
+      showFacetSearch,
     }),
-    [hiddenFacets, mobileLayout, pagination, showFacetQuantity]
+    [
+      hiddenFacets,
+      mobileLayout,
+      pagination,
+      showFacetQuantity,
+      orderFacetsBy,
+      showFacetSearch,
+    ]
   )
 
   const context = useMemo(

--- a/react/components/AccordionFilterGroup.js
+++ b/react/components/AccordionFilterGroup.js
@@ -26,7 +26,11 @@ const AccordionFilterGroup = ({
       quantitySelected={quantitySelected}
     >
       <div className={className}>
-        <FacetCheckboxList onFilterCheck={onFilterCheck} facets={filters} />
+        <FacetCheckboxList
+          title={title}
+          onFilterCheck={onFilterCheck}
+          facets={filters}
+        />
       </div>
     </AccordionFilterItem>
   )

--- a/react/components/FacetCheckboxList.js
+++ b/react/components/FacetCheckboxList.js
@@ -1,37 +1,59 @@
 import classNames from 'classnames'
-import React from 'react'
+import React, { useState, useContext } from 'react'
 import { Checkbox } from 'vtex.styleguide'
 
 import useSelectedFilters from '../hooks/useSelectedFilters'
 import styles from '../searchResult.css'
+import { useSortFacets } from '../constants/SearchHelpers'
+import SettingsContext from './SettingsContext'
+import SearchFilterBar from './SearchFilterBar'
 
-const FacetCheckboxList = ({ facets, onFilterCheck }) => {
+const FacetCheckboxList = ({ facets, onFilterCheck, title }) => {
   const facetsWithSelected = useSelectedFilters(facets)
+  const { orderFacetsBy, showFacetSearch, showFacetQuantity } = useContext(
+    SettingsContext
+  )
+  const [searchTerm, setSearchTerm] = useState('')
+  const sortFunc = useSortFacets(orderFacetsBy)
 
-  return facetsWithSelected.map(facet => {
-    const { name } = facet
+  return (
+    <>
+      {showFacetSearch ? (
+        <SearchFilterBar title={title} handleChange={setSearchTerm} />
+      ) : null}
+      {facetsWithSelected
+        .filter(
+          filter =>
+            searchTerm === '' ||
+            filter.name.toLowerCase().indexOf(searchTerm) > -1
+        )
+        .sort(sortFunc)
+        .map(facet => {
+          const { name, quantity } = facet
 
-    return (
-      <div
-        className={classNames(
-          styles.filterAccordionItemBox,
-          'pr4 pt3 items-center flex bb b--muted-5'
-        )}
-        key={name}
-        style={{hyphens: 'auto', wordBreak: 'break-word'}}
-      >
-        <Checkbox
-          className="mb0"
-          checked={facet.selected}
-          id={name}
-          label={name}
-          name={name}
-          onChange={() => onFilterCheck(facet)}
-          value={name}
-        />
-      </div>
-    )
-  })
+          return (
+            <div
+              className={classNames(
+                styles.filterAccordionItemBox,
+                'pr4 pt3 items-center flex bb b--muted-5'
+              )}
+              key={name}
+              style={{ hyphens: 'auto', wordBreak: 'break-word' }}
+            >
+              <Checkbox
+                className="mb0"
+                checked={facet.selected}
+                id={name}
+                label={showFacetQuantity ? `${name} (${quantity})` : name}
+                name={name}
+                onChange={() => onFilterCheck(facet)}
+                value={name}
+              />
+            </div>
+          )
+        })}
+    </>
+  )
 }
 
 export default FacetCheckboxList

--- a/react/components/FacetCheckboxList.js
+++ b/react/components/FacetCheckboxList.js
@@ -1,54 +1,59 @@
 import classNames from 'classnames'
-import React, { useState } from 'react'
+import React, { useState, useMemo } from 'react'
 import { Checkbox } from 'vtex.styleguide'
 
 import useSelectedFilters from '../hooks/useSelectedFilters'
 import styles from '../searchResult.css'
-import { useSortFacets, useSettings } from '../constants/SearchHelpers'
+import {
+  useSettings,
+  filterFacetsByName,
+  sortFacets,
+} from '../constants/SearchHelpers'
 import SearchFilterBar from './SearchFilterBar'
 
 const FacetCheckboxList = ({ facets, onFilterCheck, title }) => {
   const facetsWithSelected = useSelectedFilters(facets)
   const { orderFacetsBy, showFacetSearch, showFacetQuantity } = useSettings()
   const [searchTerm, setSearchTerm] = useState('')
-  const sortFunc = useSortFacets(orderFacetsBy)
+
+  const filteredAndOrderedFacets = useMemo(
+    () =>
+      sortFacets(
+        filterFacetsByName(facetsWithSelected, searchTerm),
+        orderFacetsBy
+      ),
+    [searchTerm, facetsWithSelected, orderFacetsBy]
+  )
 
   return (
     <>
       {showFacetSearch ? (
         <SearchFilterBar title={title} handleChange={setSearchTerm} />
       ) : null}
-      {facetsWithSelected
-        .filter(
-          filter =>
-            searchTerm === '' ||
-            filter.name.toLowerCase().indexOf(searchTerm) > -1
-        )
-        .sort(sortFunc)
-        .map(facet => {
-          const { name, quantity } = facet
+      {filteredAndOrderedFacets.map(facet => {
+        const { name, quantity } = facet
 
-          return (
-            <div
-              className={classNames(
-                styles.filterAccordionItemBox,
-                'pr4 pt3 items-center flex bb b--muted-5'
-              )}
-              key={name}
-              style={{ hyphens: 'auto', wordBreak: 'break-word' }}
-            >
-              <Checkbox
-                className="mb0"
-                checked={facet.selected}
-                id={name}
-                label={showFacetQuantity ? `${name} (${quantity})` : name}
-                name={name}
-                onChange={() => onFilterCheck(facet)}
-                value={name}
-              />
-            </div>
-          )
-        })}
+        return (
+          <div
+            className={classNames(
+              styles.filterAccordionItemBox,
+              'pr4 pt3 items-center flex bb b--muted-5'
+            )}
+            key={name}
+            style={{ hyphens: 'auto', wordBreak: 'break-word' }}
+          >
+            <Checkbox
+              className="mb0"
+              checked={facet.selected}
+              id={name}
+              label={showFacetQuantity ? `${name} (${quantity})` : name}
+              name={name}
+              onChange={() => onFilterCheck(facet)}
+              value={name}
+            />
+          </div>
+        )
+      })}
     </>
   )
 }

--- a/react/components/FacetCheckboxList.js
+++ b/react/components/FacetCheckboxList.js
@@ -1,18 +1,15 @@
 import classNames from 'classnames'
-import React, { useState, useContext } from 'react'
+import React, { useState } from 'react'
 import { Checkbox } from 'vtex.styleguide'
 
 import useSelectedFilters from '../hooks/useSelectedFilters'
 import styles from '../searchResult.css'
-import { useSortFacets } from '../constants/SearchHelpers'
-import SettingsContext from './SettingsContext'
+import { useSortFacets, useSettings } from '../constants/SearchHelpers'
 import SearchFilterBar from './SearchFilterBar'
 
 const FacetCheckboxList = ({ facets, onFilterCheck, title }) => {
   const facetsWithSelected = useSelectedFilters(facets)
-  const { orderFacetsBy, showFacetSearch, showFacetQuantity } = useContext(
-    SettingsContext
-  )
+  const { orderFacetsBy, showFacetSearch, showFacetQuantity } = useSettings()
   const [searchTerm, setSearchTerm] = useState('')
   const sortFunc = useSortFacets(orderFacetsBy)
 

--- a/react/components/FacetItem.js
+++ b/react/components/FacetItem.js
@@ -1,15 +1,15 @@
-import React, { useContext } from 'react'
+import React from 'react'
 import { Checkbox } from 'vtex.styleguide'
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 import classNames from 'classnames'
 
-import SettingsContext from './SettingsContext'
 import useFacetNavigation from '../hooks/useFacetNavigation'
+import { useSettings } from '../constants/SearchHelpers'
 
 const CSS_HANDLES = ['filterItem']
 
 const FacetItem = ({ facet, className, preventRouteChange = false }) => {
-  const { showFacetQuantity } = useContext(SettingsContext)
+  const { showFacetQuantity } = useSettings()
   const handles = useCssHandles(CSS_HANDLES)
   const navigateToFacet = useFacetNavigation()
 

--- a/react/components/FilterOptionTemplate.js
+++ b/react/components/FilterOptionTemplate.js
@@ -20,7 +20,6 @@ const CSS_HANDLES = [
   'filterTitle',
   'filterIcon',
   'filterContent',
-  'filterSearch',
 ]
 
 /**
@@ -121,11 +120,9 @@ const FilterOptionTemplate = ({
       >
         {collapsable ? (
           <Collapse isOpened={open} theme={{ content: handles.filterContent }}>
-            <div className={classNames('mb3', handles.filterSearch)}>
-              {showFacetSearch ? (
-                <SearchFilterBar title={title} handleChange={setSearchTerm} />
-              ) : null}
-            </div>
+            {showFacetSearch ? (
+              <SearchFilterBar title={title} handleChange={setSearchTerm} />
+            ) : null}
             {renderChildren()}
           </Collapse>
         ) : (

--- a/react/components/FilterOptionTemplate.js
+++ b/react/components/FilterOptionTemplate.js
@@ -5,12 +5,12 @@ import classNames from 'classnames'
 
 import { IconCaret } from 'vtex.store-icons'
 import { useCssHandles } from 'vtex.css-handles'
-import { Input } from 'vtex.styleguide'
-import { defineMessages, injectIntl, intlShape } from 'react-intl'
 
 import SettingsContext from './SettingsContext'
 
 import styles from '../searchResult.css'
+import { useSortFacets } from '../constants/SearchHelpers'
+import SearchFilterBar from './SearchFilterBar'
 
 const CSS_HANDLES = [
   'filter__container',
@@ -23,13 +23,6 @@ const CSS_HANDLES = [
   'filterSearch',
 ]
 
-const messages = defineMessages({
-  searchPlaceHolder: {
-    id: 'store/search.filter.search-placeholder',
-    defaultMessage: '',
-  },
-})
-
 /**
  * Collapsable filters container
  */
@@ -41,31 +34,12 @@ const FilterOptionTemplate = ({
   children,
   filters,
   initiallyCollapsed = false,
-  intl,
 }) => {
   const [open, setOpen] = useState(!initiallyCollapsed)
   const [searchTerm, setSearchTerm] = useState('')
   const handles = useCssHandles(CSS_HANDLES)
-
   const { orderFacetsBy, showFacetSearch } = useContext(SettingsContext)
-
-  const sortFacets = useCallback(
-    (a, b) => {
-      switch (orderFacetsBy) {
-        case 'QuantityDESC':
-          return b.quantity - a.quantity
-        case 'QuantityASC':
-          return a.quantity - b.quantity
-        case 'NameASC':
-          return a.name > b.name ? 1 : -1
-        case 'NameDESC':
-          return a.name > b.name ? -1 : 1
-        default:
-          return 0
-      }
-    },
-    [orderFacetsBy]
-  )
+  const sortFunc = useSortFacets(orderFacetsBy)
 
   const renderChildren = () => {
     if (typeof children !== 'function') {
@@ -78,7 +52,7 @@ const FilterOptionTemplate = ({
           searchTerm === '' ||
           filter.name.toLowerCase().indexOf(searchTerm) > -1
       )
-      .sort(sortFacets)
+      .sort(sortFunc)
       .map(children)
   }
 
@@ -149,12 +123,7 @@ const FilterOptionTemplate = ({
           <Collapse isOpened={open} theme={{ content: handles.filterContent }}>
             <div className={classNames('mb3', handles.filterSearch)}>
               {showFacetSearch ? (
-                <Input
-                  onChange={e => setSearchTerm(e.target.value.toLowerCase())}
-                  placeholder={intl.formatMessage(messages.searchPlaceHolder, {
-                    filterName: title,
-                  })}
-                />
+                <SearchFilterBar title={title} handleChange={setSearchTerm} />
               ) : null}
             </div>
             {renderChildren()}
@@ -181,8 +150,6 @@ FilterOptionTemplate.propTypes = {
   /** Whether it represents the selected filters */
   selected: PropTypes.bool,
   initiallyCollapsed: PropTypes.bool,
-  /** Intl instance */
-  intl: intlShape,
 }
 
-export default injectIntl(FilterOptionTemplate)
+export default FilterOptionTemplate

--- a/react/components/FilterOptionTemplate.js
+++ b/react/components/FilterOptionTemplate.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { useState, useCallback } from 'react'
+import React, { useState, useCallback, useMemo } from 'react'
 import { Collapse } from 'react-collapse'
 import classNames from 'classnames'
 
@@ -7,7 +7,11 @@ import { IconCaret } from 'vtex.store-icons'
 import { useCssHandles } from 'vtex.css-handles'
 
 import styles from '../searchResult.css'
-import { useSortFacets, useSettings } from '../constants/SearchHelpers'
+import {
+  useSettings,
+  sortFacets,
+  filterFacetsByName,
+} from '../constants/SearchHelpers'
 import SearchFilterBar from './SearchFilterBar'
 
 const CSS_HANDLES = [
@@ -36,21 +40,18 @@ const FilterOptionTemplate = ({
   const [searchTerm, setSearchTerm] = useState('')
   const handles = useCssHandles(CSS_HANDLES)
   const { orderFacetsBy, showFacetSearch } = useSettings()
-  const sortFunc = useSortFacets(orderFacetsBy)
+
+  const filteredAndOrderedFilters = useMemo(
+    () => sortFacets(filterFacetsByName(filters, searchTerm), orderFacetsBy),
+    [searchTerm, filters, orderFacetsBy]
+  )
 
   const renderChildren = () => {
     if (typeof children !== 'function') {
       return children
     }
 
-    return filters
-      .filter(
-        filter =>
-          searchTerm === '' ||
-          filter.name.toLowerCase().indexOf(searchTerm) > -1
-      )
-      .sort(sortFunc)
-      .map(children)
+    return filteredAndOrderedFilters.map(children)
   }
 
   const handleKeyDown = useCallback(

--- a/react/components/FilterOptionTemplate.js
+++ b/react/components/FilterOptionTemplate.js
@@ -1,15 +1,13 @@
 import PropTypes from 'prop-types'
-import React, { useState, useCallback, useContext } from 'react'
+import React, { useState, useCallback } from 'react'
 import { Collapse } from 'react-collapse'
 import classNames from 'classnames'
 
 import { IconCaret } from 'vtex.store-icons'
 import { useCssHandles } from 'vtex.css-handles'
 
-import SettingsContext from './SettingsContext'
-
 import styles from '../searchResult.css'
-import { useSortFacets } from '../constants/SearchHelpers'
+import { useSortFacets, useSettings } from '../constants/SearchHelpers'
 import SearchFilterBar from './SearchFilterBar'
 
 const CSS_HANDLES = [
@@ -37,7 +35,7 @@ const FilterOptionTemplate = ({
   const [open, setOpen] = useState(!initiallyCollapsed)
   const [searchTerm, setSearchTerm] = useState('')
   const handles = useCssHandles(CSS_HANDLES)
-  const { orderFacetsBy, showFacetSearch } = useContext(SettingsContext)
+  const { orderFacetsBy, showFacetSearch } = useSettings()
   const sortFunc = useSortFacets(orderFacetsBy)
 
   const renderChildren = () => {

--- a/react/components/SearchFilterBar.js
+++ b/react/components/SearchFilterBar.js
@@ -1,6 +1,10 @@
 import React from 'react'
 import { defineMessages, injectIntl } from 'react-intl'
 import { Input } from 'vtex.styleguide'
+import classNames from 'classnames'
+import { useCssHandles } from 'vtex.css-handles'
+
+const CSS_HANDLES = ['filterSearch']
 
 const messages = defineMessages({
   searchPlaceHolder: {
@@ -10,13 +14,17 @@ const messages = defineMessages({
 })
 
 const SearchFilterBar = ({ title, handleChange, intl }) => {
+  const handles = useCssHandles(CSS_HANDLES)
+
   return (
-    <Input
-      onChange={e => handleChange(e.target.value.toLowerCase())}
-      placeholder={intl.formatMessage(messages.searchPlaceHolder, {
-        filterName: title,
-      })}
-    />
+    <div className={classNames('mb3', handles.filterSearch)}>
+      <Input
+        onChange={e => handleChange(e.target.value.toLowerCase())}
+        placeholder={intl.formatMessage(messages.searchPlaceHolder, {
+          filterName: title,
+        })}
+      />
+    </div>
   )
 }
 

--- a/react/components/SearchFilterBar.js
+++ b/react/components/SearchFilterBar.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import { defineMessages, injectIntl } from 'react-intl'
+import { Input } from 'vtex.styleguide'
+
+const messages = defineMessages({
+  searchPlaceHolder: {
+    id: 'store/search.filter.search-placeholder',
+    defaultMessage: '',
+  },
+})
+
+const SearchFilterBar = ({ title, handleChange, intl }) => {
+  return (
+    <Input
+      onChange={e => handleChange(e.target.value.toLowerCase())}
+      placeholder={intl.formatMessage(messages.searchPlaceHolder, {
+        filterName: title,
+      })}
+    />
+  )
+}
+
+export default injectIntl(SearchFilterBar)

--- a/react/components/SearchFilterBar.js
+++ b/react/components/SearchFilterBar.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { defineMessages, injectIntl } from 'react-intl'
+import { defineMessages, useIntl } from 'react-intl'
 import { Input } from 'vtex.styleguide'
 import classNames from 'classnames'
 import { useCssHandles } from 'vtex.css-handles'
@@ -13,8 +13,9 @@ const messages = defineMessages({
   },
 })
 
-const SearchFilterBar = ({ title, handleChange, intl }) => {
+const SearchFilterBar = ({ title, handleChange }) => {
   const handles = useCssHandles(CSS_HANDLES)
+  const intl = useIntl()
 
   return (
     <div className={classNames('mb3', handles.filterSearch)}>
@@ -28,4 +29,4 @@ const SearchFilterBar = ({ title, handleChange, intl }) => {
   )
 }
 
-export default injectIntl(SearchFilterBar)
+export default SearchFilterBar

--- a/react/constants/SearchHelpers.js
+++ b/react/constants/SearchHelpers.js
@@ -1,5 +1,27 @@
+import { useCallback } from 'react'
+
 export function getFilterTitle(title = '', intl) {
   return intl.messages[title] ? intl.formatMessage({ id: title }) : title
+}
+
+export function useSortFacets(orderFacetsBy) {
+  return useCallback(
+    (a, b) => {
+      switch (orderFacetsBy) {
+        case 'QuantityDESC':
+          return b.quantity - a.quantity
+        case 'QuantityASC':
+          return a.quantity - b.quantity
+        case 'NameASC':
+          return a.name > b.name ? 1 : -1
+        case 'NameDESC':
+          return a.name > b.name ? -1 : 1
+        default:
+          return 0
+      }
+    },
+    [orderFacetsBy]
+  )
 }
 
 export const HEADER_SCROLL_OFFSET = 90

--- a/react/constants/SearchHelpers.js
+++ b/react/constants/SearchHelpers.js
@@ -1,28 +1,31 @@
-import { useCallback, useContext } from 'react'
+import { useContext } from 'react'
 import SettingsContext from '../components/SettingsContext'
 
 export function getFilterTitle(title = '', intl) {
   return intl.messages[title] ? intl.formatMessage({ id: title }) : title
 }
 
-export function useSortFacets(orderFacetsBy) {
-  return useCallback(
-    (a, b) => {
-      switch (orderFacetsBy) {
-        case 'QuantityDESC':
-          return b.quantity - a.quantity
-        case 'QuantityASC':
-          return a.quantity - b.quantity
-        case 'NameASC':
-          return a.name > b.name ? 1 : -1
-        case 'NameDESC':
-          return a.name > b.name ? -1 : 1
-        default:
-          return 0
-      }
-    },
-    [orderFacetsBy]
-  )
+export function sortFacets(facets, orderFacetsBy) {
+  switch (orderFacetsBy) {
+    case 'QuantityDESC':
+      return facets.sort((a, b) => b.quantity - a.quantity)
+    case 'QuantityASC':
+      return facets.sort((a, b) => a.quantity - b.quantity)
+    case 'NameASC':
+      return facets.sort((a, b) => (a.name > b.name ? 1 : -1))
+    case 'NameDESC':
+      return facets.sort((a, b) => (a.name > b.name ? -1 : 1))
+    default:
+      return facets
+  }
+}
+
+export function filterFacetsByName(facets, name) {
+  if (!name || name === '') {
+    return facets
+  }
+
+  return facets.filter(facet => facet.name.toLowerCase().indexOf(name) > -1)
 }
 
 export function useSettings() {

--- a/react/constants/SearchHelpers.js
+++ b/react/constants/SearchHelpers.js
@@ -1,4 +1,5 @@
-import { useCallback } from 'react'
+import { useCallback, useContext } from 'react'
+import SettingsContext from '../components/SettingsContext'
 
 export function getFilterTitle(title = '', intl) {
   return intl.messages[title] ? intl.formatMessage({ id: title }) : title
@@ -22,6 +23,10 @@ export function useSortFacets(orderFacetsBy) {
     },
     [orderFacetsBy]
   )
+}
+
+export function useSettings() {
+  return useContext(SettingsContext)
 }
 
 export const HEADER_SCROLL_OFFSET = 90


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR adds two new feature to the filter navigator facets:

- Facets are now sortable by name and quantity.
- A search input for facets.

It also fixes a bug where the `showFacetQuantity` prop was not causing any effect.

#### How should this be manually tested?

[workspace](https://facetsearchandsort--storecomponents.myvtex.com/shirt?_q=shirt&map=ft)

#### Screenshots or example usage

![search-facet](https://user-images.githubusercontent.com/40380674/71595932-55654400-2b1c-11ea-85d3-4bc4105176dc.gif)


#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
