### PR TITLE
Add trackingId prop to the Search Result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `trackingId` prop to the Search Result.
 
 ## [3.47.3] - 2020-02-18
 ### Changed

--- a/docs/README.md
+++ b/docs/README.md
@@ -363,6 +363,7 @@ These properties can be changed in the `blocks.json` file of your theme.
 | `showFacetQuantity` | `Boolean`      | If quantity of items filtered by facet should appear besides its name on `filter-navigator`                                          | `false`           |
 | `blockClass`        | `String`       | Unique class name to be appended to block classes                                                                                    | `""`              |
 | `showProductsCount` | `Boolean`      | controls if the quantity of loaded products and total number of items of a search result are displayed under the `show more` button. | `false`           |
+| `trackingId` | `string` | Name to show in the Google Analytics | If nothing is passed it will just use `'Search result'` | 
 
 ##### QuerySchema
 

--- a/messages/context.json
+++ b/messages/context.json
@@ -33,6 +33,9 @@
   "admin/editor.search-result.showTitle": "Show category title or search term above the gallery",
   "admin/editor.search-result.gap.title": "Gap between gallery items",
   "admin/editor.search-result.facet-quantity": "Show filter item quantity",
+  "admin.editor.search-result.advanced-settings.title": "Advanced settings",
+  "admin.editor.search-result.advanced-settings.trackingId.title": "GTM Search Result name",
+  "admin.editor.search-result.advanced-settings.trackingId.description": "Name to show in the Google Analytics. If nothing is passed it will use just \"Search result\"",
 
   "store/search-result.show-more-button": "Show more",
   "store/search-result.show-previous-button": "Show previous",

--- a/messages/en.json
+++ b/messages/en.json
@@ -33,6 +33,9 @@
   "admin/editor.search-result.showTitle": "Show category title or search term above the gallery",
   "admin/editor.search-result.gap.title": "Gap between gallery items",
   "admin/editor.search-result.facet-quantity": "Show filter item quantity",
+  "admin.editor.search-result.advanced-settings.title": "Advanced settings",
+  "admin.editor.search-result.advanced-settings.trackingId.title": "GTM Search Result name",
+  "admin.editor.search-result.advanced-settings.trackingId.description": "Name to show in the Google Analytics. If nothing is passed it will use just \"Search result\"",
 
   "store/search-result.show-more-button": "Show more",
   "store/search-result.show-previous-button": "Show previous",

--- a/messages/es.json
+++ b/messages/es.json
@@ -33,7 +33,10 @@
   "admin/editor.search-result.showTitle": "Mostrar el título de la categoría o el término de búsqueda en la parte superior de la galería",
   "admin/editor.search-result.gap.title": "Espacio entre los elementos de la galería",
   "admin/editor.search-result.facet-quantity": "Mostrar la cantidad de filtros",
-
+  "admin.editor.search-result.advanced-settings.title": "Configuraciones avanzadas",
+  "admin/editor.shelf.advanced-properties.tracking-id.title": "Nombre del Resultado de búsqueda en el GTM",
+  "admin/editor.shelf.advanced-properties.tracking-id.description": "Nombre para mostrar en Google Analytics. Se no se pasa nada, usará solo \"Search result\"",
+  
   "store/search-result.show-more-button": "Mostrar más",
   "store/search-result.show-previous-button": "Mostrar anteriores",
   "store/search-result.showing-products": "Mostrando {value}",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -33,6 +33,9 @@
   "admin/editor.search-result.showTitle": "Mostrar titulo da categoria ou termo de busca em cima da galeria",
   "admin/editor.search-result.gap.title": "Espaço entre os itens da galeria",
   "admin/editor.search-result.facet-quantity": "Mostrar quantidade dos filtros",
+  "admin.editor.search-result.advanced-settings.title": "Configurações avançadas",
+  "admin/editor.shelf.advanced-properties.tracking-id.title": "Nome do Resultado de pesquisa no GTM",
+  "admin/editor.shelf.advanced-properties.tracking-id.description": "Nome a ser exibido no Google Analytics. Se nada for adicionado, ele usará apenas \"Search result\"",
 
   "store/search-result.show-more-button": "Mostrar mais",
   "store/search-result.show-previous-button": "Mostrar anteriores",

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useMemo, useContext } from 'react'
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import { pluck, splitEvery } from 'ramda'
@@ -13,6 +13,7 @@ import { productShape } from './constants/propTypes'
 import withResizeDetector from './components/withResizeDetector'
 import GalleryRow from './components/GalleryRow'
 import ProductListEventCaller from './utils/ProductListEventCaller'
