### PR TITLE
Returned the fallback orderby label to ' '

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- The fallback value of orderby label to empty string again.
 
 ## [3.45.1] - 2020-01-28
 ### Changed

--- a/react/components/SelectionListOrderBy.js
+++ b/react/components/SelectionListOrderBy.js
@@ -52,7 +52,7 @@ const SelectionListOrderBy = ({ intl, orderBy, options }) => {
   const getOptionTitle = useCallback(
     option => {
       const selectedOption = find(propEq('value', option), options)
-      return selectedOption ? selectedOption.label : options[0].label // this should return to empty string after this https://github.com/vtex-apps/store/pull/407
+      return selectedOption ? selectedOption.label : ''
     },
     [options]
   )


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says. Needs https://github.com/vtex-apps/store/pull/407

#### What problem is this solving?

This removes a temporary save measure introduced in the last patch.

#### How should this be manually tested?

[Workspace](https://iarontest--storecomponents.myvtex.com/home---decor/)
