### PR TITLE
Fix mobile facets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed mobile facets breaking when `preventRouteChange` wasn't being used.
+
 ### Added
 - Updated `CODEOWNERS` file with responsible teams for each directory.
 

--- a/react/components/AccordionFilterGroup.js
+++ b/react/components/AccordionFilterGroup.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { injectIntl } from 'react-intl'
+import { useIntl } from 'react-intl'
 
 import AccordionFilterItem from './AccordionFilterItem'
 import FacetCheckboxList from './FacetCheckboxList'
@@ -15,10 +15,10 @@ const AccordionFilterGroup = ({
   open,
   onOpen,
   onFilterCheck,
-  intl,
 }) => {
   const filters = useSelectedFilters(facets)
   const quantitySelected = filters.filter(facet => facet.selected).length
+  const intl = useIntl()
   const facetTitle = getFilterTitle(title, intl)
 
   return (
@@ -40,4 +40,4 @@ const AccordionFilterGroup = ({
   )
 }
 
-export default injectIntl(AccordionFilterGroup)
+export default AccordionFilterGroup

--- a/react/components/AccordionFilterGroup.js
+++ b/react/components/AccordionFilterGroup.js
@@ -1,8 +1,11 @@
 import React from 'react'
+import { injectIntl } from 'react-intl'
 
 import AccordionFilterItem from './AccordionFilterItem'
 import FacetCheckboxList from './FacetCheckboxList'
 import useSelectedFilters from '../hooks/useSelectedFilters'
+
+import { getFilterTitle } from '../constants/SearchHelpers'
 
 const AccordionFilterGroup = ({
   className,
@@ -12,10 +15,11 @@ const AccordionFilterGroup = ({
   open,
   onOpen,
   onFilterCheck,
+  intl,
 }) => {
   const filters = useSelectedFilters(facets)
-
   const quantitySelected = filters.filter(facet => facet.selected).length
+  const facetTitle = getFilterTitle(title, intl)
 
   return (
     <AccordionFilterItem
@@ -26,10 +30,14 @@ const AccordionFilterGroup = ({
       quantitySelected={quantitySelected}
     >
       <div className={className}>
-        <FacetCheckboxList onFilterCheck={onFilterCheck} facets={filters} />
+        <FacetCheckboxList
+          onFilterCheck={onFilterCheck}
+          facets={filters}
+          facetTitle={facetTitle}
+        />
       </div>
     </AccordionFilterItem>
   )
 }
 
-export default AccordionFilterGroup
+export default injectIntl(AccordionFilterGroup)

--- a/react/components/FacetCheckboxList.js
+++ b/react/components/FacetCheckboxList.js
@@ -4,7 +4,7 @@ import { Checkbox } from 'vtex.styleguide'
 
 import styles from '../searchResult.css'
 
-const FacetCheckboxList = ({ facets, onFilterCheck }) => {
+const FacetCheckboxList = ({ facets, onFilterCheck, facetTitle }) => {
   return facets.map(facet => {
     const { name } = facet
 
@@ -23,7 +23,7 @@ const FacetCheckboxList = ({ facets, onFilterCheck }) => {
           id={name}
           label={name}
           name={name}
-          onChange={() => onFilterCheck(facet)}
+          onChange={() => onFilterCheck({ ...facet, title: facetTitle })}
           value={name}
         />
       </div>

--- a/react/package.json
+++ b/react/package.json
@@ -46,7 +46,7 @@
     "react-dom": "^16.8.3",
     "react-test-renderer": "^16.7.0",
     "regenerator-runtime": "^0.13.1",
-    "typescript": "3.7.3"
+    "typescript": "3.8.3"
   },
   "version": "3.51.0"
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5741,7 +5741,12 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.7.3, typescript@^3.3.3333:
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+
+typescript@^3.3.3333:
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
   integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==


### PR DESCRIPTION
#### What is the purpose of this pull request?

Previously, on mobile, clicking on a specification filter facet would break the sidebar. With this PR this is fixed, but the facet navigation behavior is still weird

#### How should this be manually tested?

[Workspace](https://iaronaraujo--eriksbikeshop.myvtex.com/cycling/bicycles/road/Dropbar/Performance?map=c,c,c,specificationFilter_254,specificationFilter_254)

1. open this on mobile
2. click on filter > color family > black. Notice that the interface won't show that it was checked.
3. click on "apply"
4. notice that the filter worked as intended.


#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