+import SettingsContext from './components/SettingsContext'
 
 /** Layout with one column */
 const ONE_COLUMN_LAYOUT = 1
@@ -37,6 +38,7 @@ const Gallery = ({
   showingFacets,
 }) => {
   const { isMobile } = useDevice()
+  const { trackingId = 'Search result' } = useContext(SettingsContext) || {}
   const handles = useCssHandles(CSS_HANDLES)
   const responsiveMaxItemsPerRow = useResponsiveValue(maxItemsPerRow)
 
@@ -80,7 +82,7 @@ const Gallery = ({
   )
 
   return (
-    <ProductListProvider>
+    <ProductListProvider listName={trackingId}>
       <div className={galleryClasses}>
         {rows.map((rowProducts, index) => (
           <GalleryRow
@@ -113,6 +115,7 @@ Gallery.propTypes = {
   /** Min Item Width. */
   minItemWidth: PropTypes.number,
   showingFacets: PropTypes.bool,
+  trackingId: PropTypes.string,
 }
 
 export default withResizeDetector(Gallery)

--- a/react/SearchResultFlexible.js
+++ b/react/SearchResultFlexible.js
@@ -57,6 +57,7 @@ const SearchResultFlexible = ({
   orderBy,
   page,
   facetsLoading,
+  trackingId,
 }) => {
   //This makes infinite scroll unavailable.
   //Infinite scroll was deprecated and we have
@@ -103,8 +104,9 @@ const SearchResultFlexible = ({
       pagination,
       mobileLayout,
       showFacetQuantity,
+      trackingId,
     }),
-    [hiddenFacets, mobileLayout, pagination, showFacetQuantity]
+    [hiddenFacets, mobileLayout, pagination, showFacetQuantity, trackingId]
   )
 
   const context = useMemo(

--- a/react/index.js
+++ b/react/index.js
@@ -23,6 +23,7 @@ const SearchResult = props => {
     pagination,
     mobileLayout,
     searchQuery,
+    trackingId,
   } = props
   const { query } = useRuntime()
   const settings = useMemo(
@@ -30,8 +31,9 @@ const SearchResult = props => {
       hiddenFacets,
       pagination,
       mobileLayout,
+      trackingId,
     }),
-    [hiddenFacets, mobileLayout, pagination]
+    [hiddenFacets, mobileLayout, pagination, trackingId]
   )
 
   const fieldsFromQueryString = {
@@ -138,6 +140,24 @@ SearchResult.getSchema = props => {
     title: 'admin/editor.search-result.title',
     description: 'admin/editor.search-result.description',
     type: 'object',
+    dependencies: {
+      advancedSettings: {
+        oneOf: [
+          {
+            properties: {
+              advancedSettings: {
+                enum: [true],
+              },
+              trackingId: {
+                title: 'admin.editor.search-result.advanced-settings.trackingId.title',
+                description: 'admin.editor.search-result.advanced-settings.trackingId.description',
+                type: 'string',
+              },
+            },
+          },
+        ],
+      },
+    },
     properties: {
       ...querySchema,
       mobileLayout: {
@@ -227,6 +247,10 @@ SearchResult.getSchema = props => {
           'admin/editor.search-result.pagination.infinite-scroll',
         ],
         isLayout: true,
+      },
+      advancedSettings: {
+        title: 'admin.editor.search-result.advanced-settings.title',
+        type: 'boolean',
       },
     },
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says.

#### How should this be manually tested?

[workspace](https://oldsearch--storecomponents.myvtex.com/admin/cms/site-editor/shoes?_q=shoes&map=ft)
Follow the same instructions of https://github.com/vtex-apps/product-list-context/pull/4

[old search with wrong `listName`](https://notrackingid--ecowaterqa.myvtex.com/pure?_q=pure&map=ft)

[old search fixed with these changes](https://trackingid--ecowaterqa.myvtex.com/pure?_q=pure&map=ft)

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [X] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
