### PR TITLE
Fix/facets loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix issues related to FilterNavigator loading state.
 
 ## [3.42.0] - 2020-01-04
 

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -72,21 +72,23 @@ const FilterNavigator = ({
 
   if (loading && !mobileLayout) {
     return (
-      <ContentLoader
-        style={{
-          width: '100%',
-          height: '100%',
-        }}
-        width="230"
-        height="320"
-        y="0"
-        x="0"
-      >
-        <rect width="100%" height="1em" />
-        <rect width="100%" height="8em" y="1.5em" />
-        <rect width="100%" height="1em" y="10.5em" />
-        <rect width="100%" height="8em" y="12em" />
-      </ContentLoader>
+      <div className="mv5">
+        <ContentLoader
+          style={{
+            width: '100%',
+            height: '100%',
+          }}
+          width="230"
+          height="320"
+          y="0"
+          x="0"
+        >
+          <rect width="100%" height="1em" />
+          <rect width="100%" height="8em" y="1.5em" />
+          <rect width="100%" height="1em" y="10.5em" />
+          <rect width="100%" height="8em" y="12em" />
+        </ContentLoader>
+      </div>
     )
   }
 

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -7,6 +7,7 @@ import { FormattedMessage } from 'react-intl'
 import { ExtensionPoint } from 'vtex.render-runtime'
 import { useDevice } from 'vtex.device-detector'
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
+
 import FilterSidebar from './components/FilterSidebar'
 import SelectedFilters from './components/SelectedFilters'
 import AvailableFilters from './components/AvailableFilters'
@@ -75,8 +76,8 @@ const FilterNavigator = ({
       <div className="mv5">
         <ContentLoader
           style={{
-            width: '100%',
-            height: '100%',
+            width: "230px",
+            height: "320px",
           }}
           width="230"
           height="320"

--- a/react/FilterNavigatorFlexible.js
+++ b/react/FilterNavigatorFlexible.js
@@ -43,7 +43,7 @@ const withSearchPageContextProps = Component => ({ layout }) => {
         priceRanges={priceRanges}
         specificationFilters={specificationFilters}
         tree={categoriesTrees}
-        loading={facetsLoading && showContentLoader}
+        loading={facetsLoading}
         filters={filters}
         hiddenFacets={hiddenFacets}
         layout={layout}

--- a/react/components/FilterNavigator/legacy/index.js
+++ b/react/components/FilterNavigator/legacy/index.js
@@ -76,8 +76,8 @@ const FilterNavigator = ({
     return (
       <ContentLoader
         style={{
-          width: '100%',
-          height: '100%',
+          width: "230px",
+          height: "320px",
         }}
         width="230"
         height="320"


### PR DESCRIPTION
#### What is the purpose of this pull request?

We were not showing the filter-navigator content loader properly.

https://fidelis--alssports.myvtex.com/climbing/hardware/carabiners?map=c,c,c

This workspace forces the facetsLoading prop to true for more than 10seconds so you can see the change happening

also
https://fidfacets--alssports.myvtex.com
https://fidfacets--exitocol.myvtex.com
https://fidfacets--boticario.myvtex.com
https://fidfacets--tbb.myvtex.com
https://fidfacets--paguemenos.myvtex.com
https://fidfacets--garmin.myvtex.com
https://fidfacets--samsungar.myvtex.com

All have this branch installed with a version of render-server

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
