### PR TITLE
Add specific classes to `filterGroup` and `filterItem` of the `filter…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Add specific classes to `filterGroup` and `filterItem` of the `filterAccordion` (filter mobile)
+
 ## [3.56.1] - 2020-04-24
 ### Fixed
 - Make query in component and done on SSR match.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Added
 - Add specific classes to `filterGroup` and `filterItem` of the `filterAccordion` (filter mobile)
 

--- a/react/components/AccordionFilterGroup.js
+++ b/react/components/AccordionFilterGroup.js
@@ -2,13 +2,13 @@ import React from 'react'
 import { useIntl } from 'react-intl'
 import classNames from 'classnames'
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
-import slugify from 'slugify'
 
 import AccordionFilterItem from './AccordionFilterItem'
 import FacetCheckboxList from './FacetCheckboxList'
 import useSelectedFilters from '../hooks/useSelectedFilters'
 
 import { getFilterTitle } from '../constants/SearchHelpers'
+import { searchSlugify } from '../utils/slug'
 
 const CSS_HANDLES = ['accordionFilterOpened']
 
@@ -26,7 +26,7 @@ const AccordionFilterGroup = ({
   const quantitySelected = filters.filter(facet => facet.selected).length
   const intl = useIntl()
   const facetTitle = getFilterTitle(title, intl)
-  const slugFaceTitle = slugify(facetTitle, { lower: true, remove: /[*+~.()'"!:@]/g })
+  const slugifyFaceTitle = searchSlugify(facetTitle)
 
   return (
     <AccordionFilterItem
@@ -37,7 +37,7 @@ const AccordionFilterGroup = ({
       quantitySelected={quantitySelected}
     >
       <div className={classNames(
-          applyModifiers(handles.accordionFilterOpened, slugFaceTitle),
+          applyModifiers(handles.accordionFilterOpened, slugifyFaceTitle),
           className
         )}>
         <FacetCheckboxList

--- a/react/components/AccordionFilterGroup.js
+++ b/react/components/AccordionFilterGroup.js
@@ -26,7 +26,7 @@ const AccordionFilterGroup = ({
   const quantitySelected = filters.filter(facet => facet.selected).length
   const intl = useIntl()
   const facetTitle = getFilterTitle(title, intl)
-  const slugifyFacetTitle = searchSlugify(facetTitle)
+  const slugifiedFacetTitle = searchSlugify(facetTitle)
 
   return (
     <AccordionFilterItem
@@ -37,7 +37,7 @@ const AccordionFilterGroup = ({
       quantitySelected={quantitySelected}
     >
       <div className={classNames(
-          applyModifiers(handles.accordionFilterOpen, slugifyFaceTitle),
+          applyModifiers(handles.accordionFilterOpen, slugifiedFacetTitle),
           className
         )}>
         <FacetCheckboxList

--- a/react/components/AccordionFilterGroup.js
+++ b/react/components/AccordionFilterGroup.js
@@ -37,7 +37,7 @@ const AccordionFilterGroup = ({
       quantitySelected={quantitySelected}
     >
       <div className={classNames(
-          applyModifiers(handles.accordionFilterOpened, slugifyFaceTitle),
+          applyModifiers(handles.accordionFilterOpen, slugifyFaceTitle),
           className
         )}>
         <FacetCheckboxList

--- a/react/components/AccordionFilterGroup.js
+++ b/react/components/AccordionFilterGroup.js
@@ -1,11 +1,16 @@
 import React from 'react'
 import { useIntl } from 'react-intl'
+import classNames from 'classnames'
+import { useCssHandles, applyModifiers } from 'vtex.css-handles'
+import slugify from 'slugify'
 
 import AccordionFilterItem from './AccordionFilterItem'
 import FacetCheckboxList from './FacetCheckboxList'
 import useSelectedFilters from '../hooks/useSelectedFilters'
 
 import { getFilterTitle } from '../constants/SearchHelpers'
+
+const CSS_HANDLES = ['accordionFilterOpened']
 
 const AccordionFilterGroup = ({
   className,
@@ -16,10 +21,12 @@ const AccordionFilterGroup = ({
   onOpen,
   onFilterCheck,
 }) => {
+  const handles = useCssHandles(CSS_HANDLES)
   const filters = useSelectedFilters(facets)
   const quantitySelected = filters.filter(facet => facet.selected).length
   const intl = useIntl()
   const facetTitle = getFilterTitle(title, intl)
+  const slugFaceTitle = slugify(facetTitle, { lower: true, remove: /[*+~.()'"!:@]/g })
 
   return (
     <AccordionFilterItem
@@ -29,7 +36,10 @@ const AccordionFilterGroup = ({
       onOpen={onOpen}
       quantitySelected={quantitySelected}
     >
-      <div className={className}>
+      <div className={classNames(
+          applyModifiers(handles.accordionFilterOpened, slugFaceTitle),
+          className
+        )}>
         <FacetCheckboxList
           onFilterCheck={onFilterCheck}
           facets={filters}

--- a/react/components/AccordionFilterGroup.js
+++ b/react/components/AccordionFilterGroup.js
@@ -10,7 +10,7 @@ import useSelectedFilters from '../hooks/useSelectedFilters'
 import { getFilterTitle } from '../constants/SearchHelpers'
 import { searchSlugify } from '../utils/slug'
 
-const CSS_HANDLES = ['accordionFilterOpened']
+const CSS_HANDLES = ['accordionFilterOpen']
 
 const AccordionFilterGroup = ({
   className,

--- a/react/components/AccordionFilterGroup.js
+++ b/react/components/AccordionFilterGroup.js
@@ -26,7 +26,7 @@ const AccordionFilterGroup = ({
   const quantitySelected = filters.filter(facet => facet.selected).length
   const intl = useIntl()
   const facetTitle = getFilterTitle(title, intl)
-  const slugifyFaceTitle = searchSlugify(facetTitle)
+  const slugifyFacetTitle = searchSlugify(facetTitle)
 
   return (
     <AccordionFilterItem

--- a/react/components/FacetCheckboxList.js
+++ b/react/components/FacetCheckboxList.js
@@ -15,7 +15,7 @@ const FacetCheckboxList = ({ facets, onFilterCheck, facetTitle }) => {
     return (
       <div
         className={classNames(
-          applyModifiers(styles.filterAccordionItemBox, slugifyName),
+          applyModifiers(styles.filterAccordionItemBox, slugifiedName),
           'pr4 pt3 items-center flex bb b--muted-5'
         )}
         key={name}

--- a/react/components/FacetCheckboxList.js
+++ b/react/components/FacetCheckboxList.js
@@ -2,19 +2,20 @@ import classNames from 'classnames'
 import React from 'react'
 import { Checkbox } from 'vtex.styleguide'
 import { applyModifiers } from 'vtex.css-handles'
-import slugify from 'slugify'
 
 import styles from '../searchResult.css'
+
+import { searchSlugify } from '../utils/slug'
 
 const FacetCheckboxList = ({ facets, onFilterCheck, facetTitle }) => {
   return facets.map(facet => {
     const { name } = facet
-    const slugName = slugify(name, { lower: true, remove: /[*+~.()'"!:@]/g })
+    const slugifyName = searchSlugify(name)
 
     return (
       <div
         className={classNames(
-          applyModifiers(styles.filterAccordionItemBox, slugName),
+          applyModifiers(styles.filterAccordionItemBox, slugifyName),
           'pr4 pt3 items-center flex bb b--muted-5'
         )}
         key={name}

--- a/react/components/FacetCheckboxList.js
+++ b/react/components/FacetCheckboxList.js
@@ -1,17 +1,20 @@
 import classNames from 'classnames'
 import React from 'react'
 import { Checkbox } from 'vtex.styleguide'
+import { applyModifiers } from 'vtex.css-handles'
+import slugify from 'slugify'
 
 import styles from '../searchResult.css'
 
 const FacetCheckboxList = ({ facets, onFilterCheck, facetTitle }) => {
   return facets.map(facet => {
     const { name } = facet
+    const slugName = slugify(name, { lower: true, remove: /[*+~.()'"!:@]/g })
 
     return (
       <div
         className={classNames(
-          styles.filterAccordionItemBox,
+          applyModifiers(styles.filterAccordionItemBox, slugName),
           'pr4 pt3 items-center flex bb b--muted-5'
         )}
         key={name}

--- a/react/components/FacetCheckboxList.js
+++ b/react/components/FacetCheckboxList.js
@@ -10,7 +10,7 @@ import { searchSlugify } from '../utils/slug'
 const FacetCheckboxList = ({ facets, onFilterCheck, facetTitle }) => {
   return facets.map(facet => {
     const { name } = facet
-    const slugifyName = searchSlugify(name)
+    const slugifiedName = searchSlugify(name)
 
     return (
       <div


### PR DESCRIPTION
#308 ## What is the purpose of this pull request?

The purpose of this PR is to customize filters distinctly adding a class to them as there is on `desktop filters`

#### What problem is this solving?

It's solving the issue on mobile filters, that we can't apply different CSS modifiers to each filter group

#### How should this be manually tested?

Here it is an workspace for further tests https://leo2--worldwidegolf.myvtex.com/mens-spiked-golf-shoes

And here it is a print showing this changes https://prnt.sc/sg7hze

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [*] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
