### PR TITLE
Changed "Relevance" value to `OrderByScoreDESC`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Ordination value of "Relevance" from empty string to `OrderByScoreDESC`.
 
 ## [3.44.1] - 2020-01-22
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -372,7 +372,7 @@ These properties can be changed in the `blocks.json` file of your theme.
 | `queryField`           | `String`         | Query field                                                                                                                                                                                           | N/A               |
 | `mapField`             | `String`         | Map field                                                                                                                                                                                             | N/A               |
 | `restField`            | `String`         | Other Query Strings                                                                                                                                                                                   | N/A               |
-| `orderByField`         | `Enum`           | Order by field (values: `OrderByTopSaleDESC`, `OrderByReleaseDateDESC`, `OrderByBestDiscountDESC`, `OrderByPriceDESC`, `OrderByPriceASC`, `OrderByNameASC`, `OrderByNameDESC` or `''` (by relevance)) | `''`              |
+| `orderByField`         | `Enum`           | Order by field (values: `OrderByTopSaleDESC`, `OrderByReleaseDateDESC`, `OrderByBestDiscountDESC`, `OrderByPriceDESC`, `OrderByPriceASC`, `OrderByNameASC`, `OrderByNameDESC` or `OrderByScoreDESC` (by relevance)) | `OrderByScoreDESC`              |
 | `hideUnavailableItems` | `Boolean`        | Set if unavailable items should show on search                                                                                                                                                        | `false`           |
 | `facetsBehavior` | `String`        | Set if specificationFilters will be ignored when getting the facets. If set to `Static`, you will be able to filter your search result with facets of the same specification filters, making it possible to make an `or` filter. If set to `Dynamic`, you won't be able to filter by `or` but the facets will be smarter and will only show the facets that will have at least one result.                                                                                                                                                        | `Static`           |
 | `skusFilter`           | `SkusFilterEnum` | Control SKUs returned for each product in the query. The less SKUs needed to be returned, the more performant your shelf query will be.                                                               | `"ALL_AVAILABLE"` |
@@ -450,7 +450,7 @@ Also, you can configure the product summary that is defined on search-result. Se
 
 | Option                   | Value                       |
 | ------------------------ | --------------------------- |
-| Relevance                | `""`                        |
+| Relevance                | `"OrderByScoreDESC"`        |
 | Top Sales Descending     | `"OrderByTopSaleDESC"`      |
 | Release Date Descending  | `"OrderByReleaseDateDESC"`  |
 | Best Discount Descending | `"OrderByBestDiscountDESC"` |

--- a/react/OrderBy.js
+++ b/react/OrderBy.js
@@ -6,7 +6,7 @@ import SelectionListOrderBy from './components/SelectionListOrderBy'
 
 export const SORT_OPTIONS = [
   {
-    value: '',
+    value: 'OrderByScoreDESC',
     label: 'store/ordenation.relevance',
   },
   {

--- a/react/components/SelectionListOrderBy.js
+++ b/react/components/SelectionListOrderBy.js
@@ -52,7 +52,7 @@ const SelectionListOrderBy = ({ intl, orderBy, options }) => {
   const getOptionTitle = useCallback(
     option => {
       const selectedOption = find(propEq('value', option), options)
-      return selectedOption ? selectedOption.label : ''
+      return selectedOption ? selectedOption.label : options[0].label // this should return to empty string after this https://github.com/vtex-apps/store/pull/407
     },
     [options]
   )


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says

#### What problem is this solving?

People are complaining that "Relevance" does not take consideration of the products' scores.

#### How should this be manually tested?

[Workspace](https://iaronaraujo--storecomponents.myvtex.com/home---decor?order=OrderByScoreDESC)

*Scores:*
- clock: 9999
- bell: 10
- vase: 5
- phone: 2
