### PR TITLE
add hidden field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Hide facets with property `hidden`.
 
 ## [3.59.3] - 2020-06-01
 ### Added

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -82,7 +82,10 @@ const FilterNavigator = ({
     const options = [
       ...specificationFilters.map(filter => {
         return filter.facets.map(facet => {
-          return newNamedFacet({ ...facet, title: filter.name })
+          return {
+            ...newNamedFacet({ ...facet, title: filter.name }),
+            hidden: filter.hidden,
+          }
         })
       }),
       ...brands,

--- a/react/components/SelectedFilters.js
+++ b/react/components/SelectedFilters.js
@@ -24,12 +24,14 @@ const SelectedFilters = ({
     return null
   }
 
+  const visibleFilters = filters.filter(filter => !filter.hidden)
+
   const title = intl.formatMessage({ id: 'store/search.selected-filters' })
   return (
     <FilterOptionTemplate
       id="selectedFilters"
       title={title}
-      filters={filters}
+      filters={visibleFilters}
       collapsable={false}
       selected
     >

--- a/react/utils/getFilters.js
+++ b/react/utils/getFilters.js
@@ -23,7 +23,7 @@ const getFilters = ({
     hiddenFacets
   )
     ? specificationFilters
-        .filter(spec => !contains(spec.name, hiddenFacetsNames))
+        .filter(spec => !contains(spec.name, hiddenFacetsNames) && !spec.hidden)
         .map(spec => ({
           type: SPECIFICATION_FILTERS_TYPE,
           title: spec.name,


### PR DESCRIPTION
#### What problem is this solving?

There are some filters that should be hidden in UI. For example, the ones related to collections. This PR adds a `hidden` field to indicate which filter should be hidden.

⚠️ Please, do not merge it before:
- https://github.com/vtex-apps/search-resolver/pull/29
- https://github.com/vtex-apps/search-resolver/pull/28
- https://github.com/vtex-apps/search-graphql/pull/82
- https://github.com/vtex-apps/store-resources/pull/119

#### How should this be manually tested?

[Workspace](https://hiago--storecomponents.myvtex.com/apparel---accessories/clothing/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

