### PR TITLE
`totalProductsMessage` & `filterMessage` handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Two new css handles: `totalProductsMessage` and `filtersMessage`.
 
 ## [3.43.2] - 2020-01-13
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -505,6 +505,7 @@ To use this CSS API, you must add the `styles` builder and create an app styling
 | `dropdownMobile`                      |
 | `accordionFilterItemActive`           |
 | `totalProducts`                       |
+| `totalProductsMessage`                |
 | `orderBy`                             |
 | `accordionFilterItemHidden`           |
 | `accordionFilterItem`                 |
@@ -515,6 +516,7 @@ To use this CSS API, you must add the `styles` builder and create an app styling
 | `filterSelected`                      |
 | `filterPopupTitle`                    |
 | `filterPopupArrowIcon`                |
+| `filterMessage`                       |
 | `footerButton`                        |
 | `layoutSwitcher`                      |
 | `filterPopup`                         |

--- a/messages/en.json
+++ b/messages/en.json
@@ -50,7 +50,7 @@
   "store/search.filter.title.price-ranges": "Price Ranges",
   "store/search.text": "Showing {from}-{to} from {recordsFiltered} records",
   "store/search.selected-filters": "Filter by:",
-  "store/search.total-products": "{recordsFiltered} <span class=\"c-muted-2\">{recordsFiltered, plural, one {Product} other {Products}}</span>",
+  "store/search.total-products": "{recordsFiltered} <span>{recordsFiltered, plural, one {Product} other {Products}}</span>",
   "store/search.empty-products": "We didn't find any result related to \"{term}\"",
   "store/search.what-do-i-do": "What do I do?",
   "store/search.what-to-do.1": "Verify the terms you typed.",

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -23,7 +23,7 @@ import useFacetNavigation from './hooks/useFacetNavigation'
 import styles from './searchResult.css'
 import { CATEGORIES_TITLE } from './utils/getFilters'
 
-const CSS_HANDLES = ['filter__container']
+const CSS_HANDLES = ['filter__container', 'filterMessage']
 
 const LAYOUT_TYPES = {
   responsive: 'responsive',
@@ -118,7 +118,7 @@ const FilterNavigator = ({
             'title'
           )} bb b--muted-4`}
         >
-          <h5 className="t-heading-5 mv5">
+          <h5 className={`${handles.filterMessage} t-heading-5 mv5`}>
             <FormattedMessage id="store/search-result.filter-button.title" />
           </h5>
         </div>

--- a/react/TotalProducts.js
+++ b/react/TotalProducts.js
@@ -1,22 +1,32 @@
-import { FormattedHTMLMessage } from 'react-intl'
+import { FormattedMessage } from 'react-intl'
 import React from 'react'
 import PropTypes from 'prop-types'
+import { useCssHandles } from 'vtex.css-handles'
 
 import styles from './searchResult.css'
+
+const CSS_HANDLES = ['totalProductsMessage']
 
 const TotalProducts = ({
   recordsFiltered,
   wrapperClass = styles.totalProducts,
 }) => {
+  const handles = useCssHandles(CSS_HANDLES)
   return (
     <div
       className={`${wrapperClass} pv5 ph9 bn-ns bt-s b--muted-5 tc-s tl t-action--small`}
     >
-      <FormattedHTMLMessage
+      <FormattedMessage
         tagName="span"
         id="store/search.total-products"
         values={{
           recordsFiltered,
+          // eslint-disable-next-line react/display-name
+          span: (...chunks) => (
+            <span className={`${handles.totalProductsMessage} c-muted-2`}>
+              {chunks}
+            </span>
+          ),
         }}
       />
     </div>
@@ -26,6 +36,7 @@ const TotalProducts = ({
 TotalProducts.propTypes = {
   /** Total of records filtered */
   recordsFiltered: PropTypes.number.isRequired,
+  wrapperClass: PropTypes.string,
 }
 
 export default TotalProducts

--- a/react/__tests__/__snapshots__/FilterNavigator.test.js.snap
+++ b/react/__tests__/__snapshots__/FilterNavigator.test.js.snap
@@ -9,7 +9,7 @@ exports[`<FilterNavigator /> should display related categories 1`] = `
       class="filter__container filter__container--title bb b--muted-4"
     >
       <h5
-        class="t-heading-5 mv5"
+        class="filterMessage t-heading-5 mv5"
       >
         <span>
           Filters
@@ -181,7 +181,7 @@ exports[`<FilterNavigator /> should match snapshot with all 1`] = `
       class="filter__container filter__container--title bb b--muted-4"
     >
       <h5
-        class="t-heading-5 mv5"
+        class="filterMessage t-heading-5 mv5"
       >
         <span>
           Filters


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add two new css handles: `totalProductsMessage` and `filtersMessage`

#### How should this be manually tested?

[Workspace](https://iaronaraujo--storecomponents.myvtex.com/top?_q=top&map=ft)

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/8443580/72621043-40135680-391f-11ea-9dc9-c874e36b29fb.png)

![image](https://user-images.githubusercontent.com/8443580/72621079-53262680-391f-11ea-9220-44a0eaae4b02.png)



#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
