### PR TITLE
Fix `productImpression` event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Error causing the `productImpression` event to not be sent on some cases.
 
 ## [3.46.1] - 2020-02-06
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -37,7 +37,8 @@
     "vtex.blog-interfaces": "0.x",
     "vtex.responsive-values": "0.x",
     "vtex.css-handles": "0.x",
-    "vtex.store-drawer": "0.x"
+    "vtex.store-drawer": "0.x",
+    "vtex.product-list-context": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -4,19 +4,22 @@ import PropTypes from 'prop-types'
 import { pluck, splitEvery } from 'ramda'
 
 import { useDevice } from 'vtex.device-detector'
+import { ProductListContext } from 'vtex.product-list-context'
 import { useResponsiveValue } from 'vtex.responsive-values'
 import { useCssHandles } from 'vtex.css-handles'
 
 import { LAYOUT_MODE } from './components/LayoutModeSwitcher'
 import { productShape } from './constants/propTypes'
 import withResizeDetector from './components/withResizeDetector'
-
 import GalleryRow from './components/GalleryRow'
+import ProductListEventCaller from './utils/ProductListEventCaller'
 
 /** Layout with one column */
 const ONE_COLUMN_LAYOUT = 1
 
 const CSS_HANDLES = ['gallery']
+
+const { ProductListProvider } = ProductListContext
 /**
  * Canonical gallery that displays a list of given products.
  */
@@ -77,19 +80,22 @@ const Gallery = ({
   )
 
   return (
-    <div className={galleryClasses}>
-      {rows.map((rowProducts, index) => (
-        <GalleryRow
-          key={index.toString()}
-          widthAvailable={width != null}
-          products={rowProducts}
-          summary={summary}
-          displayMode={layoutMode}
-          rowIndex={index}
-          itemsPerRow={itemsPerRow}
-        />
-      ))}
-    </div>
+    <ProductListProvider>
+      <div className={galleryClasses}>
+        {rows.map((rowProducts, index) => (
+          <GalleryRow
+            key={index.toString()}
+            widthAvailable={width != null}
+            products={rowProducts}
+            summary={summary}
+            displayMode={layoutMode}
+            rowIndex={index}
+            itemsPerRow={itemsPerRow}
+          />
+        ))}
+      </div>
+      <ProductListEventCaller />
+    </ProductListProvider>
   )
 }
 

--- a/react/__mocks__/vtex.product-list-context.js
+++ b/react/__mocks__/vtex.product-list-context.js
@@ -1,0 +1,5 @@
+const ProductListProvider = ({ children }) => children
+
+export const useProductImpression = () => {}
+
+export const ProductListContext = { ProductListProvider }

--- a/react/components/GalleryRow.js
+++ b/react/components/GalleryRow.js
@@ -5,64 +5,12 @@ import { useCssHandles } from 'vtex.css-handles'
 import classNames from 'classnames'
 
 import GalleryItem from './GalleryItem'
-import { normalizeProduct } from '../constants/productHelpers'
-
-import { useQuery } from './QueryContext'
 
 const CSS_HANDLES = ['galleryItem']
 
-const useProductImpression = (
-  products,
-  inView,
-  { rowIndex, itemsPerRow, widthAvailable }
-) => {
-  const viewed = useRef(false)
-  const { push } = usePixel()
-  const { query, map } = useQuery()
-
-  // This hook checks if the query and map has changed
-  useEffect(() => {
-    if (query && map) {
-      viewed.current = false
-    }
-  }, [map, query])
-
-  useEffect(() => {
-    if (!products || viewed.current || !inView || !widthAvailable) {
-      return
-    }
-    const normalizedProducts = products.map(normalizeProduct)
-    const impressions = normalizedProducts.map((product, index) => ({
-      product,
-      position: rowIndex * itemsPerRow + index + 1,
-    }))
-    push({
-      event: 'productImpression',
-      list: 'Search result',
-      impressions,
-    })
-    viewed.current = true
-  }, [push, products, inView, viewed, rowIndex, itemsPerRow, widthAvailable])
-}
-
-const GalleryRow = ({
-  products,
-  summary,
-  displayMode,
-  rowIndex,
-  widthAvailable,
-  itemsPerRow,
-}) => {
+const GalleryRow = ({ products, summary, displayMode, itemsPerRow }) => {
   const handles = useCssHandles(CSS_HANDLES)
-  const [ref, inView] = useInView({
-    // inView will be true when at least 10% of the row is viewed by user
-    threshold: 0.1,
-  })
-  useProductImpression(products, inView, {
-    rowIndex,
-    itemsPerRow,
-    widthAvailable,
-  })
+
   const style = {
     flexBasis: `${100 / itemsPerRow}%`,
     maxWidth: `${100 / itemsPerRow}%`,
@@ -73,7 +21,6 @@ const GalleryRow = ({
         key={product.productId}
         style={style}
         className={classNames(handles.galleryItem, 'pa4')}
-        ref={ref}
       >
         <GalleryItem
           item={product}

--- a/react/utils/ProductListEventCaller.js
+++ b/react/utils/ProductListEventCaller.js
@@ -1,0 +1,8 @@
+import { useProductImpression } from 'vtex.product-list-context'
+
+const ProductListEventCaller = () => {
+  useProductImpression()
+  return null
+}
+
+export default ProductListEventCaller


### PR DESCRIPTION
#### What is the purpose of this pull request?

Previously when you clicked on "show more" and the new items completed an existing row, these new items wouldn't have `productImpression`. This issue was fixed by adopting `product-list-context`.

#### How should this be manually tested?

[Workspace](https://iaronaraujo--storecomponents.myvtex.com/apparel---accessories)
Go to the console, type pixelManagerEvents and check that the `productImpression` events are being sent correctly.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
