### PR TITLE
Fix mobile facets selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Facets selection switch on mobile
 
 ## [3.51.2] - 2020-03-11
 ### Fixed

--- a/react/__tests__/useFacetNavigation.test.js
+++ b/react/__tests__/useFacetNavigation.test.js
@@ -62,28 +62,27 @@ it('pass array of facets as args work', () => {
     query: 'clothing/Brand',
   }))
 
-  const { result } = renderHook(() => useFacetNavigation([]))
+  const facets = [
+    {
+      map: 'b',
+      value: 'OtherBrand',
+      title: '',
+    },
+    {
+      map: 'specificationFilter_100',
+      value: 'Mens',
+      title: 'gender',
+    },
+    { map: 'c', value: 'shorts', title: '', newQuerySegment: 'shorts' },
+  ]
+  const { result } = renderHook(() => useFacetNavigation(facets))
   act(() => {
-    result.current([
-      {
-        map: 'b',
-        value: 'OtherBrand',
-        title: '',
-        newQuerySegment: 'otherbrand',
-      },
-      {
-        map: 'specificationFilter_100',
-        value: 'Mens',
-        title: 'gender',
-        newQuerySegment: 'gender_Mens',
-      },
-      { map: 'c', value: 'shorts', title: '', newQuerySegment: 'shorts' },
-    ])
+    result.current(facets)
   })
 
   const navigateCall = mockNavigate.mock.calls[0][0]
   expect(navigateCall.to).toBe('/clothing/shorts/Brand/otherbrand/gender_Mens')
-  expect(navigateCall.query).toBe('map=b%2Cb%2CspecificationFilter_100')
+  expect(navigateCall.query).toBe('map=b%2Cb')
 })
 
 // We've removed the concept of preventRouteChange since the urls should be transformed to the new urls format.

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -72,8 +72,7 @@ const FilterSidebar = ({
   }
 
   const handleClearFilters = () => {
-    setFilterOperations(selectedFilters) // this is necessary to unselect the selected checkboxes
-    navigateToFacet(selectedFilters, preventRouteChange)
+    setFilterOperations([])
     setOpen(false)
   }
 

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -69,6 +69,7 @@ const FilterSidebar = ({
   const handleApply = () => {
     navigateToFacet(filterOperations, preventRouteChange)
     setOpen(false)
+    setFilterOperations([])
   }
 
   const handleClearFilters = () => {

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -41,8 +41,8 @@ const FilterSidebar = ({
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
   const currentTree = useCategoryTree(tree, categoryTreeOperations)
 
-  const isFilterSelected = (filterOperations, filter) => {
-    return filterOperations.find(
+  const isFilterSelected = (filters, filter) => {
+    return filters.find(
       filterOperation =>
         filter.value === filterOperation.value && filter.map === filter.map
     )
@@ -98,12 +98,6 @@ const FilterSidebar = ({
 
   const context = useMemo(() => {
     const { query, map } = filterContext
-
-    // This should be done properly later. Right now preventRouteChange is always set to true
-    // because we need the queries and map as they used to be to detect the selected
-    // filters. The change to the URL is applied only when navigate is called.
-    // The way this is done will be changed and preventRouteChange will probably
-    // not be necessary on the buildNewQueryMap function anymore.
     return {
       ...filterContext,
       ...buildNewQueryMap(query, map, filterOperations, selectedFilters),

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -47,6 +47,7 @@ const FilterSidebar = ({
         filter.value === filterOperation.value && filter.map === filter.map
     )
   }
+
   const handleFilterCheck = filter => {
     if (!isFilterSelected(filterOperations, filter)) {
       setFilterOperations(filterOperations.concat(filter))
@@ -105,7 +106,7 @@ const FilterSidebar = ({
     // not be necessary on the buildNewQueryMap function anymore.
     return {
       ...filterContext,
-      ...buildNewQueryMap(query, map, filterOperations, selectedFilters, true),
+      ...buildNewQueryMap(query, map, filterOperations, selectedFilters),
     }
   }, [filterOperations, filterContext, selectedFilters])
 

--- a/react/hooks/useFacetNavigation.js
+++ b/react/hooks/useFacetNavigation.js
@@ -175,14 +175,13 @@ const useFacetNavigation = selectedFacets => {
         return
       }
 
-      const newQuery = replaceQueryForNewQueryFormat(
-        currentQuery,
-        currentMap,
-        selectedFacets
-      )
+      const newQuery = replaceQueryForNewQueryFormat(currentQuery, currentMap, [
+        ...selectedFacets,
+        ...facets,
+      ])
 
       const urlParams = getCleanUrlParams(
-        removeMapForNewURLFormat(currentMap, selectedFacets)
+        removeMapForNewURLFormat(currentMap, [...selectedFacets, ...facets])
       )
 
       navigate({

--- a/react/hooks/useFacetNavigation.js
+++ b/react/hooks/useFacetNavigation.js
@@ -20,7 +20,9 @@ const removeElementAtIndex = (strArray, index) =>
   strArray.filter((_, i) => i !== index)
 
 const upsert = (array, item) => {
-  const foundItemIndex = array.findIndex(e => e.name === item.name)
+  const foundItemIndex = array.findIndex(
+    e => e.value === item.value && e.map === item.map
+  )
   if (foundItemIndex === -1) {
     array.push(item)
   } else {

--- a/react/hooks/useFacetNavigation.js
+++ b/react/hooks/useFacetNavigation.js
@@ -28,7 +28,11 @@ const upsert = (array, item) => {
   }
 }
 
-const compareFacetWithQueryValues = (querySegment, mapSegment, facet) => {
+export const compareFacetWithQueryValues = (
+  querySegment,
+  mapSegment,
+  facet
+) => {
   return (
     decodeURIComponent(querySegment).toLowerCase() ===
       decodeURIComponent(facet.value).toLowerCase() && mapSegment === facet.map
@@ -99,8 +103,8 @@ const buildQueryAndMap = (
             selectedFacet.map !== facet.map
         )
         return {
-          query: removeElementAtIndex(querySegments, facetIndex),
-          map: removeElementAtIndex(mapSegments, facetIndex),
+          query: removeElementAtIndex(query, facetIndex),
+          map: removeElementAtIndex(map, facetIndex),
         }
       } else {
         upsert(selectedFacets, facet)


### PR DESCRIPTION
#### What is the purpose of this pull request?
When clicking to select a filter that was already selected. Some others filters were getting unselected.

<!--- Describe your changes in detail. -->

#### What problem is this solving?
Separate url formation from since mobile component takes advantage of it. Now we only transform the url before navigating if preventRouteChange is not active.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
Could be testes in any of these workspaces

https://jey--eriksbikeshop.myvtex.com/cycling/bicycles/road/style_Dropbar/style_Performance/color-family_Black
https://jey--alssports.myvtex.com/clothing/jackets/Womens?map=c,c,specificationFilter_7721
https://jey--exitocol.myvtex.com/tecnologia/celulares/smartphones
https://jey--boticario.myvtex.com
https://jey--storecomponents.myvtex.com

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
