### PR TITLE
Fixed typo on css handle and on message keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - Typo on `filterApplyButtonWrapper`.
+- `trackingId` messages keys.
 
 ## [3.50.0] - 2020-03-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Typo on `filterApplyButtonWrapper`.
 
 ## [3.50.0] - 2020-03-02
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -515,7 +515,7 @@ To use this CSS API, you must add the `styles` builder and create an app styling
 | `dropdownMobile`                      |
 | `filterAccordionBreadcrumbs`          |
 | `filterAccordionItemBox`              |
-| `filterApplytButtonWrapper`           |
+| `filterApplyButtonWrapper`           |
 | `filterAvailable`                     |
 | `filterButtonsBox`                    |
 | `filterClearButtonWrapper`            |

--- a/messages/es.json
+++ b/messages/es.json
@@ -34,8 +34,8 @@
   "admin/editor.search-result.gap.title": "Espacio entre los elementos de la galería",
   "admin/editor.search-result.facet-quantity": "Mostrar la cantidad de filtros",
   "admin.editor.search-result.advanced-settings.title": "Configuraciones avanzadas",
-  "admin/editor.shelf.advanced-properties.tracking-id.title": "Nombre del Resultado de búsqueda en el GTM",
-  "admin/editor.shelf.advanced-properties.tracking-id.description": "Nombre para mostrar en Google Analytics. Se no se pasa nada, usará solo \"Search result\"",
+  "admin.editor.search-result.advanced-settings.trackingId.title": "Nombre del Resultado de búsqueda en el GTM",
+  "admin.editor.search-result.advanced-settings.trackingId.description": "Nombre para mostrar en Google Analytics. Se no se pasa nada, usará solo \"Search result\"",
   
   "store/search-result.show-more-button": "Mostrar más",
   "store/search-result.show-previous-button": "Mostrar anteriores",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -34,8 +34,8 @@
   "admin/editor.search-result.gap.title": "Espaço entre os itens da galeria",
   "admin/editor.search-result.facet-quantity": "Mostrar quantidade dos filtros",
   "admin.editor.search-result.advanced-settings.title": "Configurações avançadas",
-  "admin/editor.shelf.advanced-properties.tracking-id.title": "Nome do Resultado de pesquisa no GTM",
-  "admin/editor.shelf.advanced-properties.tracking-id.description": "Nome a ser exibido no Google Analytics. Se nada for adicionado, ele usará apenas \"Search result\"",
+  "admin.editor.search-result.advanced-settings.trackingId.title": "Nome do Resultado de pesquisa no GTM",
+  "admin.editor.search-result.advanced-settings.trackingId.description": "Nome a ser exibido no Google Analytics. Se nada for adicionado, ele usará apenas \"Search result\"",
 
   "store/search-result.show-more-button": "Mostrar mais",
   "store/search-result.show-previous-button": "Mostrar anteriores",

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -20,7 +20,7 @@ const CSS_HANDLES = [
   'filterButtonsBox',
   'filterPopupArrowIcon',
   'filterClearButtonWrapper',
-  'filterApplytButtonWrapper',
+  'filterApplyButtonWrapper',
 ]
 
 const FilterSidebar = ({
@@ -148,7 +148,7 @@ const FilterSidebar = ({
             </Button>
           </div>
           <div
-            className={`${handles.filterApplytButtonWrapper} bottom-0 fr w-50 pr4 pl2`}
+            className={`${handles.filterApplyButtonWrapper} bottom-0 fr w-50 pr4 pl2`}
           >
             <Button
               block


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fixed :
- Typo on `filterApplyButtonWrapper`.
- `trackingId` messages keys.

#### How should this be manually tested?

[Workspace](https://iaronaraujo--storecomponents.myvtex.com/apparel---accessories/)
Go on mobile, click on filters and check the css handles on the `clean` and `apply` buttons
#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/8443580/75804368-98cb7100-5d5e-11ea-8f58-361519c0a74e.png)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Requires change to documentation, which has been updated accordingly.
