### PR TITLE
cover cases where the category tree is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Cover cases where the category tree is empty in the `FilterNavigator`.
+
 ## [3.57.0] - 2020-05-04
 ### Added
 - New CSS handles: `filtersWrapper` and `filtersWrapperMobile`.

--- a/react/components/AccordionFilterContainer.js
+++ b/react/components/AccordionFilterContainer.js
@@ -84,21 +84,23 @@ const AccordionFilterContainer = ({
         )}
       </div>
 
-      <AccordionFilterItem
-        title={CATEGORIES_TITLE}
-        open={departmentsOpen}
-        show={!openItem || departmentsOpen}
-        onOpen={handleOpen(CATEGORIES_TITLE)}
-      >
-        <div className={itemClassName}>
-          <DepartmentFilters
-            tree={tree}
-            isVisible={tree.length > 0}
-            onCategorySelect={onCategorySelect}
-            hideBorder
-          />
-        </div>
-      </AccordionFilterItem>
+      {tree.length > 0 && (
+        <AccordionFilterItem
+          title={CATEGORIES_TITLE}
+          open={departmentsOpen}
+          show={!openItem || departmentsOpen}
+          onOpen={handleOpen(CATEGORIES_TITLE)}
+        >
+          <div className={itemClassName}>
+            <DepartmentFilters
+              tree={tree}
+              isVisible={tree.length > 0}
+              onCategorySelect={onCategorySelect}
+              hideBorder
+            />
+          </div>
+        </AccordionFilterItem>
+      )}
 
       {nonEmptyFilters.map(filter => {
         const { type, title } = filter

--- a/react/components/DepartmentFilters.js
+++ b/react/components/DepartmentFilters.js
@@ -24,7 +24,7 @@ const DepartmentFilters = ({
   maxItemsCategory,
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
-  if (!isVisible) {
+  if (!isVisible || tree.length === 0) {
     return null
   }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Hide the departments' filter when the category tree is empty.

#### What problem is this solving?

When the search engine doesn't return any category tree, the UI shows the department filter with no facets

<img width="555" alt="Captura de Tela 2020-04-16 às 13 11 10" src="https://user-images.githubusercontent.com/40380674/79484653-601fe800-7fea-11ea-91b1-bdc32e76c9a6.png">
<img width="380" alt="Captura de Tela 2020-04-16 às 13 11 47" src="https://user-images.githubusercontent.com/40380674/79484661-62824200-7fea-11ea-973e-4c394b1db4fc.png">

#### How should this be manually tested?

[workspace](https://emptydepartments--storecomponents.myvtex.com)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
