### PR TITLE
Feature/maxitens links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New prop `maxItemsDepartment` to `filter-navigator.v3`.
+- New prop `maxItemsCategory` to `filter-navigator.v3`.
 
 ## [3.55.3] - 2020-04-15
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -280,8 +280,8 @@ Check out the [**Product Summary documentation**](https://vtex.io/docs/component
 | Prop name | Type                      | Description                                                                                       | Default value |
 | --------- | ------------------------- | ------------------------------------------------------------------------------------------------- | ------------- |
 | `layout`  | `Enum` | Whether the Filter Navigator layout should be responsive (`responsive`) or not (`desktop`). You may use `desktop` when the Filter Navigator was configured to be displayed in a [drawer](https://vtex.io/docs/components/content-blocks/vtex.store-drawer@0.9.0). | `responsive`  |
-| `maxItemsDepartment` | `numeric`                 | The maximum number of departments to be displayed before a See more button be triggered.          | 8             |
-| `maxItemsCategory`   | `numeric`                 | The maximum number of categories items to be displayed before a See more button be triggered.     | 8             |
+| `maxItemsDepartment` | `number`                 | Maximum number of departments to be displayed before the See More button is triggered.          | `8`             |
+| `maxItemsCategory`   | `number`                 | Maximum number of category items to be displayed before the See More button is triggered.     | `8`             |
 
 -  **`order-by` block**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -280,6 +280,8 @@ Check out the [**Product Summary documentation**](https://vtex.io/docs/component
 | Prop name | Type                      | Description                                                                                       | Default value |
 | --------- | ------------------------- | ------------------------------------------------------------------------------------------------- | ------------- |
 | `layout`  | `Enum` | Whether the Filter Navigator layout should be responsive (`responsive`) or not (`desktop`). You may use `desktop` when the Filter Navigator was configured to be displayed in a [drawer](https://vtex.io/docs/components/content-blocks/vtex.store-drawer@0.9.0). | `responsive`  |
+| `maxItemsDepartment` | `numeric`                 | The maximum number of departments to be displayed before a See more button be triggered.          | 8             |
+| `maxItemsCategory`   | `numeric`                 | The maximum number of categories items to be displayed before a See more button be triggered.     | 8             |
 
 -  **`order-by` block**
 

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -64,6 +64,8 @@ const FilterNavigator = ({
   hiddenFacets = {},
   initiallyCollapsed = false,
   layout = LAYOUT_TYPES.responsive,
+  maxItemsDepartment = 8,
+  maxItemsCategory = 8,
 }) => {
   const { isMobile } = useDevice()
   const handles = useCssHandles(CSS_HANDLES)
@@ -157,6 +159,8 @@ const FilterNavigator = ({
               isVisible={!hiddenFacets.categories}
               onCategorySelect={navigateToFacet}
               preventRouteChange={preventRouteChange}
+              maxItemsDepartment={maxItemsDepartment}
+              maxItemsCategory={maxItemsCategory}
             />
             <AvailableFilters
               filters={filters}

--- a/react/FilterNavigatorFlexible.js
+++ b/react/FilterNavigatorFlexible.js
@@ -11,6 +11,8 @@ import styles from './searchResult.css'
 const withSearchPageContextProps = Component => ({
   layout,
   initiallyCollapsed,
+  maxItemsDepartment,
+  maxItemsCategory,
 }) => {
   const {
     searchQuery,
@@ -58,6 +60,8 @@ const withSearchPageContextProps = Component => ({
           hiddenFacets={hiddenFacets}
           layout={layout}
           initiallyCollapsed={initiallyCollapsed}
+          maxItemsDepartment={maxItemsDepartment}
+          maxItemsCategory={maxItemsCategory}
         />
       </FilterNavigatorContext.Provider>
     </div>

--- a/react/components/CategoryFilter.js
+++ b/react/components/CategoryFilter.js
@@ -42,6 +42,7 @@ const CategoryFilter = ({
   shallow = false,
   onCategorySelect,
   preventRouteChange,
+  maxItemsCategory,
 }) => {
   const { map } = useFilterNavigator()
   const handles = useCssHandles(CSS_HANDLES)
@@ -144,7 +145,7 @@ const CategoryFilter = ({
             >
               <Collapsible
                 items={lastSelectedCategory.children}
-                maxItems={8}
+                maxItems={maxItemsCategory}
                 threshold={2}
                 linkClassName="ml3"
                 openLabel="store/filter.more-categories"

--- a/react/components/DepartmentFilters.js
+++ b/react/components/DepartmentFilters.js
@@ -20,6 +20,8 @@ const DepartmentFilters = ({
   onCategorySelect,
   hideBorder = false,
   preventRouteChange,
+  maxItemsDepartment,
+  maxItemsCategory,
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
   if (!isVisible) {
@@ -55,7 +57,7 @@ const DepartmentFilters = ({
       >
         {showAllDepartments ? (
           <Collapsible
-            maxItems={8}
+            maxItems={maxItemsDepartment}
             threshold={2}
             items={tree}
             openLabel="store/filter.more-departments"
@@ -66,6 +68,7 @@ const DepartmentFilters = ({
                 shallow
                 onCategorySelect={onCategorySelect}
                 preventRouteChange={preventRouteChange}
+                maxItemsCategory={maxItemsCategory}
               />
             )}
           />
@@ -74,6 +77,7 @@ const DepartmentFilters = ({
             category={tree.find(category => category.selected)}
             onCategorySelect={onCategorySelect}
             preventRouteChange={preventRouteChange}
+            maxItemsCategory={maxItemsCategory}
           />
         )}
       </div>


### PR DESCRIPTION
#### What is the purpose of this pull request?

Create a Prop on the filter navigator, to set the max items of categories and departments. Right now the max items are 8, so if you have more than 8 categories, for example, it triggers a see more button. With this prop, you can change this value. 

#### What problem is this solving?

My client doesn't want the client to have to click on a button to see all possible categories on the side filter. 

#### How should this be manually tested?

Change the props, maxItemsCategory, and maxItemsDepartment on filter-navigator.v3 block. 

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/28959326/79604368-55d21c80-80c4-11ea-84c8-3b219421948a.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Requires change to documentation, which has been updated accordingly.
