### PR TITLE
Remove default values from contentSchemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `TotalProducts` and `OrderBy` would not render expected text due to the default message id defined in `contentSchemas.json` being modified.
 
-## [3.58.1] - 2020-05-12
+## [3.58.1] - 2020-05-12 [YANKED]
 ### Fixed
 - Bug causing `TotalProducts` and `OrderBy` not to appear on non flexible components.
 
-## [3.58.0] - 2020-05-12
+## [3.58.0] - 2020-05-12 [YANKED]
 ### Added
 - Support for customization of `TotalProductsFlexible` and `OrderByFlexible` components via site-editor.
 

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -6,8 +6,7 @@
       "properties": {
         "message": {
           "$ref": "app:vtex.native-types#/definitions/text",
-          "title": "admin/editor.search-result.ordination.sort-by",
-          "default": "store/ordenation.sort-by"
+          "title": "admin/editor.search-result.ordination.sort-by"
         }
       }
     },
@@ -17,8 +16,7 @@
       "properties": {
         "message": {
           "$ref": "app:vtex.native-types#/definitions/text",
-          "title": "admin/editor.search-result.total-products",
-          "default": "store/search.total-products-2"
+          "title": "admin/editor.search-result.total-products"
         }
       }
     }


### PR DESCRIPTION
#### What is the purpose of this pull request?

This removes the default values defined in the `contentSchemas.json` file for `messages` prop in the following blocks:

- `OrderBy`
- `TotalProducts`

#### What problem is this solving?

For some reason that we're not fully aware of, the values passed as a `default` were prefixed with `vtex.search-result@3.x::`, that caused the call to `formatIOMessage` to return the message itself, since the message ID was not found.

#### How should this be manually tested?

[Workspace](https://victormiranda--txboot.myvtex.com/)

#### Screenshots or example usage

**Before**

<img width="853" alt="Screen Shot 2020-05-13 at 18 02 31" src="https://user-images.githubusercontent.com/27777263/81865150-ee34b300-9543-11ea-989d-e069e80e7ff9.png">

**After**

<img width="1437" alt="Screen Shot 2020-05-13 at 18 03 47" src="https://user-images.githubusercontent.com/27777263/81865311-1ae8ca80-9544-11ea-9b59-104f1e0ced34.png">

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
