### PR TITLE
adjust-compatibility-with-the-new-search-protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- A compatibility layer to handle the new search protocol.
+- `fuzzy`, `operator` and `searchState` props.
+
+### Changed
+- `FilterNavigator` children are not remounted each time a new facet is selected.
+- When the user selects a new `priceRange`, the `facets` query will be reloaded.
+- `FilterNavigator` now uses the `selected` property.
 
 ## [3.53.2] - 2020-04-03
 ### Fixed

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -17,7 +17,6 @@ import {
   paramShape,
   hiddenFacetsSchema,
 } from './constants/propTypes'
-import useSelectedFilters from './hooks/useSelectedFilters'
 import useFacetNavigation from './hooks/useFacetNavigation'
 
 import styles from './searchResult.css'
@@ -34,7 +33,7 @@ const LAYOUT_TYPES = {
 const getSelectedCategories = tree => {
   for (const node of tree) {
     if (!node.selected) {
-      return []
+      continue
     }
     if (node.children) {
       return [node, ...getSelectedCategories(node.children)]
@@ -72,20 +71,20 @@ const FilterNavigator = ({
     (isMobile && layout === LAYOUT_TYPES.responsive) ||
     layout === LAYOUT_TYPES.mobile
 
-  const selectedFilters = useSelectedFilters(
-    useMemo(() => {
-      const options = [
-        ...specificationFilters.map(filter => {
-          return filter.facets.map(facet => {
-            return newNamedFacet({ ...facet, title: filter.name })
-          })
-        }),
-        ...brands,
-        ...priceRanges,
-      ]
-      return flatten(options)
-    }, [brands, priceRanges, specificationFilters])
-  ).filter(facet => facet.selected)
+  const selectedFilters = useMemo(() => {
+    const options = [
+      ...specificationFilters.map(filter => {
+        return filter.facets.map(facet => {
+          return newNamedFacet({ ...facet, title: filter.name })
+        })
+      }),
+      ...brands,
+      ...priceRanges,
+    ]
+    return flatten(options)
+  }, [brands, priceRanges, specificationFilters]).filter(
+    facet => facet.selected
+  )
 
   const selectedCategories = getSelectedCategories(tree)
   const navigateToFacet = useFacetNavigation(
@@ -96,82 +95,80 @@ const FilterNavigator = ({
 
   const filterClasses = classNames({
     'flex items-center justify-center flex-auto h-100': mobileLayout,
+    dn: loading,
   })
-
-  if (loading && !mobileLayout) {
-    return (
-      <div className="mv5">
-        <ContentLoader
-          style={{
-            width: '230px',
-            height: '320px',
-          }}
-          width="230"
-          height="320"
-          y="0"
-          x="0"
-        >
-          <rect width="100%" height="1em" />
-          <rect width="100%" height="8em" y="1.5em" />
-          <rect width="100%" height="1em" y="10.5em" />
-          <rect width="100%" height="8em" y="12em" />
-        </ContentLoader>
-      </div>
-    )
-  }
-
-  if (mobileLayout) {
-    return (
-      <div className={styles.filters}>
-        <div className={filterClasses}>
-          <FilterSidebar
-            selectedFilters={selectedFilters}
-            filters={filters}
-            tree={tree}
-            priceRange={priceRange}
-            preventRouteChange={preventRouteChange}
-            navigateToFacet={navigateToFacet}
-          />
-        </div>
-      </div>
-    )
-  }
 
   return (
     <Fragment>
-      <div className={filterClasses}>
-        <div
-          className={`${applyModifiers(
-            handles.filter__container,
-            'title'
-          )} bb b--muted-4`}
-          // eslint-disable-next-line prettier/prettier
-        >
-          <h5 className={`${handles.filterMessage} t-heading-5 mv5`}>
-            <FormattedMessage id="store/search-result.filter-button.title" />
-          </h5>
+      {loading && !mobileLayout ? (
+        <div className="mv5">
+          <ContentLoader
+            style={{
+              width: '230px',
+              height: '320px',
+            }}
+            width="230"
+            height="320"
+            y="0"
+            x="0"
+          >
+            <rect width="100%" height="1em" />
+            <rect width="100%" height="8em" y="1.5em" />
+            <rect width="100%" height="1em" y="10.5em" />
+            <rect width="100%" height="8em" y="12em" />
+          </ContentLoader>
         </div>
-        <SelectedFilters
-          filters={selectedFilters}
-          preventRouteChange={preventRouteChange}
-          navigateToFacet={navigateToFacet}
-        />
-        <DepartmentFilters
-          title={CATEGORIES_TITLE}
-          tree={tree}
-          isVisible={!hiddenFacets.categories}
-          onCategorySelect={navigateToFacet}
-          preventRouteChange={preventRouteChange}
-        />
-        <AvailableFilters
-          filters={filters}
-          priceRange={priceRange}
-          preventRouteChange={preventRouteChange}
-          initiallyCollapsed={initiallyCollapsed}
-          navigateToFacet={navigateToFacet}
-        />
-      </div>
-      <ExtensionPoint id="shop-review-summary" />
+      ) : null}
+
+      {mobileLayout ? (
+        <div className={styles.filters}>
+          <div className={filterClasses}>
+            <FilterSidebar
+              selectedFilters={selectedFilters.concat(selectedCategories)}
+              filters={filters}
+              tree={tree}
+              priceRange={priceRange}
+              preventRouteChange={preventRouteChange}
+              navigateToFacet={navigateToFacet}
+            />
+          </div>
+        </div>
+      ) : (
+        <Fragment>
+          <div className={filterClasses}>
+            <div
+              className={`${applyModifiers(
+                handles.filter__container,
+                'title'
+              )} bb b--muted-4`}
+            >
+              <h5 className={`${handles.filterMessage} t-heading-5 mv5`}>
+                <FormattedMessage id="store/search-result.filter-button.title" />
+              </h5>
+            </div>
+            <SelectedFilters
+              filters={selectedFilters}
+              preventRouteChange={preventRouteChange}
+              navigateToFacet={navigateToFacet}
+            />
+            <DepartmentFilters
+              title={CATEGORIES_TITLE}
+              tree={tree}
+              isVisible={!hiddenFacets.categories}
+              onCategorySelect={navigateToFacet}
+              preventRouteChange={preventRouteChange}
+            />
+            <AvailableFilters
+              filters={filters}
+              priceRange={priceRange}
+              preventRouteChange={preventRouteChange}
+              initiallyCollapsed={initiallyCollapsed}
+              navigateToFacet={navigateToFacet}
+            />
+          </div>
+          <ExtensionPoint id="shop-review-summary" />
+        </Fragment>
+      )}
     </Fragment>
   )
 }

--- a/react/__mocks__/vtex.search-page-context/SearchPageContext.js
+++ b/react/__mocks__/vtex.search-page-context/SearchPageContext.js
@@ -1,0 +1,3 @@
+export const useSearchPage = () => ({
+  searchQuery: undefined,
+})

--- a/react/__tests__/useFacetNavigation.test.js
+++ b/react/__tests__/useFacetNavigation.test.js
@@ -29,7 +29,14 @@ it('navigating to another category facet', () => {
     query: 'clothing',
   }))
 
-  const { result } = renderHook(() => useFacetNavigation([]))
+  const { result } = renderHook(() =>
+    useFacetNavigation([
+      {
+        map,
+        value: 'clothing',
+      },
+    ])
+  )
   act(() => {
     result.current({ map: 'c', value: 'shorts' })
   })
@@ -45,13 +52,18 @@ it('joins categories', () => {
     query: 'clothing/Brand',
   }))
 
-  const { result } = renderHook(() => useFacetNavigation([]))
+  const selectedFacets = [
+    { map: 'c', value: 'clothing' },
+    { map: 'b', value: 'Brand' },
+  ]
+
+  const { result } = renderHook(() => useFacetNavigation(selectedFacets))
   act(() => {
     result.current({ map: 'c', value: 'shorts' })
   })
 
   const navigateCall = mockNavigate.mock.calls[0][0]
-  expect(navigateCall.to).toBe('/clothing/shorts/Brand')
+  expect(navigateCall.to).toBe('/clothing/shorts/brand')
   expect(navigateCall.query).toBe('map=b')
 })
 
@@ -61,6 +73,11 @@ it('pass array of facets as args work', () => {
     map,
     query: 'clothing/Brand',
   }))
+
+  const selectedFacets = [
+    { map: 'c', value: 'clothing' },
+    { map: 'b', value: 'Brand' },
+  ]
 
   const facets = [
     {
@@ -75,13 +92,13 @@ it('pass array of facets as args work', () => {
     },
     { map: 'c', value: 'shorts', title: '', newQuerySegment: 'shorts' },
   ]
-  const { result } = renderHook(() => useFacetNavigation(facets))
+  const { result } = renderHook(() => useFacetNavigation(selectedFacets))
   act(() => {
     result.current(facets)
   })
 
   const navigateCall = mockNavigate.mock.calls[0][0]
-  expect(navigateCall.to).toBe('/clothing/shorts/Brand/otherbrand/gender_Mens')
+  expect(navigateCall.to).toBe('/clothing/shorts/brand/otherbrand/gender_Mens')
   expect(navigateCall.query).toBe('map=b%2Cb')
 })
 

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -15,6 +15,7 @@ import Sidebar from './SideBar'
 import { buildNewQueryMap } from '../hooks/useFacetNavigation'
 
 import styles from '../searchResult.css'
+import { getFullText } from '../utils/compatibilityLayer'
 
 const CSS_HANDLES = [
   'filterPopupButton',
@@ -99,9 +100,11 @@ const FilterSidebar = ({
 
   const context = useMemo(() => {
     const { query, map } = filterContext
+    const fullText = getFullText(query, map)
+
     return {
       ...filterContext,
-      ...buildNewQueryMap(query, map, filterOperations, selectedFilters),
+      ...buildNewQueryMap(fullText, filterOperations, selectedFilters),
     }
   }, [filterOperations, filterContext, selectedFilters])
 

--- a/react/components/SearchFilter.js
+++ b/react/components/SearchFilter.js
@@ -6,7 +6,6 @@ import FilterOptionTemplate from './FilterOptionTemplate'
 import FacetItem from './FacetItem'
 import { facetOptionShape } from '../constants/propTypes'
 import { getFilterTitle } from '../constants/SearchHelpers'
-import useSelectedFilters from '../hooks/useSelectedFilters'
 
 /**
  * Search Filter Component.
@@ -19,8 +18,6 @@ const SearchFilter = ({
   initiallyCollapsed = false,
   navigateToFacet,
 }) => {
-  const filtersWithSelected = useSelectedFilters(facets)
-
   const sampleFacet = facets && facets.length > 0 ? facets[0] : null
   const facetTitle = getFilterTitle(title, intl)
 
@@ -28,7 +25,7 @@ const SearchFilter = ({
     <FilterOptionTemplate
       id={sampleFacet ? sampleFacet.map : null}
       title={facetTitle}
-      filters={filtersWithSelected}
+      filters={facets}
       initiallyCollapsed={initiallyCollapsed}
     >
       {facet => (

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -147,9 +147,10 @@ class SearchResult extends Component {
       showLoadingAsOverlay,
     } = this.state
 
-    const queryArgs = this.props.searchQuery.facets
-      ? this.props.searchQuery.facets.queryArgs
-      : { query: '', map: '' }
+    const queryArgs =
+      this.props.searchQuery.facets && this.props.searchQuery.facets.queryArgs
+        ? this.props.searchQuery.facets.queryArgs
+        : { query: '', map: '' }
 
     const { map } = queryArgs
 

--- a/react/constants.ts
+++ b/react/constants.ts
@@ -1,6 +1,7 @@
 export const MAP_CATEGORY_CHAR = 'c'
 export const MAP_BRAND_CHAR = 'b'
 export const MAP_QUERY_KEY = 'map'
+export const FULLTEXT_QUERY_KEY = 'ft'
 export const MAP_VALUES_SEP = ','
 export const PATH_SEPARATOR = '/'
 export const SPACE_REPLACER = '-'

--- a/react/hooks/useFetchMore.js
+++ b/react/hooks/useFetchMore.js
@@ -5,6 +5,7 @@ import {
   useSearchPageStateDispatch,
   useSearchPageState,
 } from 'vtex.search-page-context/SearchPageContext'
+import useSearchState from './useSearchState'
 
 export const FETCH_TYPE = {
   NEXT: 'next',
@@ -50,7 +51,10 @@ const handleFetchMore = async (
   setLoading,
   fetchMore,
   products,
-  updateQueryError
+  updateQueryError,
+  fuzzy,
+  operator,
+  searchState
 ) => {
   if (fetchMoreLocked.current || products.length === 0) {
     return
@@ -66,6 +70,9 @@ const handleFetchMore = async (
     variables: {
       from,
       to,
+      fuzzy,
+      operator,
+      searchState,
     },
     updateQuery: (prevResult, { fetchMoreResult }) => {
       setLoading(false)
@@ -143,6 +150,7 @@ export const useFetchMore = props => {
     queryData: { query, map, orderBy, priceRange },
   } = props
   const { setQuery } = useRuntime()
+  const { fuzzy, operator, searchState } = useSearchState()
   const initialState = {
     page,
     nextPage: page + 1,
@@ -173,7 +181,17 @@ export const useFetchMore = props => {
     const to = min(recordsFiltered, from + maxItemsPerPage) - 1
     setInfiniteScrollError(false)
     pageDispatch({ type: 'NEXT_PAGE', args: { to } })
-    setQuery({ page: pageState.nextPage }, { replace: true })
+
+    setQuery(
+      {
+        page: pageState.nextPage,
+        fuzzy: fuzzy || undefined,
+        operator: operator || undefined,
+        searchState: searchState || undefined,
+      },
+      { replace: true }
+    )
+
     const promiseResult = await handleFetchMore(
       from,
       to,
@@ -182,7 +200,10 @@ export const useFetchMore = props => {
       setLoading,
       fetchMore,
       products,
-      updateQueryError
+      updateQueryError,
+      fuzzy,
+      operator,
+      searchState
     )
     //if error, rollback
     if (promiseResult && updateQueryError.current) {
@@ -199,7 +220,17 @@ export const useFetchMore = props => {
     const from = max(0, to - maxItemsPerPage + 1)
     setInfiniteScrollError(false)
     pageDispatch({ type: 'PREVIOUS_PAGE', args: { from } })
-    setQuery({ page: pageState.previousPage }, { replace: true, merge: true })
+
+    setQuery(
+      {
+        page: pageState.previousPage,
+        fuzzy: fuzzy || undefined,
+        operator: operator || undefined,
+        searchState: searchState || undefined,
+      },
+      { replace: true, merge: true }
+    )
+
     const promiseResult = await handleFetchMore(
       from,
       to,
@@ -208,7 +239,10 @@ export const useFetchMore = props => {
       setLoading,
       fetchMore,
       products,
-      updateQueryError
+      updateQueryError,
+      fuzzy,
+      operator,
+      searchState
     )
     //if error, rollback
     if (promiseResult && updateQueryError.current) {

--- a/react/hooks/useSearchState.js
+++ b/react/hooks/useSearchState.js
@@ -1,0 +1,14 @@
+import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
+import { path } from 'ramda'
+
+const useSearchState = () => {
+  const { searchQuery } = useSearchPage()
+
+  return {
+    fuzzy: path(['data', 'productSearch', 'fuzzy'], searchQuery),
+    operator: path(['data', 'productSearch', 'operator'], searchQuery),
+    searchState: path(['data', 'productSearch', 'searchState'], searchQuery),
+  }
+}
+
+export default useSearchState

--- a/react/utils/compatibilityLayer.js
+++ b/react/utils/compatibilityLayer.js
@@ -1,0 +1,97 @@
+import { groupBy, pathOr, zipObj } from 'ramda'
+import { PATH_SEPARATOR, MAP_VALUES_SEP } from '../constants'
+
+export const getFullText = (query, map) => {
+  const querySegments = (query && query.split(PATH_SEPARATOR)) || []
+  const mapSegments = (map && map.split(MAP_VALUES_SEP)) || []
+
+  return zipObj(mapSegments, querySegments).ft
+}
+
+export const buildSelectedFacetsAndFullText = (query, map, priceRange) => {
+  if (!map || !query) {
+    return []
+  }
+
+  const queryValues = query.split('/')
+  const mapValues = map.split(',')
+
+  let fullText
+
+  const selectedFacets =
+    queryValues.length === mapValues.length
+      ? mapValues.map((map, i) => {
+          if (map === 'ft') {
+            fullText = decodeURI(queryValues[i])
+          }
+
+          return {
+            key: mapValues[i],
+            value: queryValues[i],
+          }
+        })
+      : []
+
+  if (priceRange) {
+    selectedFacets.push({
+      key: 'priceRange',
+      value: priceRange,
+    })
+  }
+
+  return [selectedFacets, fullText]
+}
+
+const addMap = facet => {
+  facet.map = facet.key
+
+  if (facet.children) {
+    facet.children.forEach(facet => addMap(facet))
+  }
+}
+
+export const detachFiltersByType = facets => {
+  facets.forEach(facet => facet.facets.forEach(value => addMap(value)))
+
+  const byType = groupBy(filter => filter.type)
+
+  const groupedFilters = byType(facets)
+
+  const brands = pathOr([], ['BRAND', 0, 'facets'], groupedFilters)
+
+  const specificationFilters = groupedFilters['TEXT']
+
+  const categoriesTrees = pathOr(
+    [],
+    ['CATEGORYTREE', 0, 'facets'],
+    groupedFilters
+  )
+  const priceRanges = pathOr(
+    [],
+    ['PRICERANGE', 0, 'facets'],
+    groupedFilters
+  ).map(priceRange => {
+    return {
+      ...priceRange,
+      slug: `de-${priceRange.range.from}-a-${priceRange.range.to}`,
+    }
+  })
+
+  return {
+    brands,
+    specificationFilters,
+    categoriesTrees,
+    priceRanges,
+  }
+}
+
+export const buildQueryArgsFromSelectedFacets = selectedFacets => {
+  return selectedFacets.reduce(
+    (queryArgs, facet, index) => {
+      queryArgs.query += `${index > 0 ? '/' : ''}${facet.value}`
+      queryArgs.map += `${index > 0 ? ',' : ''}${facet.key}`
+      return queryArgs
+    },
+    { query: '', map: '' }
+  )
+}


### PR DESCRIPTION
#### What problem is this solving?

Currently, VTEX has its own protocol between the search API and the UI components. This protocol forces new search-engines to implement specific rules to communicate with the UI. The search-protocol project purposes a generic way to make the UI/API communication.

This PR adds a "compatibility layer" to handle the new `search-protocol`. With this layer, there is no need to make further changes in the UI components.

It also adds three new props that are essential for new search engines. They are: `fuzzy`, `operator` and `searchState`. These props are in the URL as queryStrings.

Finally, this PR makes a slight improvement in the FilterNavigator by avoiding unnecessary mounting.

#### How should this be manually tested?
I have created two workspaces, each one with a search engine
- [`search-graphql` engine](https://hiago--storecomponents.myvtex.com/)
- [`vtex-search` engine](https://hiagolucas--storecomponents.myvtex.com/) - It only solves full text searches.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.

#### Notes
This PR depends on 
- https://github.com/vtex-apps/search-graphql/pull/64
- https://github.com/vtex-apps/store-resources/pull/107
- https://github.com/vtex-apps/store/pull/440
Don't publish it before them!
