### PR TITLE
Feature/new search urls 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New search URL structure for specification filters and categories.
+
 ### Fixed
 - Error causing the `productImpression` event to not be sent on some cases.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Error causing the `productImpression` event to not be sent on some cases.
 
 ## [3.49.0] - 2020-02-27
 ### Added

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -85,12 +85,7 @@ const FilterNavigator = ({
       ]
       return flatten(options)
     }, [brands, priceRanges, specificationFilters])
-  ).reduce((acc, facet) => {
-    if (facet.selected) {
-      acc.push(facet)
-    }
-    return acc
-  }, [])
+  ).filter(facet => facet.selected)
 
   const selectedCategories = getSelectedCategories(tree)
   const navigateToFacet = useFacetNavigation(
@@ -166,6 +161,7 @@ const FilterNavigator = ({
           tree={tree}
           isVisible={!hiddenFacets.categories}
           onCategorySelect={navigateToFacet}
+          preventRouteChange={preventRouteChange}
         />
         <AvailableFilters
           filters={filters}

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import { map, flatten, prop } from 'ramda'
+import { flatten } from 'ramda'
 import React, { useMemo, Fragment } from 'react'
 import ContentLoader from 'react-content-loader'
 import { FormattedMessage } from 'react-intl'
@@ -22,12 +22,31 @@ import useFacetNavigation from './hooks/useFacetNavigation'
 
 import styles from './searchResult.css'
 import { CATEGORIES_TITLE } from './utils/getFilters'
+import { newFacetPathName } from './utils/slug'
 
 const CSS_HANDLES = ['filter__container', 'filterMessage']
 
 const LAYOUT_TYPES = {
   responsive: 'responsive',
   desktop: 'desktop',
+}
+
+const getSelectedCategories = tree => {
+  for (const node of tree) {
+    if (!node.selected) {
+      return []
+    }
+    if (node.children) {
+      return [node, ...getSelectedCategories(node.children)]
+    } else {
+      return [node]
+    }
+  }
+  return []
+}
+
+const newNamedFacet = facet => {
+  return { ...facet, newQuerySegment: newFacetPathName(facet) }
 }
 
 /**
@@ -53,19 +72,32 @@ const FilterNavigator = ({
     (isMobile && layout === LAYOUT_TYPES.responsive) ||
     layout === LAYOUT_TYPES.mobile
 
-  const navigateToFacet = useFacetNavigation()
-
   const selectedFilters = useSelectedFilters(
     useMemo(() => {
       const options = [
-        ...map(prop('facets'), specificationFilters),
+        ...specificationFilters.map(filter => {
+          return filter.facets.map(facet => {
+            return newNamedFacet({ ...facet, title: filter.name })
+          })
+        }),
         ...brands,
         ...priceRanges,
       ]
-
       return flatten(options)
     }, [brands, priceRanges, specificationFilters])
-  ).filter(facet => facet.selected)
+  ).reduce((acc, facet) => {
+    if (facet.selected) {
+      acc.push(facet)
+    }
+    return acc
+  }, [])
+
+  const selectedCategories = getSelectedCategories(tree)
+  const navigateToFacet = useFacetNavigation(
+    useMemo(() => {
+      return selectedFilters.concat(selectedCategories)
+    }, [selectedFilters, selectedCategories])
+  )
 
   const filterClasses = classNames({
     'flex items-center justify-center flex-auto h-100': mobileLayout,
@@ -76,8 +108,8 @@ const FilterNavigator = ({
       <div className="mv5">
         <ContentLoader
           style={{
-            width: "230px",
-            height: "320px",
+            width: '230px',
+            height: '320px',
           }}
           width="230"
           height="320"
@@ -103,6 +135,7 @@ const FilterNavigator = ({
             tree={tree}
             priceRange={priceRange}
             preventRouteChange={preventRouteChange}
+            navigateToFacet={navigateToFacet}
           />
         </div>
       </div>
@@ -117,6 +150,7 @@ const FilterNavigator = ({
             handles.filter__container,
             'title'
           )} bb b--muted-4`}
+          // eslint-disable-next-line prettier/prettier
         >
           <h5 className={`${handles.filterMessage} t-heading-5 mv5`}>
             <FormattedMessage id="store/search-result.filter-button.title" />
@@ -125,6 +159,7 @@ const FilterNavigator = ({
         <SelectedFilters
           filters={selectedFilters}
           preventRouteChange={preventRouteChange}
+          navigateToFacet={navigateToFacet}
         />
         <DepartmentFilters
           title={CATEGORIES_TITLE}
@@ -137,6 +172,7 @@ const FilterNavigator = ({
           priceRange={priceRange}
           preventRouteChange={preventRouteChange}
           initiallyCollapsed={initiallyCollapsed}
+          navigateToFacet={navigateToFacet}
         />
       </div>
       <ExtensionPoint id="shop-review-summary" />

--- a/react/FilterNavigatorFlexible.js
+++ b/react/FilterNavigatorFlexible.js
@@ -4,6 +4,7 @@ import { useDevice } from 'vtex.device-detector'
 import { pathOr } from 'ramda'
 
 import FilterNavigator from './FilterNavigator'
+import FilterNavigatorContext from './components/FilterNavigatorContext'
 
 import styles from './searchResult.css'
 
@@ -16,14 +17,19 @@ const withSearchPageContextProps = Component => ({ layout }) => {
     hiddenFacets,
     filters,
     showFacets,
-    showContentLoader,
     preventRouteChange,
     facetsLoading,
   } = useSearchPage()
   const { isMobile } = useDevice()
 
   const facets = pathOr({}, ['data', 'facets'], searchQuery)
-  const { brands, priceRanges, specificationFilters, categoriesTrees } = facets
+  const {
+    brands,
+    priceRanges,
+    specificationFilters,
+    categoriesTrees,
+    queryArgs,
+  } = facets
 
   if (showFacets === false || !map) {
     return null
@@ -35,19 +41,21 @@ const withSearchPageContextProps = Component => ({ layout }) => {
         layout === 'desktop' && isMobile ? 'w-100 mh5' : ''
       }`}
     >
-      <Component
-        preventRouteChange={preventRouteChange}
-        brands={brands}
-        params={params}
-        priceRange={priceRange}
-        priceRanges={priceRanges}
-        specificationFilters={specificationFilters}
-        tree={categoriesTrees}
-        loading={facetsLoading}
-        filters={filters}
-        hiddenFacets={hiddenFacets}
-        layout={layout}
-      />
+      <FilterNavigatorContext.Provider value={queryArgs}>
+        <Component
+          preventRouteChange={preventRouteChange}
+          brands={brands}
+          params={params}
+          priceRange={priceRange}
+          priceRanges={priceRanges}
+          specificationFilters={specificationFilters}
+          tree={categoriesTrees}
+          loading={facetsLoading}
+          filters={filters}
+          hiddenFacets={hiddenFacets}
+          layout={layout}
+        />
+      </FilterNavigatorContext.Provider>
     </div>
   )
 }

--- a/react/__tests__/FilterNavigator.test.js
+++ b/react/__tests__/FilterNavigator.test.js
@@ -8,6 +8,7 @@ import FilterNavigator from '../FilterNavigator'
 import QueryContext from '../components/QueryContext'
 
 import { useRuntime } from '../__mocks__/vtex.render-runtime'
+import FilterNavigatorContext from '../components/FilterNavigatorContext'
 const mockUseRuntime = useRuntime
 
 const mockNavigate = jest.fn()
@@ -26,6 +27,7 @@ describe('<FilterNavigator />', () => {
     const props = {
       map: 'c',
       tree: categoriesTree,
+      queryArgs: { query: customProps.query, map: 'c' },
       ...customProps,
     }
 
@@ -33,7 +35,11 @@ describe('<FilterNavigator />', () => {
       <QueryContext.Provider
         value={{ query: customProps.query, map: props.map }}
       >
-        <FilterNavigator {...props} />
+        <FilterNavigatorContext.Provider
+          value={{ query: customProps.query, map: props.map }}
+        >
+          <FilterNavigator {...props} />
+        </FilterNavigatorContext.Provider>
       </QueryContext.Provider>
     )
   }

--- a/react/__tests__/useFacetNavigation.test.js
+++ b/react/__tests__/useFacetNavigation.test.js
@@ -72,15 +72,25 @@ it('pass array of facets as args work', () => {
   const { result } = renderHook(() => useFacetNavigation([]))
   act(() => {
     result.current([
-      { map: 'b', value: 'OtherBrand', title: '' },
-      { map: 'specificationFilter_100', value: 'Mens', title: 'gender' },
-      { map: 'c', value: 'shorts', title: '' },
+      {
+        map: 'b',
+        value: 'OtherBrand',
+        title: '',
+        newQuerySegment: 'otherbrand',
+      },
+      {
+        map: 'specificationFilter_100',
+        value: 'Mens',
+        title: 'gender',
+        newQuerySegment: 'gender_Mens',
+      },
+      { map: 'c', value: 'shorts', title: '', newQuerySegment: 'shorts' },
     ])
   })
 
   const navigateCall = mockNavigate.mock.calls[0][0]
-  expect(navigateCall.to).toBe('/clothing/shorts/Brand/OtherBrand/gender_Mens')
-  expect(navigateCall.query).toBe('map=b%2Cb')
+  expect(navigateCall.to).toBe('/clothing/shorts/Brand/otherbrand/gender_Mens')
+  expect(navigateCall.query).toBe('map=b%2Cb%2CspecificationFilter_100')
 })
 
 // We've removed the concept of preventRouteChange since the urls should be transformed to the new urls format.

--- a/react/__tests__/useFacetNavigation.test.js
+++ b/react/__tests__/useFacetNavigation.test.js
@@ -2,9 +2,12 @@ import useFacetNavigation from '../hooks/useFacetNavigation'
 import { renderHook, act } from '@testing-library/react-hooks'
 
 jest.mock('../components/QueryContext')
+jest.mock('../components/FilterNavigatorContext')
 const { useQuery } = require('../components/QueryContext')
 
 import { useRuntime } from '../__mocks__/vtex.render-runtime'
+import { useFilterNavigator } from '../components/FilterNavigatorContext'
+
 const mockUseRuntime = useRuntime
 
 const mockNavigate = jest.fn()
@@ -19,69 +22,65 @@ beforeEach(() => {
 })
 
 it('navigating to another category facet', () => {
+  // The new idea here is that we event though we pass the map=c,c,c to navigate we dont have it in our response anymore.
+  // This state is recordered and sent by search-graphql so we can know where we are in catalog search
+  const map = 'c'
   useQuery.mockImplementation(() => ({
     query: 'clothing',
-    map: 'c'
   }))
-  
-  const { result } = renderHook(() => useFacetNavigation())
+  useFilterNavigator.mockImplementation(() => ({
+    map,
+  }))
+
+  const { result } = renderHook(() => useFacetNavigation([]))
   act(() => {
     result.current({ map: 'c', value: 'shorts' })
   })
 
   const navigateCall = mockNavigate.mock.calls[0][0]
   expect(navigateCall.to).toBe('/clothing/shorts')
-  expect(navigateCall.query).toBe('map=c%2Cc')
 })
 
 it('joins categories', () => {
+  const map = 'c,b'
   useQuery.mockImplementation(() => ({
     query: 'clothing/Brand',
-    map: 'c,b'
   }))
-  
-  const { result } = renderHook(() => useFacetNavigation())
+  useFilterNavigator.mockImplementation(() => ({
+    map,
+  }))
+
+  const { result } = renderHook(() => useFacetNavigation([]))
   act(() => {
     result.current({ map: 'c', value: 'shorts' })
   })
 
   const navigateCall = mockNavigate.mock.calls[0][0]
   expect(navigateCall.to).toBe('/clothing/shorts/Brand')
-  expect(navigateCall.query).toBe('map=c%2Cc%2Cb')
+  expect(navigateCall.query).toBe('map=b')
 })
 
 it('pass array of facets as args work', () => {
+  const map = 'c,b'
   useQuery.mockImplementation(() => ({
     query: 'clothing/Brand',
-    map: 'c,b'
   }))
-  
-  const { result } = renderHook(() => useFacetNavigation())
+  useFilterNavigator.mockImplementation(() => ({
+    map,
+  }))
+
+  const { result } = renderHook(() => useFacetNavigation([]))
   act(() => {
-    result.current([{ map: 'b', value: 'OtherBrand' }, { map: 'specificationFilter_100', value: 'Mens' }, {map: 'c', value: 'shorts'}])
+    result.current([
+      { map: 'b', value: 'OtherBrand', title: '' },
+      { map: 'specificationFilter_100', value: 'Mens', title: 'gender' },
+      { map: 'c', value: 'shorts', title: '' },
+    ])
   })
 
   const navigateCall = mockNavigate.mock.calls[0][0]
-  expect(navigateCall.to).toBe('/clothing/shorts/Brand/OtherBrand/Mens')
-  expect(navigateCall.query).toBe('map=c%2Cc%2Cb%2Cb%2CspecificationFilter_100')
+  expect(navigateCall.to).toBe('/clothing/shorts/Brand/OtherBrand/gender_Mens')
+  expect(navigateCall.query).toBe('map=b%2Cb')
 })
 
-
-it('if preventRouteChange call setQuery and not navigate', () => {
-  useQuery.mockImplementation(() => ({
-    query: 'clothing/Brand',
-    map: 'c,b'
-  }))
-  
-  const { result } = renderHook(() => useFacetNavigation())
-  act(() => {
-    result.current({ map: 'c', value: 'shorts' }, true)
-  })
-
-  const setQueryCall = mockSetQuery.mock.calls[0][0]
-  expect(setQueryCall.query).toBe('/clothing/shorts/Brand')
-  expect(setQueryCall.map).toBe('c,c,b')
-  expect(setQueryCall.page).toBe(undefined)
-  expect(mockNavigate.mock.calls.length).toBe(0)
-
-})
+// We've removed the concept of preventRouteChange since the urls should be transformed to the new urls format.

--- a/react/components/AccordionFilterContainer.js
+++ b/react/components/AccordionFilterContainer.js
@@ -14,6 +14,7 @@ import styles from '../searchResult.css'
 const CATEGORIES_TITLE = 'store/search.filter.title.categories'
 
 const AccordionFilterContainer = ({
+  map,
   filters,
   intl,
   onFilterCheck,
@@ -92,6 +93,7 @@ const AccordionFilterContainer = ({
       >
         <div className={itemClassName}>
           <DepartmentFilters
+            map={map}
             tree={tree}
             isVisible={tree.length > 0}
             onCategorySelect={onCategorySelect}
@@ -139,6 +141,8 @@ const AccordionFilterContainer = ({
 }
 
 AccordionFilterContainer.propTypes = {
+  /** Legacy search map */
+  map: PropTypes.string,
   /** Current available filters */
   filters: PropTypes.arrayOf(PropTypes.object),
   /** Intl instance */

--- a/react/components/AccordionFilterGroup.js
+++ b/react/components/AccordionFilterGroup.js
@@ -26,7 +26,11 @@ const AccordionFilterGroup = ({
       quantitySelected={quantitySelected}
     >
       <div className={className}>
-        <FacetCheckboxList onFilterCheck={onFilterCheck} facets={filters} />
+        <FacetCheckboxList
+          title={title}
+          onFilterCheck={onFilterCheck}
+          facets={filters}
+        />
       </div>
     </AccordionFilterItem>
   )

--- a/react/components/AvailableFilters.js
+++ b/react/components/AvailableFilters.js
@@ -9,6 +9,7 @@ const AvailableFilters = ({
   priceRange,
   preventRouteChange = false,
   initiallyCollapsed = false,
+  navigateToFacet,
 }) =>
   filters.map(filter => {
     const { type, title, facets, oneSelectedCollapse = false } = filter
@@ -33,6 +34,7 @@ const AvailableFilters = ({
             oneSelectedCollapse={oneSelectedCollapse}
             preventRouteChange={preventRouteChange}
             initiallyCollapsed={initiallyCollapsed}
+            navigateToFacet={navigateToFacet}
           />
         )
     }

--- a/react/components/CategoryFilter.js
+++ b/react/components/CategoryFilter.js
@@ -1,10 +1,10 @@
 import classNames from 'classnames'
-import React, { useContext } from 'react'
+import React from 'react'
 import { injectIntl } from 'react-intl'
 import { IconClose } from 'vtex.styleguide'
 import { useCssHandles } from 'vtex.css-handles'
+import { useFilterNavigator } from './FilterNavigatorContext'
 
-import QueryContext from './QueryContext'
 import Collapsible from './Collapsible'
 import CategoryItem from './CategoryItem'
 
@@ -38,7 +38,7 @@ const getSelectedCategories = rootCategory => {
 }
 
 const CategoryFilter = ({ category, shallow = false, onCategorySelect }) => {
-  const { map } = useContext(QueryContext)
+  const { map } = useFilterNavigator()
   const handles = useCssHandles(CSS_HANDLES)
 
   const selectedCategories = getSelectedCategories(category)
@@ -59,7 +59,7 @@ const CategoryFilter = ({ category, shallow = false, onCategorySelect }) => {
     }
 
     if (shallow) {
-      onCategorySelect(category)
+      onCategorySelect()
     } else {
       // deselect root category
       handleUnselectCategories(0)

--- a/react/components/CategoryFilter.js
+++ b/react/components/CategoryFilter.js
@@ -37,7 +37,12 @@ const getSelectedCategories = rootCategory => {
   return selectedCategories
 }
 
-const CategoryFilter = ({ category, shallow = false, onCategorySelect }) => {
+const CategoryFilter = ({
+  category,
+  shallow = false,
+  onCategorySelect,
+  preventRouteChange,
+}) => {
   const { map } = useFilterNavigator()
   const handles = useCssHandles(CSS_HANDLES)
 
@@ -46,7 +51,7 @@ const CategoryFilter = ({ category, shallow = false, onCategorySelect }) => {
   const handleUnselectCategories = index => {
     const categoriesToRemove = selectedCategories.slice(index)
 
-    onCategorySelect(categoriesToRemove)
+    onCategorySelect(categoriesToRemove, preventRouteChange)
   }
 
   const lastSelectedCategory = selectedCategories[selectedCategories.length - 1]
@@ -151,7 +156,8 @@ const CategoryFilter = ({ category, shallow = false, onCategorySelect }) => {
                     })}
                     onClick={() =>
                       onCategorySelect(
-                        shallow ? [category, childCategory] : childCategory
+                        shallow ? [category, childCategory] : childCategory,
+                        preventRouteChange
                       )
                     }
                     label={childCategory.name}

--- a/react/components/DepartmentFilters.js
+++ b/react/components/DepartmentFilters.js
@@ -14,6 +14,7 @@ const CSS_HANDLES = [
 ]
 
 const DepartmentFilters = ({
+  map,
   title,
   isVisible,
   tree,
@@ -61,6 +62,7 @@ const DepartmentFilters = ({
             render={category => (
               <CategoryFilter
                 key={category.id}
+                map={map}
                 category={category}
                 shallow
                 onCategorySelect={onCategorySelect}
@@ -68,11 +70,12 @@ const DepartmentFilters = ({
             )}
           />
         ) : (
-            <CategoryFilter
-              category={tree.find(category => category.selected)}
-              onCategorySelect={onCategorySelect}
-            />
-          )}
+          <CategoryFilter
+            map={map}
+            category={tree.find(category => category.selected)}
+            onCategorySelect={onCategorySelect}
+          />
+        )}
       </div>
     </div>
   )

--- a/react/components/DepartmentFilters.js
+++ b/react/components/DepartmentFilters.js
@@ -20,6 +20,7 @@ const DepartmentFilters = ({
   tree,
   onCategorySelect,
   hideBorder = false,
+  preventRouteChange,
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
   if (!isVisible) {
@@ -66,6 +67,7 @@ const DepartmentFilters = ({
                 category={category}
                 shallow
                 onCategorySelect={onCategorySelect}
+                preventRouteChange={preventRouteChange}
               />
             )}
           />
@@ -74,6 +76,7 @@ const DepartmentFilters = ({
             map={map}
             category={tree.find(category => category.selected)}
             onCategorySelect={onCategorySelect}
+            preventRouteChange={preventRouteChange}
           />
         )}
       </div>

--- a/react/components/FacetCheckboxList.js
+++ b/react/components/FacetCheckboxList.js
@@ -2,13 +2,10 @@ import classNames from 'classnames'
 import React from 'react'
 import { Checkbox } from 'vtex.styleguide'
 
-import useSelectedFilters from '../hooks/useSelectedFilters'
 import styles from '../searchResult.css'
 
-const FacetCheckboxList = ({ facets, onFilterCheck }) => {
-  const facetsWithSelected = useSelectedFilters(facets)
-
-  return facetsWithSelected.map(facet => {
+const FacetCheckboxList = ({ title, facets, onFilterCheck }) => {
+  return facets.map(facet => {
     const { name } = facet
 
     return (
@@ -18,7 +15,7 @@ const FacetCheckboxList = ({ facets, onFilterCheck }) => {
           'pr4 pt3 items-center flex bb b--muted-5'
         )}
         key={name}
-        style={{hyphens: 'auto', wordBreak: 'break-word'}}
+        style={{ hyphens: 'auto', wordBreak: 'break-word' }}
       >
         <Checkbox
           className="mb0"
@@ -26,7 +23,7 @@ const FacetCheckboxList = ({ facets, onFilterCheck }) => {
           id={name}
           label={name}
           name={name}
-          onChange={() => onFilterCheck(facet)}
+          onChange={() => onFilterCheck(title, facet)}
           value={name}
         />
       </div>

--- a/react/components/FacetItem.js
+++ b/react/components/FacetItem.js
@@ -7,7 +7,13 @@ import SettingsContext from './SettingsContext'
 
 const CSS_HANDLES = ['filterItem']
 
-const FacetItem = ({ navigateToFacet, facetTitle, facet, className }) => {
+const FacetItem = ({
+  navigateToFacet,
+  facetTitle,
+  facet,
+  className,
+  preventRouteChange,
+}) => {
   const { showFacetQuantity } = useContext(SettingsContext)
   const handles = useCssHandles(CSS_HANDLES)
   const classes = classNames(
@@ -29,7 +35,9 @@ const FacetItem = ({ navigateToFacet, facetTitle, facet, className }) => {
           showFacetQuantity ? `${facet.name} (${facet.quantity})` : facet.name
         }
         name={facet.name}
-        onChange={() => navigateToFacet({ ...facet, title: facetTitle })}
+        onChange={() =>
+          navigateToFacet({ ...facet, title: facetTitle }, preventRouteChange)
+        }
         value={facet.name}
       />
     </div>

--- a/react/components/FacetItem.js
+++ b/react/components/FacetItem.js
@@ -4,15 +4,12 @@ import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 import classNames from 'classnames'
 
 import SettingsContext from './SettingsContext'
-import useFacetNavigation from '../hooks/useFacetNavigation'
 
 const CSS_HANDLES = ['filterItem']
 
-const FacetItem = ({ facet, className, preventRouteChange = false }) => {
+const FacetItem = ({ navigateToFacet, facetTitle, facet, className }) => {
   const { showFacetQuantity } = useContext(SettingsContext)
   const handles = useCssHandles(CSS_HANDLES)
-  const navigateToFacet = useFacetNavigation()
-
   const classes = classNames(
     applyModifiers(handles.filterItem, facet.value),
     { [`${handles.filterItem}--selected`]: facet.selected },
@@ -32,7 +29,7 @@ const FacetItem = ({ facet, className, preventRouteChange = false }) => {
           showFacetQuantity ? `${facet.name} (${facet.quantity})` : facet.name
         }
         name={facet.name}
-        onChange={() => navigateToFacet(facet, preventRouteChange)}
+        onChange={() => navigateToFacet({ ...facet, title: facetTitle })}
         value={facet.name}
       />
     </div>

--- a/react/components/FilterNavigatorContext.ts
+++ b/react/components/FilterNavigatorContext.ts
@@ -1,0 +1,7 @@
+import { createContext, useContext } from 'react'
+
+const FilterNavigatorContext = createContext({})
+
+export default FilterNavigatorContext
+
+export const useFilterNavigator = () => useContext(FilterNavigatorContext)

--- a/react/components/FilterNavigatorContext.ts
+++ b/react/components/FilterNavigatorContext.ts
@@ -1,7 +1,0 @@
-import { createContext, useContext } from 'react'
-
-const FilterNavigatorContext = createContext({})
-
-export default FilterNavigatorContext
-
-export const useFilterNavigator = () => useContext(FilterNavigatorContext)

--- a/react/components/FilterNavigatorContext.tsx
+++ b/react/components/FilterNavigatorContext.tsx
@@ -1,0 +1,7 @@
+import { createContext, useContext } from 'react'
+
+const FilterNavigatorContext = createContext({})
+
+export default FilterNavigatorContext
+
+export const useFilterNavigator = () => useContext(FilterNavigatorContext)

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -66,7 +66,7 @@ const FilterSidebar = ({
 
   const handleClearFilters = () => {
     setFilterOperations(selectedFilters) // this is necessary to unselect the selected checkboxes
-    navigateToFacet(selectedFilters)
+    navigateToFacet(selectedFilters, preventRouteChange)
     setOpen(false)
   }
 

--- a/react/components/SearchFilter.js
+++ b/react/components/SearchFilter.js
@@ -17,23 +17,27 @@ const SearchFilter = ({
   intl,
   preventRouteChange = false,
   initiallyCollapsed = false,
+  navigateToFacet,
 }) => {
   const filtersWithSelected = useSelectedFilters(facets)
 
   const sampleFacet = facets && facets.length > 0 ? facets[0] : null
+  const facetTitle = getFilterTitle(title, intl)
 
   return (
     <FilterOptionTemplate
       id={sampleFacet ? sampleFacet.map : null}
-      title={getFilterTitle(title, intl)}
+      title={facetTitle}
       filters={filtersWithSelected}
       initiallyCollapsed={initiallyCollapsed}
     >
       {facet => (
         <FacetItem
           key={facet.name}
+          facetTitle={facetTitle}
           facet={facet}
           preventRouteChange={preventRouteChange}
+          navigateToFacet={navigateToFacet}
         />
       )}
     </FilterOptionTemplate>
@@ -50,6 +54,7 @@ SearchFilter.propTypes = {
   /** Prevent route changes */
   preventRouteChange: PropTypes.bool,
   initiallyCollapsed: PropTypes.bool,
+  navigateToFacet: PropTypes.func,
 }
 
 export default injectIntl(SearchFilter)

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -13,6 +13,7 @@ import FetchPreviousButton from './loaders/FetchPreviousButton'
 import FetchMoreButton from './loaders/FetchMoreButton'
 import LoadingSpinner from './loaders/LoadingSpinner'
 import { PAGINATION_TYPE } from '../constants/paginationType'
+import FilterNavigatorContext from './FilterNavigatorContext'
 
 import getFilters from '../utils/getFilters'
 
@@ -39,7 +40,6 @@ class SearchResult extends Component {
     products: this.props.products,
     recordsFiltered: this.props.recordsFiltered,
     brands: this.props.brands,
-    map: this.props.map,
     params: this.props.params,
     priceRange: this.props.priceRange,
     priceRanges: this.props.priceRanges,
@@ -74,7 +74,6 @@ class SearchResult extends Component {
         products,
         recordsFiltered,
         brands,
-        map,
         params,
         priceRange,
         priceRanges,
@@ -87,7 +86,6 @@ class SearchResult extends Component {
         products,
         recordsFiltered,
         brands,
-        map,
         params,
         priceRange,
         priceRanges,
@@ -140,7 +138,6 @@ class SearchResult extends Component {
       recordsFiltered,
       products = [],
       brands,
-      map,
       params,
       priceRange,
       priceRanges,
@@ -149,6 +146,12 @@ class SearchResult extends Component {
       hiddenFacets,
       showLoadingAsOverlay,
     } = this.state
+
+    const queryArgs = this.props.searchQuery.facets
+      ? this.props.searchQuery.facets.queryArgs
+      : { query: '', map: '' }
+
+    const { map } = queryArgs
 
     const hideFacets = !map || !map.length
     const showLoading = loading && !fetchMoreLoading
@@ -192,18 +195,20 @@ class SearchResult extends Component {
           />
           {showFacets && !!map && (
             <div className={styles.filters}>
-              <ExtensionPoint
-                id="filter-navigator"
-                brands={brands}
-                params={params}
-                priceRange={priceRange}
-                priceRanges={priceRanges}
-                specificationFilters={specificationFilters}
-                tree={tree}
-                loading={showFacetsContentLoader}
-                filters={filters}
-                hiddenFacets={hiddenFacets}
-              />
+              <FilterNavigatorContext.Provider value={queryArgs}>
+                <ExtensionPoint
+                  id="filter-navigator"
+                  brands={brands}
+                  params={params}
+                  priceRange={priceRange}
+                  priceRanges={priceRanges}
+                  specificationFilters={specificationFilters}
+                  tree={tree}
+                  loading={showFacetsContentLoader}
+                  filters={filters}
+                  hiddenFacets={hiddenFacets}
+                />
+              </FilterNavigatorContext.Provider>
             </div>
           )}
           <ExtensionPoint
@@ -274,7 +279,4 @@ class SearchResult extends Component {
   }
 }
 
-export default compose(
-  withRuntimeContext,
-  withDevice
-)(SearchResult)
+export default compose(withRuntimeContext, withDevice)(SearchResult)

--- a/react/components/SelectedFilters.js
+++ b/react/components/SelectedFilters.js
@@ -13,9 +13,11 @@ const CSS_HANDLES = ['selectedFilterItem']
  * Search Filter Component.
  */
 const SelectedFilters = ({
+  map,
   filters = [],
   intl,
   preventRouteChange = false,
+  navigateToFacet,
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
   if (!filters.length) {
@@ -33,10 +35,13 @@ const SelectedFilters = ({
     >
       {facet => (
         <FacetItem
+          map={map}
           key={facet.name}
+          facetTitle={facet.title}
           facet={facet}
           className={handles.selectedFilterItem}
           preventRouteChange={preventRouteChange}
+          navigateToFacet={navigateToFacet}
         />
       )}
     </FilterOptionTemplate>
@@ -44,12 +49,16 @@ const SelectedFilters = ({
 }
 
 SelectedFilters.propTypes = {
+  filterTitle: PropTypes.string,
+  /** Legacy search map */
+  map: PropTypes.string,
   /** Selected filters. */
   filters: PropTypes.arrayOf(facetOptionShape).isRequired,
   /** Intl instance. */
   intl: intlShape,
   /** Prevent route changes */
   preventRouteChange: PropTypes.bool,
+  navigateToFacet: PropTypes.func,
 }
 
 export default injectIntl(SelectedFilters)

--- a/react/constants.ts
+++ b/react/constants.ts
@@ -1,0 +1,8 @@
+export const MAP_CATEGORY_CHAR = 'c'
+export const MAP_BRAND_CHAR = 'b'
+export const MAP_QUERY_KEY = 'map'
+export const MAP_VALUES_SEP = ','
+export const PATH_SEPARATOR = '/'
+export const SPACE_REPLACER = '-'
+export const FILTER_TITLE_SEP = '_'
+export const SPEC_FILTER = 'specificationFilter'

--- a/react/hooks/useFacetNavigation.js
+++ b/react/hooks/useFacetNavigation.js
@@ -179,16 +179,14 @@ const useFacetNavigation = selectedFacets => {
     )
 
     const urlParams = getCleanUrlParams(currentMap)
-    const modifiersIgnore = getStaticPathSegments([
-      ...selectedFacets,
-      ...facets,
-    ])
 
     navigate({
       to: `${PATH_SEPARATOR}${currentQuery}`,
       query: urlParams.toString(),
       scrollOptions,
-      modifiersOptions: modifiersIgnore,
+      modifiersOptions: {
+        LOWERCASE: false,
+      },
     })
   })
 

--- a/react/hooks/useFacetNavigation.js
+++ b/react/hooks/useFacetNavigation.js
@@ -23,7 +23,7 @@ const removeElementAtIndex = (strArray, index) =>
 
 const upsert = (array, item) => {
   const foundItemIndex = array.findIndex(e => e.name === item.name)
-  if (!foundItemIndex) {
+  if (foundItemIndex === -1) {
     array.push(item)
   } else {
     array[foundItemIndex] = item
@@ -33,7 +33,8 @@ const upsert = (array, item) => {
 const removeMapForNewURLFormat = (queryAndMap, selectedFacets) => {
   const mapsToFilter = selectedFacets.reduce((acc, facet) => {
     return facet.map === MAP_CATEGORY_CHAR ||
-      facet.newQuerySegments !== facet.value
+      (facet.newQuerySegment &&
+        facet.newQuerySegment.toLowerCase() !== facet.value.toLowerCase())
       ? acc.concat(facet.map)
       : acc
   }, [])

--- a/react/hooks/useFacetNavigation.js
+++ b/react/hooks/useFacetNavigation.js
@@ -2,111 +2,178 @@ import { zip } from 'ramda'
 import { useCallback } from 'react'
 import { useRuntime } from 'vtex.render-runtime'
 import { useQuery } from '../components/QueryContext'
-
+import { useFilterNavigator } from '../components/FilterNavigatorContext'
+import { newFacetPathName } from '../utils/slug'
 import { HEADER_SCROLL_OFFSET } from '../constants/SearchHelpers'
+import {
+  MAP_CATEGORY_CHAR,
+  MAP_QUERY_KEY,
+  MAP_VALUES_SEP,
+  PATH_SEPARATOR,
+  SPEC_FILTER,
+} from '../constants'
 
 const scrollOptions = {
   baseElementId: 'search-result-anchor',
   top: -HEADER_SCROLL_OFFSET,
 }
 
-const removeElementAtIndex = (str, index, separator) =>
-  str
-    .split(separator)
-    .filter((_, i) => i !== index)
-    .join(separator)
+const removeElementAtIndex = (strArray, index) =>
+  strArray.filter((_, i) => i !== index)
 
-export const buildQueryAndMap = (inputQuery, inputMap, facets) =>
-  facets.reduce(
+const removeMapForNewURLFormat = (queryAndMap, selectedFacets) => {
+  return queryAndMap.map.filter(
+    mapValue =>
+      selectedFacets.findIndex(facet => facet.map === mapValue) === -1 ||
+      (mapValue !== MAP_CATEGORY_CHAR && !mapValue.includes(SPEC_FILTER))
+  )
+}
+
+const getCleanUrlParams = currentMap => {
+  const urlParams = new URLSearchParams(window.location.search)
+  urlParams.set(MAP_QUERY_KEY, currentMap)
+  if (!currentMap) {
+    urlParams.delete(MAP_QUERY_KEY)
+  }
+  return urlParams
+}
+
+const getStaticPathSegments = facets => {
+  const fieldsNotNormalizable = facets
+    .filter(facet => facet.map.includes(SPEC_FILTER))
+    .map(facet => newFacetPathName(facet))
+    .join(PATH_SEPARATOR)
+  const modifiersIgnore = {
+    [fieldsNotNormalizable]: {
+      path: fieldsNotNormalizable,
+    },
+  }
+  return modifiersIgnore
+}
+
+export const convertSegmentsToNewURLs = (
+  querySegments,
+  mapSegments,
+  facets
+) => {
+  const newQuerySegments = querySegments.map(querySegment => {
+    const selectedFacet = facets.find(
+      facet => facet.value.toLowerCase() === querySegment.toLowerCase()
+    )
+    const newSegment = selectedFacet
+      ? selectedFacet.newFacetPathName
+        ? selectedFacet.newFacetPathName
+        : newFacetPathName(selectedFacet)
+      : querySegment
+    return newSegment
+  })
+  return { map: mapSegments, query: newQuerySegments }
+}
+
+const buildQueryAndMap = (
+  querySegments,
+  mapSegments,
+  facets,
+  selectedFacets
+) => {
+  const queryAndMap = facets.reduce(
     ({ query, map }, facet) => {
+      const facetValue = newFacetPathName(facet)
+      facet.newQuerySegment = facetValue
       if (facet.selected) {
-        const facetIndex = zip(
-          query
-            .toLowerCase()
-            .split('/')
-            .map(decodeURIComponent),
-          map.split(',')
-        ).findIndex(
+        const facetIndex = zip(query, map).findIndex(
           ([value, valueMap]) =>
-            value === decodeURIComponent(facet.value).toLowerCase() &&
+            decodeURIComponent(value).toLowerCase() ===
+              decodeURIComponent(facetValue).toLowerCase() &&
             valueMap === facet.map
         )
-
+        selectedFacets = selectedFacets.filter(
+          selectedFacet => selectedFacet.value !== facet.value
+        )
         return {
-          query: removeElementAtIndex(query, facetIndex, '/'),
-          map: removeElementAtIndex(map, facetIndex, ','),
+          query: removeElementAtIndex(querySegments, facetIndex),
+          map: removeElementAtIndex(mapSegments, facetIndex),
         }
       }
 
-      if (facet.map === 'c') {
-        const mapArray = map.split(',')
-        const lastCategoryIndex = mapArray.lastIndexOf('c')
-        if (
-          lastCategoryIndex >= 0 &&
-          lastCategoryIndex !== mapArray.length - 1
-        ) {
+      if (facet.map === MAP_CATEGORY_CHAR) {
+        const lastCategoryIndex = map.lastIndexOf(MAP_CATEGORY_CHAR)
+        if (lastCategoryIndex >= 0 && lastCategoryIndex !== map.length - 1) {
           // Corner case: if we are adding a category but there are other filter other than category applied. Add the new category filter to the right of the other categories.
-          const queryArray = query.split('/')
           return {
             query: [
-              ...queryArray.slice(0, lastCategoryIndex + 1),
-              facet.value,
-              ...queryArray.slice(lastCategoryIndex + 1),
-            ].join('/'),
+              ...query.slice(0, lastCategoryIndex + 1),
+              facetValue,
+              ...query.slice(lastCategoryIndex + 1),
+            ],
             map: [
-              ...mapArray.slice(0, lastCategoryIndex + 1),
+              ...map.slice(0, lastCategoryIndex + 1),
               facet.map,
-              ...mapArray.slice(lastCategoryIndex + 1),
-            ].join(','),
+              ...map.slice(lastCategoryIndex + 1),
+            ],
           }
         }
       }
 
       return {
-        query: `${query}/${facet.value}`,
-        map: `${map},${facet.map}`,
+        query: [...query, facetValue],
+        map: [...map, facet.map],
       }
     },
-    { query: inputQuery, map: inputMap }
+    { query: querySegments, map: mapSegments }
   )
+  return {
+    query: queryAndMap.query.join(PATH_SEPARATOR),
+    map: removeMapForNewURLFormat(queryAndMap, selectedFacets).join(
+      MAP_VALUES_SEP
+    ),
+  }
+}
 
-const useFacetNavigation = () => {
-  const { navigate, setQuery } = useRuntime()
-  const { query, map } = useQuery()
+export const buildNewQueryMap = (query, map, facets, selectedFacets) => {
+  const querySegments = (query && query.split(PATH_SEPARATOR)) || []
+  const mapSegments = (map && map.split(MAP_VALUES_SEP)) || []
 
-  const navigateToFacet = useCallback(
-    (maybeFacets, preventRouteChange = false) => {
-      const facets = Array.isArray(maybeFacets) ? maybeFacets : [maybeFacets]
+  const {
+    query: newQuerySegments,
+    map: newMapSegments,
+  } = convertSegmentsToNewURLs(querySegments, mapSegments, selectedFacets)
 
-      const { query: currentQuery, map: currentMap } = buildQueryAndMap(
-        query,
-        map,
-        facets
-      )
-
-      if (preventRouteChange) {
-        setQuery({
-          map: `${currentMap}`,
-          query: `/${currentQuery}`,
-          page: undefined,
-        })
-        return
-      }
-
-      const urlParams = new URLSearchParams(window.location.search)
-
-      urlParams.set('map', currentMap)
-      urlParams.delete('page')
-      urlParams.delete('query')
-
-      navigate({
-        to: `/${currentQuery}`,
-        query: urlParams.toString(),
-        scrollOptions,
-      })
-    },
-    [query, map, navigate, setQuery]
+  return buildQueryAndMap(
+    newQuerySegments,
+    newMapSegments,
+    facets,
+    selectedFacets
   )
+}
+
+const useFacetNavigation = selectedFacets => {
+  const { navigate } = useRuntime()
+  const { query } = useQuery()
+  const { map } = useFilterNavigator()
+
+  const navigateToFacet = useCallback(maybeFacets => {
+    const facets = Array.isArray(maybeFacets) ? maybeFacets : [maybeFacets]
+    const { query: currentQuery, map: currentMap } = buildNewQueryMap(
+      query,
+      map,
+      facets,
+      selectedFacets
+    )
+
+    const urlParams = getCleanUrlParams(currentMap)
+    const modifiersIgnore = getStaticPathSegments([
+      ...selectedFacets,
+      ...facets,
+    ])
+
+    navigate({
+      to: `${PATH_SEPARATOR}${currentQuery}`,
+      query: urlParams.toString(),
+      scrollOptions,
+      modifiersOptions: modifiersIgnore,
+    })
+  })
 
   return navigateToFacet
 }

--- a/react/hooks/useFacetNavigation.js
+++ b/react/hooks/useFacetNavigation.js
@@ -21,6 +21,15 @@ const scrollOptions = {
 const removeElementAtIndex = (strArray, index) =>
   strArray.filter((_, i) => i !== index)
 
+const upsert = (array, item) => {
+  const foundItemIndex = array.findIndex(e => e.name === item.name)
+  if (!foundItemIndex) {
+    array.push(item)
+  } else {
+    array[foundItemIndex] = item
+  }
+}
+
 const removeMapForNewURLFormat = (queryAndMap, selectedFacets) => {
   const mapsToFilter = selectedFacets.reduce((acc, facet) => {
     return facet.map === MAP_CATEGORY_CHAR ||
@@ -100,7 +109,7 @@ const buildQueryAndMap = (
           map: removeElementAtIndex(mapSegments, facetIndex),
         }
       } else {
-        selectedFacets.push(facet)
+        upsert(selectedFacets, facet)
       }
 
       if (facet.map === MAP_CATEGORY_CHAR) {

--- a/react/hooks/useSelectedFilters.js
+++ b/react/hooks/useSelectedFilters.js
@@ -1,7 +1,5 @@
 import { zip } from 'ramda'
-import { useContext } from 'react'
-
-import QueryContext from '../components/QueryContext'
+import { useFilterNavigator } from '../components/FilterNavigatorContext'
 
 /**
  * This hook is required because we make the facets query
@@ -9,7 +7,7 @@ import QueryContext from '../components/QueryContext'
  * need to calculate manually if the other filters are selected
  */
 const useSelectedFilters = facets => {
-  const { query, map } = useContext(QueryContext)
+  const { query, map } = useFilterNavigator()
   if (!query && !map) {
     return []
   }

--- a/react/utils/slug.ts
+++ b/react/utils/slug.ts
@@ -1,0 +1,39 @@
+import {
+  SPACE_REPLACER,
+  SPEC_FILTER,
+  FILTER_TITLE_SEP,
+  MAP_CATEGORY_CHAR,
+  MAP_BRAND_CHAR,
+} from '../constants'
+
+const from =
+  'ÁÄÂÀÃÅČÇĆĎÉĚËÈÊẼĔȆÍÌÎÏŇÑÓÖÒÔÕØŘŔŠŤÚŮÜÙÛÝŸŽáäâàãåčçćďéěëèêẽĕȇíìîïňñóöòôõøðřŕšťúůüùûýÿžþÞĐđßÆa·/_,:;'
+const to =
+  'AAAAAACCCDEEEEEEEEIIIINNOOOOOORRSTUUUUUYYZaaaaaacccdeeeeeeeeiiiinnooooooorrstuuuuuyyzbBDdBAa------'
+const removeAccents = (str: string) => {
+  let newStr = str.slice(0)
+  for (let i = 0; i < from.length; i++) {
+    newStr = newStr.replace(new RegExp(from.charAt(i), 'g'), to.charAt(i))
+  }
+  return newStr
+}
+
+// Parameter "S. Coifman" should output "s--coifman"
+export function searchSlugify(str: string) {
+  // According to Bacelar, the search API uses a legacy method for slugifying strings.
+  // replaces special characters with dashes, remove accents and lower cases everything
+  // eslint-disable-next-line no-useless-escape
+  const replaced = str.replace(/[*+~.()'"!:@&\[\]`,/ %$#?{}|><=_^]/g, '-')
+  return removeAccents(replaced).toLowerCase()
+}
+
+export const newFacetPathName = (facet: any) => {
+  if (facet.map && facet.map.includes(SPEC_FILTER)) {
+    return `${searchSlugify(
+      facet.title
+    )}${FILTER_TITLE_SEP}${facet.value.replace(/\s/g, SPACE_REPLACER)}`
+  } else if (facet.map === MAP_CATEGORY_CHAR || facet.map === MAP_BRAND_CHAR) {
+    return facet.value.toLowerCase()
+  }
+  return facet.value
+}


### PR DESCRIPTION
#### What problem is this solving?
Resolve more friendly URLS for filters

In order to have a platform more SEO friendly we are changing our searches URL structure when applying filters. This is a workaround that should be resolved when we have a complete solution with collections where each collection will be a filter with a nice structured URL.

This feature was started here. https://github.com/vtex-apps/search-result/pull/299

Should be merged after: https://github.com/vtex-apps/search-graphql/pull/49

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
**With `preventRouteChange`**
https://jey--alssports.myvtex.com 
1 - open any category/subcategory
2 - apply filters
3 - see that search and routes kept their behaviour

**Without `preventRouteChange`**
https://jey--worldwidegolf.myvtex.com 
1 - open any category/subcategory
2 - apply filters
3 - see that search routes now have a new URL structure with the same search products as before

#### Screenshots or example usage
https://jey--exitocol.myvtex.com/tecnologia/celulares/smartphones/sistema-operativo_Android

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
