### PR TITLE
do not pass tree path to extension point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Problem of components not rendering when child of flex-layout.
 
 ## [3.59.0] - 2020-05-18
 ### Added

--- a/react/SearchResultLayout.js
+++ b/react/SearchResultLayout.js
@@ -4,6 +4,7 @@ import { useDevice } from 'vtex.device-detector'
 import { path, compose, equals, pathOr, isEmpty } from 'ramda'
 
 import OldSearchResult from './index'
+import { removeTreePath } from './utils/removeTreePath'
 
 const noProducts = compose(
   isEmpty,
@@ -27,14 +28,14 @@ const SearchResultLayout = props => {
   const { isMobile } = useDevice()
 
   if (foundNothing(searchQuery) && hasCustomNotFound) {
-    return <ExtensionPoint id="search-not-found-layout" {...props} />
+    return <ExtensionPoint id="search-not-found-layout" {...removeTreePath(props)} />
   }
 
   if (hasMobileBlock && isMobile) {
-    return <ExtensionPoint id="search-result-layout.mobile" {...props} />
+    return <ExtensionPoint id="search-result-layout.mobile" {...removeTreePath(props)} />
   }
 
-  return <ExtensionPoint id="search-result-layout.desktop" {...props} />
+  return <ExtensionPoint id="search-result-layout.desktop" {...removeTreePath(props)} />
 }
 
 SearchResultLayout.getSchema = () => {

--- a/react/SearchResultLayoutCustomQuery.js
+++ b/react/SearchResultLayoutCustomQuery.js
@@ -6,6 +6,7 @@ import { path, compose, equals, pathOr, isEmpty } from 'ramda'
 import LocalQuery from './components/LocalQuery'
 
 import OldSearchResult from './index'
+import { removeTreePath } from './utils/removeTreePath'
 
 const noProducts = compose(
   isEmpty,
@@ -24,19 +25,21 @@ const foundNothing = searchQuery => {
   return isFtOnly(searchQuery) && !loading && noProducts(searchQuery)
 }
 
-const ExtensionPointWithProps = ({ id, parentProps, localSearchQueryData }) => (
-  <ExtensionPoint
-    id={id}
-    {...parentProps}
-    searchQuery={localSearchQueryData.searchQuery}
-    maxItemsPerPage={localSearchQueryData.maxItemsPerPage}
-    map={localSearchQueryData.map}
-    params={localSearchQueryData.params}
-    priceRange={localSearchQueryData.priceRange}
-    orderBy={localSearchQueryData.orderBy}
-    page={localSearchQueryData.page}
-  />
-)
+const ExtensionPointWithProps = ({ id, parentProps, localSearchQueryData }) => {
+  return (
+    <ExtensionPoint
+      id={id}
+      {...removeTreePath(parentProps)}
+      searchQuery={localSearchQueryData.searchQuery}
+      maxItemsPerPage={localSearchQueryData.maxItemsPerPage}
+      map={localSearchQueryData.map}
+      params={localSearchQueryData.params}
+      priceRange={localSearchQueryData.priceRange}
+      orderBy={localSearchQueryData.orderBy}
+      page={localSearchQueryData.page}
+    />
+  )
+}
 
 const SearchResultLayoutCustomQuery = props => {
   const hasMobileBlock = !!useChildBlock({ id: 'search-result-layout.mobile' })
@@ -64,9 +67,9 @@ const SearchResultLayoutCustomQuery = props => {
       {...(areFieldsFromQueryStringValid
         ? fieldsFromQueryString
         : {
-            queryField: props.querySchema.queryField,
-            mapField: props.querySchema.mapField,
-          })}
+          queryField: props.querySchema.queryField,
+          mapField: props.querySchema.mapField,
+        })}
       orderByField={props.querySchema.orderByField}
       hideUnavailableItems={props.querySchema.hideUnavailableItems}
       facetsBehavior={props.querySchema.facetsBehavior}

--- a/react/utils/removeTreePath.js
+++ b/react/utils/removeTreePath.js
@@ -1,0 +1,8 @@
+export const removeTreePath = props => {
+  if (!props) {
+    return {}
+  }
+
+  const { treePath, ...rest } = props
+  return rest
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?

The spread of props to ExtensionPoint was making we wrongfully pass treePath prop to children making the children treePath incorrect

#### What problem is this solving?

https://fidelis--storecomponents.myvtex.com/apparel---accessories/


#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
