### PR TITLE
Fixed `showCategories` in `SearchResult`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Problem that caused category filters to not appear when you were in page with category tree but all the other facets were in `hiddenFacets`.
 
 ## [3.51.2] - 2020-03-11
 ### Fixed

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -167,10 +167,7 @@ class SearchResult extends Component {
     })
 
     const showCategories =
-      hiddenFacets &&
-      hiddenFacets.categories === false &&
-      tree &&
-      tree.length > 0
+      hiddenFacets && !hiddenFacets.categories && tree && tree.length > 0
 
     const showFacets = showCategories || (!hideFacets && !isEmpty(filters))
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fixes the problem that caused category filters to not appear when you were on page with category tree but all the other facets were in `hiddenFacets`.

#### How should this be manually tested?

[Workspace](https://iaronaraujo--rockfordcl.myvtex.com/137?map=productClusterIds)
Check that `FilterNavigator` is being rendered. It does not appear visually in the store because of the CSS

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
