### PR TITLE
refetchvariables now follow the search-protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Guarantee that the `refetchVariables` will follow the `search-protocol`.
 - Send an empty filter when the `facets` query is not ready.
+- Funcion `buildSelectedFacetsAndFullText` now cases where map is lesser than query.
 
 ## [3.55.1] - 2020-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Guarantee that the `refetchVariables` will follow the `search-protocol`.
+- Send an empty filter when the `facets` query is not ready.
+
 ## [3.55.1] - 2020-04-09
 
 ### Fixed

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -159,6 +159,7 @@ const useQueries = (variables, facetsArgs) => {
   } = useQuery(facetsQuery, {
     variables: {
       query: facetsArgs.facetQuery,
+      map: facetsArgs.facetMap,
       fullText: variables.fullText,
       selectedFacets: variables.selectedFacets,
       hideUnavailableItems: variables.hideUnavailableItems,

--- a/react/utils/compatibilityLayer.js
+++ b/react/utils/compatibilityLayer.js
@@ -19,7 +19,7 @@ export const buildSelectedFacetsAndFullText = (query, map, priceRange) => {
   let fullText
 
   const selectedFacets =
-    queryValues.length === mapValues.length
+    queryValues.length >= mapValues.length
       ? mapValues.map((map, i) => {
           if (map === 'ft') {
             fullText = decodeURI(queryValues[i])


### PR DESCRIPTION
#### What problem is this solving?

 - Guarantee that the `refetchVariables` will follow the `search-protocol`.
 - Send an empty filter when the `facets` query is not ready.

#### How should this be manually tested?
[Naturitas](https://hiago--naturitasit.myvtex.com/integratori/fitoterapia/curcuma)
[Storecomponents](https://hiago--storecomponents.myvtex.com/)

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
