### PR TITLE
Bugfix/url facets order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - The order in which the facets are sent to the `normalizeQueryMap` in the `vtex.store` app.
+- Change from `productOrigin` to `productOriginVtex`
 
 ## [3.55.0] - 2020-04-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- The order in which the facets are sent to the `normalizeQueryMap` in the `vtex.store` app.
+
 ## [3.55.0] - 2020-04-08
 ### Added
 - A compatibility layer to handle the new search protocol.

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -89,7 +89,7 @@ const FilterNavigator = ({
   const selectedCategories = getSelectedCategories(tree)
   const navigateToFacet = useFacetNavigation(
     useMemo(() => {
-      return selectedFilters.concat(selectedCategories)
+      return selectedCategories.concat(selectedFilters)
     }, [selectedFilters, selectedCategories])
   )
 
@@ -124,7 +124,7 @@ const FilterNavigator = ({
         <div className={styles.filters}>
           <div className={filterClasses}>
             <FilterSidebar
-              selectedFilters={selectedFilters.concat(selectedCategories)}
+              selectedFilters={selectedCategories.concat(selectedFilters)}
               filters={filters}
               tree={tree}
               priceRange={priceRange}

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -179,7 +179,7 @@ const SearchQuery = ({
   operator: operatorQuery,
   fuzzy: fuzzyQuery,
   searchState: searchStateQuery,
-  __unstableProductOrigin,
+  __unstableProductOriginVtex,
 }) => {
   /* This is the page of the first query since the component was rendered. 
   We want this behaviour so we can show the correct items even if the pageQuery
@@ -224,7 +224,7 @@ const SearchQuery = ({
       operator,
       fuzzy,
       searchState,
-      productOrigin: __unstableProductOrigin,
+      productOriginVtex: __unstableProductOriginVtex,
       hideUnavailableItems: !!hideUnavailableItems,
       facetsBehavior: facetsBehavior || DEFAULT_QUERY_VALUES.facetsBehavior,
       withFacets: false,
@@ -250,7 +250,7 @@ const SearchQuery = ({
     operator,
     fuzzy,
     searchState,
-    __unstableProductOrigin,
+    __unstableProductOriginVtex,
   ])
 
   const {


### PR DESCRIPTION
#### What problem is this solving?

The [`normalizeQueryMap`](https://github.com/vtex-apps/store/blob/729a668ae5/react/utils/navigation.js#L49) in `vtex.store` is expecting to have the categories at the beginning of the array. This PR guarantee that it will happen

This PR also changes from `productOrigin` to [`productOriginVtex`](https://github.com/vtex-apps/store/blob/master/react/SearchContext.js#L38)

#### How should this be manually tested?
[Workspace](https://hiago--storecomponents.myvtex.com/)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
