### PR TITLE
Added query to productClick event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `query` to productClick event
 
 ## [3.59.2] - 2020-05-29
 ### Fixed

--- a/react/components/GalleryItem.js
+++ b/react/components/GalleryItem.js
@@ -1,7 +1,9 @@
 import React, { useMemo, useCallback, memo } from 'react'
+
 import { ExtensionPoint } from 'vtex.render-runtime'
 import { usePixel } from 'vtex.pixel-manager/PixelContext'
 import ProductSummary from 'vtex.product-summary/ProductSummaryCustom'
+import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
 
 import { productShape } from '../constants/propTypes'
 import { PropTypes } from 'prop-types'
@@ -11,16 +13,22 @@ import { PropTypes } from 'prop-types'
  */
 const GalleryItem = ({ item, displayMode, summary }) => {
   const { push } = usePixel()
+  const { searchQuery } = useSearchPage()
 
   const product = useMemo(
     () => ProductSummary.mapCatalogProductToProductSummary(item),
     [item]
   )
 
-  const handleClick = useCallback(
-    () => push({ event: 'productClick', product }),
-    [product, push]
-  )
+  const query = useMemo(() => {
+    if (searchQuery && searchQuery.variables) {
+      return searchQuery.variables.query
+    }
+  }, [searchQuery])
+
+  const handleClick = useCallback(() => {
+    push({ event: 'productClick', product, query })
+  }, [product, query, push])
 
   return (
     <ExtensionPoint


### PR DESCRIPTION
#### What is the purpose of this pull request?

Extend the information provided by the `productClick` event when inside search pages, which will include the `query` field, that can be used by VTEX Intelligent Search and other 3rd party search providers to help gather analytics info about popular products.

#### What problem is this solving?

Gather analytics information, in VTEX Intelligent Search's case, this is stored and used to provide usage reports, conversion metrics, and boost popular products.

#### How should this be manually tested?

Check the value stored in `window.pixelManagerEvents` after clicking a product on both workspaces below:

- `vtex.search-resolver@0.x`: https://christian--storecomponents.myvtex.com/shirt?_q=shirt&map=ft
- `vtex.search-resolver@1.x`: https://christiansearch--storecomponents.myvtex.com/shirt?_q=shirt&map=ft

#### Screenshots or example usage

- Using `vtex.search-resolver@0.x`:
![image](https://user-images.githubusercontent.com/34144667/82824348-8c4b4600-9e7f-11ea-916f-226ddda1b45a.png)

- Using `vtex.search-resolver@1.x`:
![image](https://user-images.githubusercontent.com/34144667/82824365-940aea80-9e7f-11ea-87cb-9369b42e0199.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
