### PR TITLE
make query on SSR match the variables on component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Make query in component and done on SSR match.
 
 ## [3.56.0] - 2020-04-23
 ### Added

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -263,7 +263,7 @@ const SearchQuery = ({
       operator,
       fuzzy,
       searchState,
-      productOriginVtex: __unstableProductOriginVtex,
+      productOriginVtex: !!__unstableProductOriginVtex,
       hideUnavailableItems: !!hideUnavailableItems,
       facetsBehavior: facetsBehavior || DEFAULT_QUERY_VALUES.facetsBehavior,
       withFacets: false,


### PR DESCRIPTION
https://fidelis--alssports.myvtex.com/
When navigation to a search page, the big grey block was appearing again because people changed a lot of stuff on search queries but did not adapt here on render-server

This fixes it.

To test, click on a category from the menu like CLimbing > Carabiners and see the search being done with no grey block