### PR TITLE
Feature: Expose `showFacetQuantity` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `showFacetQuantity` settings to `SearchResultFlexible` component. 
+
 ## [3.41.1] - 2020-01-02
 ### Fixed
 - Added default value for `facetsBehavior` variable.

--- a/react/SearchResultFlexible.js
+++ b/react/SearchResultFlexible.js
@@ -47,6 +47,7 @@ const SearchResultFlexible = ({
   showProductsCount,
   blockClass,
   preventRouteChange = false,
+  showFacetQuantity = false,
   // Below are set by SearchContext
   searchQuery,
   maxItemsPerPage,
@@ -100,8 +101,9 @@ const SearchResultFlexible = ({
       hiddenFacets,
       pagination,
       mobileLayout,
+      showFacetQuantity,
     }),
-    [hiddenFacets, mobileLayout, pagination]
+    [hiddenFacets, mobileLayout, pagination, showFacetQuantity]
   )
 
   const context = useMemo(


### PR DESCRIPTION
#### What is the purpose of this pull request?

Enable `showFacetQuantity` to be set using `store` builder.

#### What problem is this solving?

Currently `FacetItem` component read the value from `SettingsContext` but there's no way to set it.

#### How should this be manually tested?

1. Go to [Workspace](https://featfiltercount--unimarc.myvtex.com/search?_query=carne%20molida)
2. Observe that facet quantity item are showing;

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/1207017/71748096-4e0da580-2e50-11ea-954f-c2b970d2fa60.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.

PS: Couldn't find props table of the component to update docs accordingly;