### PR TITLE
Add initiallyCollapsed prop to filter-navigator.v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Prop `initiallyCollapsed` to `filter-navigator.v3`, allow filters start out collapsed.
 
 ## [3.50.2] - 2020-03-06
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -449,6 +449,7 @@ Notice that the default behavior for your store will be the one defined by the `
 | Prop name | Type                      | Description                                                                                       | Default value |
 | --------- | ------------------------- | ------------------------------------------------------------------------------------------------- | ------------- |
 | `layout`  | `responsive` or `desktop` | Which layout should it use. One might use `desktop` when adding filter-navigator inside a drawer. | `responsive`  |
+| `initiallyCollapsed` | `Boolean` | Makes the search filters start out collapsed.                                                                                                                  | `false`       |
 
 Also, you can configure the product summary that is defined on search-result. See [here](https://github.com/vtex-apps/product-summary/blob/master/README.md#configuration) the Product Summary API.
 

--- a/react/FilterNavigatorFlexible.js
+++ b/react/FilterNavigatorFlexible.js
@@ -8,7 +8,7 @@ import FilterNavigatorContext from './components/FilterNavigatorContext'
 
 import styles from './searchResult.css'
 
-const withSearchPageContextProps = Component => ({ layout }) => {
+const withSearchPageContextProps = Component => ({ layout, initiallyCollapsed }) => {
   const {
     searchQuery,
     map,
@@ -39,7 +39,7 @@ const withSearchPageContextProps = Component => ({ layout }) => {
     <div
       className={`${styles['filters--layout']} ${
         layout === 'desktop' && isMobile ? 'w-100 mh5' : ''
-      }`}
+        }`}
     >
       <FilterNavigatorContext.Provider value={queryArgs}>
         <Component
@@ -54,6 +54,7 @@ const withSearchPageContextProps = Component => ({ layout }) => {
           filters={filters}
           hiddenFacets={hiddenFacets}
           layout={layout}
+          initiallyCollapsed={initiallyCollapsed}
         />
       </FilterNavigatorContext.Provider>
     </div>


### PR DESCRIPTION
#### What is the purpose of this pull request?
The initiallyCollapsed prop to filter-navigator.v3

#### What problem is this solving?
We can set the initiallyCollapsed as true

#### How should this be manually tested?
https://devygor1--bodyandsoulcl.myvtex.com/test-category

#### Screenshots or example usage
https://monosnap.com/direct/vbd6lJczr6ozZXM7vgcAbO6OiESFz7
https://monosnap.com/direct/ndZ7sOr6SpJHJA0CaTkURHh4FZk0jh

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
