### PR TITLE
Fix TotalProducts and OrderBy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Bug causing `TotalProducts` and `OrderBy` not to appear on non flexible components.
 
 ## [3.58.0] - 2020-05-12
 ### Added

--- a/react/TotalProducts.js
+++ b/react/TotalProducts.js
@@ -9,7 +9,7 @@ import styles from './searchResult.css'
 const CSS_HANDLES = ['totalProductsMessage']
 
 const TotalProducts = ({
-  message,
+  message = 'store/search.total-products-2',
   recordsFiltered,
   wrapperClass = styles.totalProducts,
 }) => {

--- a/react/components/SelectionListOrderBy.js
+++ b/react/components/SelectionListOrderBy.js
@@ -21,7 +21,12 @@ const CSS_HANDLES = [
   'filterPopupArrowIcon',
 ]
 
-const SelectionListOrderBy = ({ intl, message, orderBy, options }) => {
+const SelectionListOrderBy = ({
+  intl,
+  message = 'store/ordenation.sort-by',
+  orderBy,
+  options,
+}) => {
   const [showDropdown, setShowDropdown] = useState(false)
   const handles = useCssHandles(CSS_HANDLES)
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fixed bug causing `TotalProducts` and `OrderBy` not to appear on non-flexible components.

#### How should this be manually tested?

[Workspace](https://iaronaraujo--lionspride.myvtex.com/mens/400/dept)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
