### PR TITLE
New search urls

### DIFF
--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import { map, flatten, prop } from 'ramda'
+import { flatten } from 'ramda'
 import React, { useMemo, Fragment } from 'react'
 import ContentLoader from 'react-content-loader'
 import { FormattedMessage } from 'react-intl'
@@ -45,7 +45,7 @@ const FilterNavigator = ({
   preventRouteChange = false,
   hiddenFacets = {},
   initiallyCollapsed = false,
-  layout = LAYOUT_TYPES.responsive,
+  queryArgs = {},
 }) => {
   const { isMobile } = useDevice()
   const handles = useCssHandles(CSS_HANDLES)
@@ -53,18 +53,23 @@ const FilterNavigator = ({
     (isMobile && layout === LAYOUT_TYPES.responsive) ||
     layout === LAYOUT_TYPES.mobile
 
-  const navigateToFacet = useFacetNavigation()
+  const navigateToFacet = useFacetNavigation(queryArgs.map)
 
   const selectedFilters = useSelectedFilters(
     useMemo(() => {
       const options = [
-        ...map(prop('facets'), specificationFilters),
+        ...specificationFilters.map(filter => {
+          return filter.facets.map(facet => {
+            return { ...facet, title: filter.name }
+          })
+        }),
         ...brands,
         ...priceRanges,
       ]
 
       return flatten(options)
-    }, [brands, priceRanges, specificationFilters])
+    }, [brands, priceRanges, specificationFilters]),
+    queryArgs
   ).filter(facet => facet.selected)
 
   const filterClasses = classNames({
@@ -98,6 +103,8 @@ const FilterNavigator = ({
       <div className={styles.filters}>
         <div className={filterClasses}>
           <FilterSidebar
+            query={queryArgs.query}
+            map={queryArgs.map}
             selectedFilters={selectedFilters}
             filters={filters}
             tree={tree}
@@ -123,10 +130,12 @@ const FilterNavigator = ({
           </h5>
         </div>
         <SelectedFilters
+          map={queryArgs.map}
           filters={selectedFilters}
           preventRouteChange={preventRouteChange}
         />
         <DepartmentFilters
+          map={queryArgs.map}
           title={CATEGORIES_TITLE}
           tree={tree}
           isVisible={!hiddenFacets.categories}
@@ -134,6 +143,7 @@ const FilterNavigator = ({
         />
         <AvailableFilters
           filters={filters}
+          queryArgs={queryArgs}
           priceRange={priceRange}
           preventRouteChange={preventRouteChange}
           initiallyCollapsed={initiallyCollapsed}

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -46,6 +46,7 @@ const FilterNavigator = ({
   hiddenFacets = {},
   initiallyCollapsed = false,
   queryArgs = {},
+  layout = LAYOUT_TYPES.responsive,
 }) => {
   const { isMobile } = useDevice()
   const handles = useCssHandles(CSS_HANDLES)

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -30,6 +30,18 @@ const LAYOUT_TYPES = {
   desktop: 'desktop',
 }
 
+const storeSelectedCategoryTreeForNavigation = (tree, navigationObj) => {
+  for (const node of tree) {
+    if (!node.selected) {
+      continue
+    }
+    navigationObj.storeSelectedFacets(node)
+    if (node.children) {
+      storeSelectedCategoryTreeForNavigation(node.children, navigationObj)
+    }
+  }
+}
+
 /**
  * Wrapper around the filters (selected and available) as well
  * as the popup filters that appear on mobile devices
@@ -67,11 +79,18 @@ const FilterNavigator = ({
         ...brands,
         ...priceRanges,
       ]
-
       return flatten(options)
     }, [brands, priceRanges, specificationFilters]),
     queryArgs
-  ).filter(facet => facet.selected)
+  ).reduce((acc, facet) => {
+    if (facet.selected) {
+      navigateToFacet.storeSelectedFacets(facet)
+      acc.push(facet)
+    }
+    return acc
+  }, [])
+
+  storeSelectedCategoryTreeForNavigation(tree, navigateToFacet)
 
   const filterClasses = classNames({
     'flex items-center justify-center flex-auto h-100': mobileLayout,

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -41,6 +41,7 @@ const getSelectedCategories = tree => {
       return [node]
     }
   }
+  return []
 }
 
 /**

--- a/react/FilterNavigatorFlexible.js
+++ b/react/FilterNavigatorFlexible.js
@@ -23,7 +23,13 @@ const withSearchPageContextProps = Component => ({ layout }) => {
   const { isMobile } = useDevice()
 
   const facets = pathOr({}, ['data', 'facets'], searchQuery)
-  const { brands, priceRanges, specificationFilters, categoriesTrees } = facets
+  const {
+    brands,
+    priceRanges,
+    specificationFilters,
+    categoriesTrees,
+    queryArgs,
+  } = facets
 
   if (showFacets === false || !map) {
     return null
@@ -47,6 +53,7 @@ const withSearchPageContextProps = Component => ({ layout }) => {
         filters={filters}
         hiddenFacets={hiddenFacets}
         layout={layout}
+        queryArgs={queryArgs}
       />
     </div>
   )

--- a/react/FilterNavigatorFlexible.js
+++ b/react/FilterNavigatorFlexible.js
@@ -4,6 +4,7 @@ import { useDevice } from 'vtex.device-detector'
 import { pathOr } from 'ramda'
 
 import FilterNavigator from './FilterNavigator'
+import FilterNavigatorContext from './components/FilterNavigatorContext'
 
 import styles from './searchResult.css'
 
@@ -16,7 +17,6 @@ const withSearchPageContextProps = Component => ({ layout }) => {
     hiddenFacets,
     filters,
     showFacets,
-    showContentLoader,
     preventRouteChange,
     facetsLoading,
   } = useSearchPage()
@@ -41,20 +41,21 @@ const withSearchPageContextProps = Component => ({ layout }) => {
         layout === 'desktop' && isMobile ? 'w-100 mh5' : ''
       }`}
     >
-      <Component
-        preventRouteChange={preventRouteChange}
-        brands={brands}
-        params={params}
-        priceRange={priceRange}
-        priceRanges={priceRanges}
-        specificationFilters={specificationFilters}
-        tree={categoriesTrees}
-        loading={facetsLoading}
-        filters={filters}
-        hiddenFacets={hiddenFacets}
-        layout={layout}
-        queryArgs={queryArgs}
-      />
+      <FilterNavigatorContext.Provider value={queryArgs}>
+        <Component
+          preventRouteChange={preventRouteChange}
+          brands={brands}
+          params={params}
+          priceRange={priceRange}
+          priceRanges={priceRanges}
+          specificationFilters={specificationFilters}
+          tree={categoriesTrees}
+          loading={facetsLoading}
+          filters={filters}
+          hiddenFacets={hiddenFacets}
+          layout={layout}
+        />
+      </FilterNavigatorContext.Provider>
     </div>
   )
 }

--- a/react/__tests__/FilterNavigator.test.js
+++ b/react/__tests__/FilterNavigator.test.js
@@ -8,6 +8,7 @@ import FilterNavigator from '../FilterNavigator'
 import QueryContext from '../components/QueryContext'
 
 import { useRuntime } from '../__mocks__/vtex.render-runtime'
+import FilterNavigatorContext from '../components/FilterNavigatorContext'
 const mockUseRuntime = useRuntime
 
 const mockNavigate = jest.fn()
@@ -34,7 +35,11 @@ describe('<FilterNavigator />', () => {
       <QueryContext.Provider
         value={{ query: customProps.query, map: props.map }}
       >
-        <FilterNavigator {...props} />
+        <FilterNavigatorContext.Provider
+          value={{ query: customProps.query, map: props.map }}
+        >
+          <FilterNavigator {...props} />
+        </FilterNavigatorContext.Provider>
       </QueryContext.Provider>
     )
   }

--- a/react/__tests__/FilterNavigator.test.js
+++ b/react/__tests__/FilterNavigator.test.js
@@ -26,6 +26,7 @@ describe('<FilterNavigator />', () => {
     const props = {
       map: 'c',
       tree: categoriesTree,
+      queryArgs: { query: customProps.query, map: 'c' },
       ...customProps,
     }
 

--- a/react/__tests__/useFacetNavigation.test.js
+++ b/react/__tests__/useFacetNavigation.test.js
@@ -2,9 +2,12 @@ import useFacetNavigation from '../hooks/useFacetNavigation'
 import { renderHook, act } from '@testing-library/react-hooks'
 
 jest.mock('../components/QueryContext')
+jest.mock('../components/FilterNavigatorContext')
 const { useQuery } = require('../components/QueryContext')
 
 import { useRuntime } from '../__mocks__/vtex.render-runtime'
+import { useFilterNavigator } from '../components/FilterNavigatorContext'
+
 const mockUseRuntime = useRuntime
 
 const mockNavigate = jest.fn()
@@ -24,10 +27,12 @@ it('navigating to another category facet', () => {
   const map = 'c'
   useQuery.mockImplementation(() => ({
     query: 'clothing',
+  }))
+  useFilterNavigator.mockImplementation(() => ({
     map,
   }))
 
-  const { result } = renderHook(() => useFacetNavigation(map))
+  const { result } = renderHook(() => useFacetNavigation([]))
   act(() => {
     result.current({ map: 'c', value: 'shorts' })
   })
@@ -40,10 +45,12 @@ it('joins categories', () => {
   const map = 'c,b'
   useQuery.mockImplementation(() => ({
     query: 'clothing/Brand',
+  }))
+  useFilterNavigator.mockImplementation(() => ({
     map,
   }))
 
-  const { result } = renderHook(() => useFacetNavigation(map))
+  const { result } = renderHook(() => useFacetNavigation([]))
   act(() => {
     result.current({ map: 'c', value: 'shorts' })
   })
@@ -57,10 +64,12 @@ it('pass array of facets as args work', () => {
   const map = 'c,b'
   useQuery.mockImplementation(() => ({
     query: 'clothing/Brand',
+  }))
+  useFilterNavigator.mockImplementation(() => ({
     map,
   }))
 
-  const { result } = renderHook(() => useFacetNavigation(map))
+  const { result } = renderHook(() => useFacetNavigation([]))
   act(() => {
     result.current([
       { map: 'b', value: 'OtherBrand', title: '' },

--- a/react/__tests__/useFacetNavigation.test.js
+++ b/react/__tests__/useFacetNavigation.test.js
@@ -19,69 +19,59 @@ beforeEach(() => {
 })
 
 it('navigating to another category facet', () => {
+  // The new idea here is that we event though we pass the map=c,c,c to navigate we dont have it in our response anymore.
+  // This state is recordered and sent by search-graphql so we can know where we are in catalog search
+  const map = 'c'
   useQuery.mockImplementation(() => ({
     query: 'clothing',
-    map: 'c'
+    map,
   }))
-  
-  const { result } = renderHook(() => useFacetNavigation())
+
+  const { result } = renderHook(() => useFacetNavigation(map))
   act(() => {
     result.current({ map: 'c', value: 'shorts' })
   })
 
   const navigateCall = mockNavigate.mock.calls[0][0]
   expect(navigateCall.to).toBe('/clothing/shorts')
-  expect(navigateCall.query).toBe('map=c%2Cc')
 })
 
 it('joins categories', () => {
+  const map = 'c,b'
   useQuery.mockImplementation(() => ({
     query: 'clothing/Brand',
-    map: 'c,b'
+    map,
   }))
-  
-  const { result } = renderHook(() => useFacetNavigation())
+
+  const { result } = renderHook(() => useFacetNavigation(map))
   act(() => {
     result.current({ map: 'c', value: 'shorts' })
   })
 
   const navigateCall = mockNavigate.mock.calls[0][0]
   expect(navigateCall.to).toBe('/clothing/shorts/Brand')
-  expect(navigateCall.query).toBe('map=c%2Cc%2Cb')
+  expect(navigateCall.query).toBe('map=b')
 })
 
 it('pass array of facets as args work', () => {
+  const map = 'c,b'
   useQuery.mockImplementation(() => ({
     query: 'clothing/Brand',
-    map: 'c,b'
+    map,
   }))
-  
-  const { result } = renderHook(() => useFacetNavigation())
+
+  const { result } = renderHook(() => useFacetNavigation(map))
   act(() => {
-    result.current([{ map: 'b', value: 'OtherBrand' }, { map: 'specificationFilter_100', value: 'Mens' }, {map: 'c', value: 'shorts'}])
+    result.current([
+      { map: 'b', value: 'OtherBrand', title: '' },
+      { map: 'specificationFilter_100', value: 'Mens', title: 'gender' },
+      { map: 'c', value: 'shorts', title: '' },
+    ])
   })
 
   const navigateCall = mockNavigate.mock.calls[0][0]
-  expect(navigateCall.to).toBe('/clothing/shorts/Brand/OtherBrand/Mens')
-  expect(navigateCall.query).toBe('map=c%2Cc%2Cb%2Cb%2CspecificationFilter_100')
+  expect(navigateCall.to).toBe('/clothing/shorts/Brand/OtherBrand/gender_Mens')
+  expect(navigateCall.query).toBe('map=b%2Cb')
 })
 
-
-it('if preventRouteChange call setQuery and not navigate', () => {
-  useQuery.mockImplementation(() => ({
-    query: 'clothing/Brand',
-    map: 'c,b'
-  }))
-  
-  const { result } = renderHook(() => useFacetNavigation())
-  act(() => {
-    result.current({ map: 'c', value: 'shorts' }, true)
-  })
-
-  const setQueryCall = mockSetQuery.mock.calls[0][0]
-  expect(setQueryCall.query).toBe('/clothing/shorts/Brand')
-  expect(setQueryCall.map).toBe('c,c,b')
-  expect(setQueryCall.page).toBe(undefined)
-  expect(mockNavigate.mock.calls.length).toBe(0)
-
-})
+// We've removed the concept of preventRouteChange since the urls should be transformed to the new urls format.

--- a/react/components/AccordionFilterContainer.js
+++ b/react/components/AccordionFilterContainer.js
@@ -14,6 +14,7 @@ import styles from '../searchResult.css'
 const CATEGORIES_TITLE = 'store/search.filter.title.categories'
 
 const AccordionFilterContainer = ({
+  map,
   filters,
   intl,
   onFilterCheck,
@@ -92,6 +93,7 @@ const AccordionFilterContainer = ({
       >
         <div className={itemClassName}>
           <DepartmentFilters
+            map={map}
             tree={tree}
             isVisible={tree.length > 0}
             onCategorySelect={onCategorySelect}
@@ -139,6 +141,8 @@ const AccordionFilterContainer = ({
 }
 
 AccordionFilterContainer.propTypes = {
+  /** Legacy search map */
+  map: PropTypes.string,
   /** Current available filters */
   filters: PropTypes.arrayOf(PropTypes.object),
   /** Intl instance */

--- a/react/components/AccordionFilterGroup.js
+++ b/react/components/AccordionFilterGroup.js
@@ -12,8 +12,9 @@ const AccordionFilterGroup = ({
   open,
   onOpen,
   onFilterCheck,
+  queryArgs,
 }) => {
-  const filters = useSelectedFilters(facets)
+  const filters = useSelectedFilters(facets, queryArgs)
 
   const quantitySelected = filters.filter(facet => facet.selected).length
 
@@ -26,7 +27,11 @@ const AccordionFilterGroup = ({
       quantitySelected={quantitySelected}
     >
       <div className={className}>
-        <FacetCheckboxList onFilterCheck={onFilterCheck} facets={filters} />
+        <FacetCheckboxList
+          title={title}
+          onFilterCheck={onFilterCheck}
+          facets={filters}
+        />
       </div>
     </AccordionFilterItem>
   )

--- a/react/components/AccordionFilterGroup.js
+++ b/react/components/AccordionFilterGroup.js
@@ -12,9 +12,8 @@ const AccordionFilterGroup = ({
   open,
   onOpen,
   onFilterCheck,
-  queryArgs,
 }) => {
-  const filters = useSelectedFilters(facets, queryArgs)
+  const filters = useSelectedFilters(facets)
 
   const quantitySelected = filters.filter(facet => facet.selected).length
 

--- a/react/components/AvailableFilters.js
+++ b/react/components/AvailableFilters.js
@@ -6,6 +6,7 @@ import PriceRange from './PriceRange'
 
 const AvailableFilters = ({
   filters = [],
+  queryArgs = {},
   priceRange,
   preventRouteChange = false,
   initiallyCollapsed = false,
@@ -30,6 +31,7 @@ const AvailableFilters = ({
             key={title}
             title={title}
             facets={facets}
+            queryArgs={queryArgs}
             oneSelectedCollapse={oneSelectedCollapse}
             preventRouteChange={preventRouteChange}
             initiallyCollapsed={initiallyCollapsed}

--- a/react/components/AvailableFilters.js
+++ b/react/components/AvailableFilters.js
@@ -6,10 +6,10 @@ import PriceRange from './PriceRange'
 
 const AvailableFilters = ({
   filters = [],
-  queryArgs = {},
   priceRange,
   preventRouteChange = false,
   initiallyCollapsed = false,
+  navigateToFacet,
 }) =>
   filters.map(filter => {
     const { type, title, facets, oneSelectedCollapse = false } = filter
@@ -31,10 +31,10 @@ const AvailableFilters = ({
             key={title}
             title={title}
             facets={facets}
-            queryArgs={queryArgs}
             oneSelectedCollapse={oneSelectedCollapse}
             preventRouteChange={preventRouteChange}
             initiallyCollapsed={initiallyCollapsed}
+            navigateToFacet={navigateToFacet}
           />
         )
     }

--- a/react/components/CategoryFilter.js
+++ b/react/components/CategoryFilter.js
@@ -62,7 +62,7 @@ const CategoryFilter = ({
     }
 
     if (shallow) {
-      onCategorySelect(map)
+      onCategorySelect()
     } else {
       // deselect root category
       handleUnselectCategories(0)

--- a/react/components/CategoryFilter.js
+++ b/react/components/CategoryFilter.js
@@ -1,10 +1,9 @@
 import classNames from 'classnames'
-import React, { useContext } from 'react'
+import React from 'react'
 import { injectIntl } from 'react-intl'
 import { IconClose } from 'vtex.styleguide'
 import { useCssHandles } from 'vtex.css-handles'
 
-import QueryContext from './QueryContext'
 import Collapsible from './Collapsible'
 import CategoryItem from './CategoryItem'
 
@@ -37,8 +36,12 @@ const getSelectedCategories = rootCategory => {
   return selectedCategories
 }
 
-const CategoryFilter = ({ category, shallow = false, onCategorySelect }) => {
-  const { map } = useContext(QueryContext)
+const CategoryFilter = ({
+  map,
+  category,
+  shallow = false,
+  onCategorySelect,
+}) => {
   const handles = useCssHandles(CSS_HANDLES)
 
   const selectedCategories = getSelectedCategories(category)
@@ -59,7 +62,7 @@ const CategoryFilter = ({ category, shallow = false, onCategorySelect }) => {
     }
 
     if (shallow) {
-      onCategorySelect(category)
+      onCategorySelect(map)
     } else {
       // deselect root category
       handleUnselectCategories(0)

--- a/react/components/CategoryFilter.js
+++ b/react/components/CategoryFilter.js
@@ -3,6 +3,7 @@ import React from 'react'
 import { injectIntl } from 'react-intl'
 import { IconClose } from 'vtex.styleguide'
 import { useCssHandles } from 'vtex.css-handles'
+import { useFilterNavigator } from './FilterNavigatorContext'
 
 import Collapsible from './Collapsible'
 import CategoryItem from './CategoryItem'
@@ -36,12 +37,8 @@ const getSelectedCategories = rootCategory => {
   return selectedCategories
 }
 
-const CategoryFilter = ({
-  map,
-  category,
-  shallow = false,
-  onCategorySelect,
-}) => {
+const CategoryFilter = ({ category, shallow = false, onCategorySelect }) => {
+  const { map } = useFilterNavigator()
   const handles = useCssHandles(CSS_HANDLES)
 
   const selectedCategories = getSelectedCategories(category)

--- a/react/components/DepartmentFilters.js
+++ b/react/components/DepartmentFilters.js
@@ -62,7 +62,7 @@ const DepartmentFilters = ({
             render={category => (
               <CategoryFilter
                 key={category.id}
-                  map={map}
+                map={map}
                 category={category}
                 shallow
                 onCategorySelect={onCategorySelect}
@@ -70,12 +70,12 @@ const DepartmentFilters = ({
             )}
           />
         ) : (
-            <CategoryFilter
+          <CategoryFilter
             map={map}
-              category={tree.find(category => category.selected)}
-              onCategorySelect={onCategorySelect}
-            />
-          )}
+            category={tree.find(category => category.selected)}
+            onCategorySelect={onCategorySelect}
+          />
+        )}
       </div>
     </div>
   )

--- a/react/components/DepartmentFilters.js
+++ b/react/components/DepartmentFilters.js
@@ -14,6 +14,7 @@ const CSS_HANDLES = [
 ]
 
 const DepartmentFilters = ({
+  map,
   title,
   isVisible,
   tree,
@@ -61,6 +62,7 @@ const DepartmentFilters = ({
             render={category => (
               <CategoryFilter
                 key={category.id}
+                  map={map}
                 category={category}
                 shallow
                 onCategorySelect={onCategorySelect}
@@ -69,6 +71,7 @@ const DepartmentFilters = ({
           />
         ) : (
             <CategoryFilter
+            map={map}
               category={tree.find(category => category.selected)}
               onCategorySelect={onCategorySelect}
             />

--- a/react/components/FacetCheckboxList.js
+++ b/react/components/FacetCheckboxList.js
@@ -2,13 +2,10 @@ import classNames from 'classnames'
 import React from 'react'
 import { Checkbox } from 'vtex.styleguide'
 
-import useSelectedFilters from '../hooks/useSelectedFilters'
 import styles from '../searchResult.css'
 
-const FacetCheckboxList = ({ facets, onFilterCheck }) => {
-  const facetsWithSelected = useSelectedFilters(facets)
-
-  return facetsWithSelected.map(facet => {
+const FacetCheckboxList = ({ title, facets, onFilterCheck }) => {
+  return facets.map(facet => {
     const { name } = facet
 
     return (
@@ -18,7 +15,7 @@ const FacetCheckboxList = ({ facets, onFilterCheck }) => {
           'pr4 pt3 items-center flex bb b--muted-5'
         )}
         key={name}
-        style={{hyphens: 'auto', wordBreak: 'break-word'}}
+        style={{ hyphens: 'auto', wordBreak: 'break-word' }}
       >
         <Checkbox
           className="mb0"
@@ -26,7 +23,7 @@ const FacetCheckboxList = ({ facets, onFilterCheck }) => {
           id={name}
           label={name}
           name={name}
-          onChange={() => onFilterCheck(facet)}
+          onChange={() => onFilterCheck(title, facet)}
           value={name}
         />
       </div>

--- a/react/components/FacetItem.js
+++ b/react/components/FacetItem.js
@@ -8,11 +8,19 @@ import useFacetNavigation from '../hooks/useFacetNavigation'
 
 const CSS_HANDLES = ['filterItem']
 
-const FacetItem = ({ facet, className, preventRouteChange = false }) => {
+const FacetItem = ({
+  map,
+  facetTitle,
+  facet,
+  className,
+  preventRouteChange = false,
+}) => {
   const { showFacetQuantity } = useContext(SettingsContext)
   const handles = useCssHandles(CSS_HANDLES)
-  const navigateToFacet = useFacetNavigation()
-
+  const navigateToFacet = useFacetNavigation(
+    map,
+    facet.selected && { ...facet, title: facetTitle }
+  )
   const classes = classNames(
     applyModifiers(handles.filterItem, facet.value),
     { [`${handles.filterItem}--selected`]: facet.selected },
@@ -32,7 +40,9 @@ const FacetItem = ({ facet, className, preventRouteChange = false }) => {
           showFacetQuantity ? `${facet.name} (${facet.quantity})` : facet.name
         }
         name={facet.name}
-        onChange={() => navigateToFacet(facet, preventRouteChange)}
+        onChange={() =>
+          navigateToFacet({ ...facet, title: facetTitle }, preventRouteChange)
+        }
         value={facet.name}
       />
     </div>

--- a/react/components/FacetItem.js
+++ b/react/components/FacetItem.js
@@ -4,14 +4,12 @@ import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 import classNames from 'classnames'
 
 import SettingsContext from './SettingsContext'
-import useFacetNavigation from '../hooks/useFacetNavigation'
 
 const CSS_HANDLES = ['filterItem']
 
-const FacetItem = ({ map, facetTitle, facet, className }) => {
+const FacetItem = ({ navigateToFacet, facetTitle, facet, className }) => {
   const { showFacetQuantity } = useContext(SettingsContext)
   const handles = useCssHandles(CSS_HANDLES)
-  const navigateToFacet = useFacetNavigation(map)
   const classes = classNames(
     applyModifiers(handles.filterItem, facet.value),
     { [`${handles.filterItem}--selected`]: facet.selected },

--- a/react/components/FacetItem.js
+++ b/react/components/FacetItem.js
@@ -8,19 +8,10 @@ import useFacetNavigation from '../hooks/useFacetNavigation'
 
 const CSS_HANDLES = ['filterItem']
 
-const FacetItem = ({
-  map,
-  facetTitle,
-  facet,
-  className,
-  preventRouteChange = false,
-}) => {
+const FacetItem = ({ map, facetTitle, facet, className }) => {
   const { showFacetQuantity } = useContext(SettingsContext)
   const handles = useCssHandles(CSS_HANDLES)
-  const navigateToFacet = useFacetNavigation(
-    map,
-    facet.selected && { ...facet, title: facetTitle }
-  )
+  const navigateToFacet = useFacetNavigation(map)
   const classes = classNames(
     applyModifiers(handles.filterItem, facet.value),
     { [`${handles.filterItem}--selected`]: facet.selected },
@@ -40,9 +31,7 @@ const FacetItem = ({
           showFacetQuantity ? `${facet.name} (${facet.quantity})` : facet.name
         }
         name={facet.name}
-        onChange={() =>
-          navigateToFacet({ ...facet, title: facetTitle }, preventRouteChange)
-        }
+        onChange={() => navigateToFacet({ ...facet, title: facetTitle })}
         value={facet.name}
       />
     </div>

--- a/react/components/FilterNavigatorContext.tsx
+++ b/react/components/FilterNavigatorContext.tsx
@@ -1,0 +1,7 @@
+import { createContext, useContext } from 'react'
+
+const FilterNavigatorContext = createContext({})
+
+export default FilterNavigatorContext
+
+export const useFilterNavigator = () => useContext(FilterNavigatorContext)

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -29,6 +29,7 @@ const CSS_HANDLES = [
 ]
 
 const FilterSidebar = ({
+  map,
   selectedFilters,
   filters,
   tree,
@@ -44,9 +45,9 @@ const FilterSidebar = ({
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
   const currentTree = useCategoryTree(tree, categoryTreeOperations)
 
-  const navigateToFacet = useFacetNavigation()
+  const navigateToFacet = useFacetNavigation(map)
 
-  const handleFilterCheck = filter => {
+  const handleFilterCheck = (title, filter) => {
     if (!filterOperations.includes(filter)) {
       setFilterOperations(filterOperations.concat(filter))
     } else {
@@ -95,13 +96,13 @@ const FilterSidebar = ({
   }
 
   const context = useMemo(() => {
-    const { query, map } = queryContext
+    const { query } = queryContext
 
     return {
       ...queryContext,
       ...buildQueryAndMap(query, map, filterOperations),
     }
-  }, [filterOperations, queryContext])
+  }, [filterOperations, map, queryContext])
 
   return (
     <Fragment>
@@ -128,6 +129,7 @@ const FilterSidebar = ({
       <Sidebar onOutsideClick={handleClose} isOpen={open}>
         <QueryContext.Provider value={context}>
           <AccordionFilterContainer
+            map={map}
             filters={filters}
             tree={currentTree}
             onFilterCheck={handleFilterCheck}

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -1,23 +1,16 @@
 import classNames from 'classnames'
 import produce from 'immer'
-import React, {
-  useState,
-  useEffect,
-  useContext,
-  useMemo,
-  Fragment,
-} from 'react'
+import React, { useState, useEffect, useMemo, Fragment } from 'react'
 import { FormattedMessage } from 'react-intl'
 import { Button } from 'vtex.styleguide'
 import { IconFilter } from 'vtex.store-icons'
 import { useCssHandles } from 'vtex.css-handles'
 
-import QueryContext from './QueryContext'
+import QueryContext, { useQuery } from './QueryContext'
+import { useFilterNavigator } from './FilterNavigatorContext'
 import AccordionFilterContainer from './AccordionFilterContainer'
 import Sidebar from './SideBar'
-import useFacetNavigation, {
-  buildQueryAndMap,
-} from '../hooks/useFacetNavigation'
+import { buildNewQueryMap } from '../hooks/useFacetNavigation'
 
 import styles from '../searchResult.css'
 
@@ -29,14 +22,15 @@ const CSS_HANDLES = [
 ]
 
 const FilterSidebar = ({
-  map,
   selectedFilters,
   filters,
   tree,
   priceRange,
   preventRouteChange,
+  navigateToFacet,
 }) => {
-  const queryContext = useContext(QueryContext)
+  const queryContext = useQuery()
+  const { map } = useFilterNavigator()
   const [open, setOpen] = useState(false)
   const handles = useCssHandles(CSS_HANDLES)
 
@@ -44,8 +38,6 @@ const FilterSidebar = ({
   const [categoryTreeOperations, setCategoryTreeOperations] = useState([])
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
   const currentTree = useCategoryTree(tree, categoryTreeOperations)
-
-  const navigateToFacet = useFacetNavigation(map)
 
   const handleFilterCheck = (title, filter) => {
     if (!filterOperations.includes(filter)) {
@@ -100,9 +92,10 @@ const FilterSidebar = ({
 
     return {
       ...queryContext,
-      ...buildQueryAndMap(query, map, filterOperations),
+      ...buildNewQueryMap(query, map, filterOperations, selectedFilters),
+      map,
     }
-  }, [filterOperations, map, queryContext])
+  }, [filterOperations, map, queryContext, selectedFilters])
 
   return (
     <Fragment>

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -72,7 +72,7 @@ const FilterSidebar = ({
 
   const handleClearFilters = () => {
     setFilterOperations(selectedFilters) // this is necessary to unselect the selected checkboxes
-    navigateToFacet(selectedFilters, preventRouteChange)
+    navigateToFacet(selectedFilters)
     setOpen(false)
   }
 

--- a/react/components/SearchFilter.js
+++ b/react/components/SearchFilter.js
@@ -4,7 +4,7 @@ import { injectIntl, intlShape } from 'react-intl'
 
 import FilterOptionTemplate from './FilterOptionTemplate'
 import FacetItem from './FacetItem'
-import { facetOptionShape } from '../constants/propTypes'
+import { facetOptionShape, facetQueryArgsShape } from '../constants/propTypes'
 import { getFilterTitle } from '../constants/SearchHelpers'
 import useSelectedFilters from '../hooks/useSelectedFilters'
 
@@ -14,24 +14,28 @@ import useSelectedFilters from '../hooks/useSelectedFilters'
 const SearchFilter = ({
   title = 'Default Title',
   facets = [],
+  queryArgs = {},
   intl,
   preventRouteChange = false,
   initiallyCollapsed = false,
 }) => {
-  const filtersWithSelected = useSelectedFilters(facets)
+  const filtersWithSelected = useSelectedFilters(facets, queryArgs)
 
   const sampleFacet = facets && facets.length > 0 ? facets[0] : null
+  const facetTitle = getFilterTitle(title, intl)
 
   return (
     <FilterOptionTemplate
       id={sampleFacet ? sampleFacet.map : null}
-      title={getFilterTitle(title, intl)}
+      title={facetTitle}
       filters={filtersWithSelected}
       initiallyCollapsed={initiallyCollapsed}
     >
       {facet => (
         <FacetItem
+          map={queryArgs.map}
           key={facet.name}
+          facetTitle={facetTitle}
           facet={facet}
           preventRouteChange={preventRouteChange}
         />
@@ -45,6 +49,7 @@ SearchFilter.propTypes = {
   title: PropTypes.string.isRequired,
   /** SearchFilter's options. */
   facets: PropTypes.arrayOf(facetOptionShape),
+  queryArgs: PropTypes.objectOf(facetQueryArgsShape),
   /** Intl instance. */
   intl: intlShape.isRequired,
   /** Prevent route changes */

--- a/react/components/SearchFilter.js
+++ b/react/components/SearchFilter.js
@@ -4,7 +4,7 @@ import { injectIntl, intlShape } from 'react-intl'
 
 import FilterOptionTemplate from './FilterOptionTemplate'
 import FacetItem from './FacetItem'
-import { facetOptionShape, facetQueryArgsShape } from '../constants/propTypes'
+import { facetOptionShape } from '../constants/propTypes'
 import { getFilterTitle } from '../constants/SearchHelpers'
 import useSelectedFilters from '../hooks/useSelectedFilters'
 
@@ -14,12 +14,12 @@ import useSelectedFilters from '../hooks/useSelectedFilters'
 const SearchFilter = ({
   title = 'Default Title',
   facets = [],
-  queryArgs = {},
   intl,
   preventRouteChange = false,
   initiallyCollapsed = false,
+  navigateToFacet,
 }) => {
-  const filtersWithSelected = useSelectedFilters(facets, queryArgs)
+  const filtersWithSelected = useSelectedFilters(facets)
 
   const sampleFacet = facets && facets.length > 0 ? facets[0] : null
   const facetTitle = getFilterTitle(title, intl)
@@ -33,11 +33,11 @@ const SearchFilter = ({
     >
       {facet => (
         <FacetItem
-          map={queryArgs.map}
           key={facet.name}
           facetTitle={facetTitle}
           facet={facet}
           preventRouteChange={preventRouteChange}
+          navigateToFacet={navigateToFacet}
         />
       )}
     </FilterOptionTemplate>
@@ -49,12 +49,12 @@ SearchFilter.propTypes = {
   title: PropTypes.string.isRequired,
   /** SearchFilter's options. */
   facets: PropTypes.arrayOf(facetOptionShape),
-  queryArgs: PropTypes.objectOf(facetQueryArgsShape),
   /** Intl instance. */
   intl: intlShape.isRequired,
   /** Prevent route changes */
   preventRouteChange: PropTypes.bool,
   initiallyCollapsed: PropTypes.bool,
+  navigateToFacet: PropTypes.func,
 }
 
 export default injectIntl(SearchFilter)

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -39,7 +39,6 @@ class SearchResult extends Component {
     products: this.props.products,
     recordsFiltered: this.props.recordsFiltered,
     brands: this.props.brands,
-    map: this.props.map,
     params: this.props.params,
     priceRange: this.props.priceRange,
     priceRanges: this.props.priceRanges,
@@ -74,7 +73,6 @@ class SearchResult extends Component {
         products,
         recordsFiltered,
         brands,
-        map,
         params,
         priceRange,
         priceRanges,
@@ -87,7 +85,6 @@ class SearchResult extends Component {
         products,
         recordsFiltered,
         brands,
-        map,
         params,
         priceRange,
         priceRanges,
@@ -140,7 +137,6 @@ class SearchResult extends Component {
       recordsFiltered,
       products = [],
       brands,
-      map,
       params,
       priceRange,
       priceRanges,
@@ -149,6 +145,12 @@ class SearchResult extends Component {
       hiddenFacets,
       showLoadingAsOverlay,
     } = this.state
+
+    const queryArgs = this.props.searchQuery.facets
+      ? this.props.searchQuery.facets.queryArgs
+      : { query: null, map: null }
+
+    const { map } = queryArgs
 
     const hideFacets = !map || !map.length
     const showLoading = loading && !fetchMoreLoading
@@ -203,6 +205,7 @@ class SearchResult extends Component {
                 loading={showFacetsContentLoader}
                 filters={filters}
                 hiddenFacets={hiddenFacets}
+                queryArgs={queryArgs}
               />
             </div>
           )}
@@ -274,7 +277,4 @@ class SearchResult extends Component {
   }
 }
 
-export default compose(
-  withRuntimeContext,
-  withDevice
-)(SearchResult)
+export default compose(withRuntimeContext, withDevice)(SearchResult)

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -13,6 +13,7 @@ import FetchPreviousButton from './loaders/FetchPreviousButton'
 import FetchMoreButton from './loaders/FetchMoreButton'
 import LoadingSpinner from './loaders/LoadingSpinner'
 import { PAGINATION_TYPE } from '../constants/paginationType'
+import FilterNavigatorContext from './FilterNavigatorContext'
 
 import getFilters from '../utils/getFilters'
 
@@ -148,7 +149,7 @@ class SearchResult extends Component {
 
     const queryArgs = this.props.searchQuery.facets
       ? this.props.searchQuery.facets.queryArgs
-      : { query: null, map: null }
+      : { query: '', map: '' }
 
     const { map } = queryArgs
 
@@ -194,19 +195,20 @@ class SearchResult extends Component {
           />
           {showFacets && !!map && (
             <div className={styles.filters}>
-              <ExtensionPoint
-                id="filter-navigator"
-                brands={brands}
-                params={params}
-                priceRange={priceRange}
-                priceRanges={priceRanges}
-                specificationFilters={specificationFilters}
-                tree={tree}
-                loading={showFacetsContentLoader}
-                filters={filters}
-                hiddenFacets={hiddenFacets}
-                queryArgs={queryArgs}
-              />
+              <FilterNavigatorContext.Provider value={queryArgs}>
+                <ExtensionPoint
+                  id="filter-navigator"
+                  brands={brands}
+                  params={params}
+                  priceRange={priceRange}
+                  priceRanges={priceRanges}
+                  specificationFilters={specificationFilters}
+                  tree={tree}
+                  loading={showFacetsContentLoader}
+                  filters={filters}
+                  hiddenFacets={hiddenFacets}
+                />
+              </FilterNavigatorContext.Provider>
             </div>
           )}
           <ExtensionPoint

--- a/react/components/SelectedFilters.js
+++ b/react/components/SelectedFilters.js
@@ -13,6 +13,7 @@ const CSS_HANDLES = ['selectedFilterItem']
  * Search Filter Component.
  */
 const SelectedFilters = ({
+  map,
   filters = [],
   intl,
   preventRouteChange = false,
@@ -33,7 +34,9 @@ const SelectedFilters = ({
     >
       {facet => (
         <FacetItem
+          map={map}
           key={facet.name}
+          facetTitle={facet.title}
           facet={facet}
           className={handles.selectedFilterItem}
           preventRouteChange={preventRouteChange}
@@ -44,6 +47,9 @@ const SelectedFilters = ({
 }
 
 SelectedFilters.propTypes = {
+  filterTitle: PropTypes.string,
+  /** Legacy search map */
+  map: PropTypes.string,
   /** Selected filters. */
   filters: PropTypes.arrayOf(facetOptionShape).isRequired,
   /** Intl instance. */

--- a/react/components/SelectedFilters.js
+++ b/react/components/SelectedFilters.js
@@ -17,6 +17,7 @@ const SelectedFilters = ({
   filters = [],
   intl,
   preventRouteChange = false,
+  navigateToFacet,
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
   if (!filters.length) {
@@ -40,6 +41,7 @@ const SelectedFilters = ({
           facet={facet}
           className={handles.selectedFilterItem}
           preventRouteChange={preventRouteChange}
+          navigateToFacet={navigateToFacet}
         />
       )}
     </FilterOptionTemplate>
@@ -56,6 +58,7 @@ SelectedFilters.propTypes = {
   intl: intlShape,
   /** Prevent route changes */
   preventRouteChange: PropTypes.bool,
+  navigateToFacet: PropTypes.func,
 }
 
 export default injectIntl(SelectedFilters)

--- a/react/constants.ts
+++ b/react/constants.ts
@@ -1,0 +1,7 @@
+export const MAP_CATEGORY_CHAR = 'c'
+export const MAP_QUERY_KEY = 'map'
+export const MAP_VALUES_SEP = ','
+export const PATH_SEPARATOR = '/'
+export const SPACE_REPLACER = '-'
+export const FILTER_TITLE_SEP = '_'
+export const SPEC_FILTER = 'specificationFilter'

--- a/react/constants/propTypes.js
+++ b/react/constants/propTypes.js
@@ -22,6 +22,13 @@ export const facetOptionShape = PropTypes.shape({
   name: PropTypes.string.isRequired,
 })
 
+export const facetQueryArgsShape = PropTypes.shape({
+  /** Search query field */
+  query: PropTypes.string.isRequired,
+  /** Search map field */
+  map: PropTypes.string,
+})
+
 export const productShape = PropTypes.shape({
   /** Product's id. */
   productId: PropTypes.string.isRequired,

--- a/react/constants/propTypes.js
+++ b/react/constants/propTypes.js
@@ -22,13 +22,6 @@ export const facetOptionShape = PropTypes.shape({
   name: PropTypes.string.isRequired,
 })
 
-export const facetQueryArgsShape = PropTypes.shape({
-  /** Search query field */
-  query: PropTypes.string.isRequired,
-  /** Search map field */
-  map: PropTypes.string,
-})
-
 export const productShape = PropTypes.shape({
   /** Product's id. */
   productId: PropTypes.string.isRequired,

--- a/react/hooks/useFacetNavigation.js
+++ b/react/hooks/useFacetNavigation.js
@@ -31,7 +31,8 @@ const removeSelectedFacets = selectedFacet => {
   }
 }
 
-const removeElementAtIndex = (str, index) => str.filter((_, i) => i !== index)
+const removeElementAtIndex = (strArray, index) =>
+  strArray.filter((_, i) => i !== index)
 
 const removeMapForNewURLFormat = queryAndMap => {
   return queryAndMap.map.filter(
@@ -51,7 +52,7 @@ const getCleanUrlParams = currentMap => {
 
 const getStaticPathSegments = facets => {
   const fieldsNotNormalizable = [...facets, ...Object.values(selectedFacets)]
-    .filter(facet => facet.map !== 'c')
+    .filter(facet => facet.map.includes(SPEC_FILTER))
     .map(facet => newFacetPathName(facet))
     .join(PATH_SEPARATOR)
   const modifiersIgnore = {
@@ -86,13 +87,13 @@ export const buildQueryAndMap = (querySegments, mapSegments, facets) => {
       if (facet.selected) {
         const facetIndex = zip(query, map).findIndex(
           ([value, valueMap]) =>
-            value.toLowerCase() === facetValue.toLowerCase() &&
-            valueMap === facet.map
+            encodeURIComponent(value).toLowerCase() ===
+              facetValue.toLowerCase() && valueMap === facet.map
         )
-        removeSelectedFacets(facet[facetIndex])
+        removeSelectedFacets(facet)
         return {
-          query: removeElementAtIndex(query, facetIndex, PATH_SEPARATOR),
-          map: removeElementAtIndex(map, facetIndex, MAP_VALUES_SEP),
+          query: removeElementAtIndex(querySegments, facetIndex),
+          map: removeElementAtIndex(mapSegments, facetIndex),
         }
       }
 

--- a/react/hooks/useFacetNavigation.js
+++ b/react/hooks/useFacetNavigation.js
@@ -87,8 +87,9 @@ export const buildQueryAndMap = (querySegments, mapSegments, facets) => {
       if (facet.selected) {
         const facetIndex = zip(query, map).findIndex(
           ([value, valueMap]) =>
-            encodeURIComponent(value).toLowerCase() ===
-              facetValue.toLowerCase() && valueMap === facet.map
+            decodeURIComponent(value).toLowerCase() ===
+              decodeURIComponent(facetValue).toLowerCase() &&
+            valueMap === facet.map
         )
         removeSelectedFacets(facet)
         return {

--- a/react/hooks/useFacetNavigation.js
+++ b/react/hooks/useFacetNavigation.js
@@ -2,16 +2,15 @@ import { zip } from 'ramda'
 import { useCallback } from 'react'
 import { useRuntime } from 'vtex.render-runtime'
 import { useQuery } from '../components/QueryContext'
-
+import { newFacetPathName } from '../utils/slug'
 import { HEADER_SCROLL_OFFSET } from '../constants/SearchHelpers'
-
-const SPEC_FILTER = 'specificationFilter'
-const MAP_CATEGORY_CHAR = 'c'
-const MAP_QUERY_KEY = 'map'
-const MAP_VALUES_SEP = ','
-const PATH_SEPARATOR = '/'
-const SPACE_REPLACER = '-'
-const FILTER_TITLE_SEP = '_'
+import {
+  MAP_CATEGORY_CHAR,
+  MAP_QUERY_KEY,
+  MAP_VALUES_SEP,
+  PATH_SEPARATOR,
+  SPEC_FILTER,
+} from '../constants'
 
 const scrollOptions = {
   baseElementId: 'search-result-anchor',
@@ -33,17 +32,6 @@ const removeSelectedFacets = selectedFacet => {
 }
 
 const removeElementAtIndex = (str, index) => str.filter((_, i) => i !== index)
-
-const newFacetPathName = facet => {
-  return facet.map && facet.map.includes(SPEC_FILTER)
-    ? `${facet.title
-        .replace(/\s/g, SPACE_REPLACER)
-        .toLowerCase()}${FILTER_TITLE_SEP}${facet.value.replace(
-        /\s/g,
-        SPACE_REPLACER
-      )}`
-    : facet.value
-}
 
 const removeMapForNewURLFormat = queryAndMap => {
   return queryAndMap.map.filter(

--- a/react/hooks/useFacetNavigation.js
+++ b/react/hooks/useFacetNavigation.js
@@ -168,7 +168,7 @@ const useFacetNavigation = selectedFacets => {
       to: `${PATH_SEPARATOR}${currentQuery}`,
       query: urlParams.toString(),
       scrollOptions,
-      modifiersIgnore,
+      modifiersOptions: modifiersIgnore,
     })
   })
 

--- a/react/hooks/useFacetNavigation.js
+++ b/react/hooks/useFacetNavigation.js
@@ -74,7 +74,9 @@ export const buildQueryAndMap = (
       const facetValue = newFacetPathName(facet, isLegacySearch)
       if (facet.selected) {
         const facetIndex = zip(query, map).findIndex(
-          ([value, valueMap]) => value === facetValue && valueMap === facet.map
+          ([value, valueMap]) =>
+            value.toLowerCase() === facetValue.toLowerCase() &&
+            valueMap === facet.map
         )
         removeSelectedFacets(facet[facetIndex])
         return {

--- a/react/hooks/useSelectedFilters.js
+++ b/react/hooks/useSelectedFilters.js
@@ -1,15 +1,12 @@
 import { zip } from 'ramda'
-import { useContext } from 'react'
-
-import QueryContext from '../components/QueryContext'
 
 /**
  * This hook is required because we make the facets query
  * with only the categories and fulltext parameters, so we
  * need to calculate manually if the other filters are selected
  */
-const useSelectedFilters = facets => {
-  const { query, map } = useContext(QueryContext)
+const useSelectedFilters = (facets, queryArgs) => {
+  const { query, map } = queryArgs
   if (!query && !map) {
     return []
   }

--- a/react/hooks/useSelectedFilters.js
+++ b/react/hooks/useSelectedFilters.js
@@ -1,12 +1,13 @@
 import { zip } from 'ramda'
+import { useFilterNavigator } from '../components/FilterNavigatorContext'
 
 /**
  * This hook is required because we make the facets query
  * with only the categories and fulltext parameters, so we
  * need to calculate manually if the other filters are selected
  */
-const useSelectedFilters = (facets, queryArgs) => {
-  const { query, map } = queryArgs
+const useSelectedFilters = facets => {
+  const { query, map } = useFilterNavigator()
   if (!query && !map) {
     return []
   }

--- a/react/utils/slug.ts
+++ b/react/utils/slug.ts
@@ -1,0 +1,31 @@
+import { SPACE_REPLACER, SPEC_FILTER, FILTER_TITLE_SEP } from '../constants'
+
+const from =
+  'ÁÄÂÀÃÅČÇĆĎÉĚËÈÊẼĔȆÍÌÎÏŇÑÓÖÒÔÕØŘŔŠŤÚŮÜÙÛÝŸŽáäâàãåčçćďéěëèêẽĕȇíìîïňñóöòôõøðřŕšťúůüùûýÿžþÞĐđßÆa·/_,:;'
+const to =
+  'AAAAAACCCDEEEEEEEEIIIINNOOOOOORRSTUUUUUYYZaaaaaacccdeeeeeeeeiiiinnooooooorrstuuuuuyyzbBDdBAa------'
+const removeAccents = (str: string) => {
+  let newStr = str.slice(0)
+  for (let i = 0; i < from.length; i++) {
+    newStr = newStr.replace(new RegExp(from.charAt(i), 'g'), to.charAt(i))
+  }
+  return newStr
+}
+
+// Parameter "S. Coifman" should output "s--coifman"
+export function searchSlugify(str: string) {
+  // According to Bacelar, the search API uses a legacy method for slugifying strings.
+  // replaces special characters with dashes, remove accents and lower cases everything
+  // eslint-disable-next-line no-useless-escape
+  const replaced = str.replace(/[*+~.()'"!:@&\[\]`,/ %$#?{}|><=_^]/g, '-')
+  return removeAccents(replaced).toLowerCase()
+}
+
+export const newFacetPathName = (facet: any) => {
+  return facet.map && facet.map.includes(SPEC_FILTER)
+    ? `${searchSlugify(facet.title)}${FILTER_TITLE_SEP}${facet.value.replace(
+        /\s/g,
+        SPACE_REPLACER
+      )}`
+    : facet.value
+}


### PR DESCRIPTION
What problem is this solving?
Resolve more friendly URLS for filters

In order to have a platform more SEO friendly we are changing our searches URL structure when applying filters. This is a workaround that should be resolved when we have a complete solution with collections where each collection will be a filter with a nice structured URL.

**Meanwhile...**

How should this be manually tested?
Open category pages and navigate. alssporst has hardcoded map=c,c,c values on menu.
We are not normalizing this at the menu component.
https://jey--alssports.myvtex.com

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
