### PR TITLE
Add `SidebarCloseButton` component.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - `SidebarCloseButton` component.
-- `sidebarCloseIconProps` prop on `filter-navigator.v2` and `filter-navigator.v3`.
 
 ## [3.52.0] - 2020-03-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `SidebarCloseButton` component.
+- `sidebarCloseIconProps` prop on `filter-navigator.v2` and `filter-navigator.v3`.
 
 ## [3.52.0] - 2020-03-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `SidebarCloseButton` component.
+- New block `sidebar-close-button`.
 
 ## [3.52.0] - 2020-03-26
 ### Added

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -55,6 +55,7 @@ const newNamedFacet = facet => {
  */
 const FilterNavigator = ({
   priceRange,
+  sidebarCloseIconProps,
   tree = [],
   specificationFilters = [],
   priceRanges = [],
@@ -131,6 +132,7 @@ const FilterNavigator = ({
             priceRange={priceRange}
             preventRouteChange={preventRouteChange}
             navigateToFacet={navigateToFacet}
+            sidebarCloseIconProps={sidebarCloseIconProps}
           />
         </div>
       </div>

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -55,7 +55,6 @@ const newNamedFacet = facet => {
  */
 const FilterNavigator = ({
   priceRange,
-  sidebarCloseIconProps,
   tree = [],
   specificationFilters = [],
   priceRanges = [],
@@ -132,7 +131,6 @@ const FilterNavigator = ({
             priceRange={priceRange}
             preventRouteChange={preventRouteChange}
             navigateToFacet={navigateToFacet}
-            sidebarCloseIconProps={sidebarCloseIconProps}
           />
         </div>
       </div>

--- a/react/FilterNavigatorFlexible.js
+++ b/react/FilterNavigatorFlexible.js
@@ -11,7 +11,6 @@ import styles from './searchResult.css'
 const withSearchPageContextProps = Component => ({
   layout,
   initiallyCollapsed,
-  sidebarCloseIconProps,
 }) => {
   const {
     searchQuery,
@@ -59,7 +58,6 @@ const withSearchPageContextProps = Component => ({
           hiddenFacets={hiddenFacets}
           layout={layout}
           initiallyCollapsed={initiallyCollapsed}
-          sidebarCloseIconProps={sidebarCloseIconProps}
         />
       </FilterNavigatorContext.Provider>
     </div>

--- a/react/FilterNavigatorFlexible.js
+++ b/react/FilterNavigatorFlexible.js
@@ -8,7 +8,11 @@ import FilterNavigatorContext from './components/FilterNavigatorContext'
 
 import styles from './searchResult.css'
 
-const withSearchPageContextProps = Component => ({ layout, initiallyCollapsed }) => {
+const withSearchPageContextProps = Component => ({
+  layout,
+  initiallyCollapsed,
+  sidebarCloseIconProps,
+}) => {
   const {
     searchQuery,
     map,
@@ -39,7 +43,7 @@ const withSearchPageContextProps = Component => ({ layout, initiallyCollapsed })
     <div
       className={`${styles['filters--layout']} ${
         layout === 'desktop' && isMobile ? 'w-100 mh5' : ''
-        }`}
+      }`}
     >
       <FilterNavigatorContext.Provider value={queryArgs}>
         <Component
@@ -55,6 +59,7 @@ const withSearchPageContextProps = Component => ({ layout, initiallyCollapsed })
           hiddenFacets={hiddenFacets}
           layout={layout}
           initiallyCollapsed={initiallyCollapsed}
+          sidebarCloseIconProps={sidebarCloseIconProps}
         />
       </FilterNavigatorContext.Provider>
     </div>

--- a/react/SidebarCloseButton.js
+++ b/react/SidebarCloseButton.js
@@ -1,0 +1,2 @@
+import SidebarCloseButton from './components/SidebarCloseButton'
+export default SidebarCloseButton

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -2,6 +2,7 @@ import classNames from 'classnames'
 import produce from 'immer'
 import React, { useState, useEffect, useMemo, Fragment } from 'react'
 import { FormattedMessage } from 'react-intl'
+import { ExtensionPoint } from 'vtex.render-runtime'
 import { Button } from 'vtex.styleguide'
 import { IconFilter } from 'vtex.store-icons'
 import { useCssHandles } from 'vtex.css-handles'
@@ -11,7 +12,6 @@ import FilterNavigatorContext, {
 } from './FilterNavigatorContext'
 import AccordionFilterContainer from './AccordionFilterContainer'
 import Sidebar from './SideBar'
-import SidebarCloseButton from './SidebarCloseButton'
 import { buildNewQueryMap } from '../hooks/useFacetNavigation'
 
 import styles from '../searchResult.css'
@@ -32,7 +32,6 @@ const FilterSidebar = ({
   priceRange,
   preventRouteChange,
   navigateToFacet,
-  sidebarCloseIconProps,
 }) => {
   const filterContext = useFilterNavigator()
   const [open, setOpen] = useState(false)
@@ -137,12 +136,7 @@ const FilterSidebar = ({
             onCategorySelect={handleUpdateCategories}
             priceRange={priceRange}
           />
-          {sidebarCloseIconProps && (
-            <SidebarCloseButton
-              iconProps={sidebarCloseIconProps}
-              onClose={handleClose}
-            />
-          )}
+          <ExtensionPoint id="sidebar-close-button" onClose={handleClose} />
         </FilterNavigatorContext.Provider>
         <div
           className={`${styles.filterButtonsBox} bt b--muted-5 bottom-0 fixed w-100 items-center flex z-1 bg-base`}

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -11,6 +11,7 @@ import FilterNavigatorContext, {
 } from './FilterNavigatorContext'
 import AccordionFilterContainer from './AccordionFilterContainer'
 import Sidebar from './SideBar'
+import SidebarCloseButton from './SidebarCloseButton'
 import { buildNewQueryMap } from '../hooks/useFacetNavigation'
 
 import styles from '../searchResult.css'
@@ -31,6 +32,7 @@ const FilterSidebar = ({
   priceRange,
   preventRouteChange,
   navigateToFacet,
+  sidebarCloseIconProps,
 }) => {
   const filterContext = useFilterNavigator()
   const [open, setOpen] = useState(false)
@@ -135,6 +137,12 @@ const FilterSidebar = ({
             onCategorySelect={handleUpdateCategories}
             priceRange={priceRange}
           />
+          {sidebarCloseIconProps && (
+            <SidebarCloseButton
+              iconProps={sidebarCloseIconProps}
+              onClose={handleClose}
+            />
+          )}
         </FilterNavigatorContext.Provider>
         <div
           className={`${styles.filterButtonsBox} bt b--muted-5 bottom-0 fixed w-100 items-center flex z-1 bg-base`}

--- a/react/components/SidebarCloseButton.js
+++ b/react/components/SidebarCloseButton.js
@@ -4,9 +4,8 @@ import { IconClose } from 'vtex.store-icons'
 
 const CSS_HANDLES = ['closeIconButton']
 
-const SidebarCloseButton = ({ iconProps, onClose }) => {
+const SidebarCloseButton = ({ size = 30, type = 'line', onClose }) => {
   const handles = useCssHandles(CSS_HANDLES)
-  const { size = 30, type = 'line' } = iconProps
 
   return (
     <button

--- a/react/components/SidebarCloseButton.js
+++ b/react/components/SidebarCloseButton.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import { useCssHandles } from 'vtex.css-handles'
+import { IconClose } from 'vtex.store-icons'
+
+const CSS_HANDLES = ['closeIconButton']
+
+const SidebarCloseButton = ({ iconProps, onClose }) => {
+  const handles = useCssHandles(CSS_HANDLES)
+  const { size = 30, type = 'line' } = iconProps
+
+  return (
+    <button
+      className={`${handles.closeIconButton} pa5 bg-transparent c-on-base bn absolute top-0 right-0 pointer`}
+      onClick={onClose}
+    >
+      <IconClose size={size} type={type} />
+    </button>
+  )
+}
+
+export default SidebarCloseButton

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -20,7 +20,7 @@
   },
   "filter-navigator.v2": {
     "component": "FilterNavigator",
-    "allowed": ["shop-review-summary"]
+    "allowed": ["shop-review-summary", "sidebar-close-button"]
   },
   "gallery": {
     "required": ["product-summary"],
@@ -134,12 +134,16 @@
     "component": "OrderByFlexible"
   },
   "filter-navigator.v3": {
-    "component": "FilterNavigatorFlexible"
+    "component": "FilterNavigatorFlexible",
+    "allowed": ["sidebar-close-button"]
   },
   "total-products.v2": {
     "component": "TotalProductsFlexible"
   },
   "search-title.v2": {
     "component": "SearchTitleFlexible"
+  },
+  "sidebar-close-button": {
+    "component": "SidebarCloseButton"
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Make it possible to add a "close button" on the filter sidebar.
❗️There won't be changes on README right now because there is an [open PR to change the whole README](https://github.com/vtex-apps/search-result/pull/332)

#### How should this be manually tested?

[Workspace](https://productprice--storecomponents.myvtex.com/apparel---accessories/clothing)
Open on mobile, click on "filter" and check that there is an X button on the top right.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/8443580/78057180-af181d00-735c-11ea-9b0e-9b2c3de70d8d.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
