### PR TITLE
adjust fuzzy, operator and searchState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- `Pricerange` event was not adding `fuzzy`, `operator` and `searchState` to the URL.
+- `fuzzy`, `operator` and `searchState` were being reset in any search interaction.
+
+### Added
+- `SearchResult` now adds `fuzzy`, `operator` and `searchState` to the URL.
+
 ## [3.63.2] - 2020-07-08
 
 ### Fixed

--- a/react/components/PriceRange.js
+++ b/react/components/PriceRange.js
@@ -8,6 +8,7 @@ import { formatCurrency } from 'vtex.format-currency'
 import { facetOptionShape } from '../constants/propTypes'
 import { getFilterTitle } from '../constants/SearchHelpers'
 import FilterOptionTemplate from './FilterOptionTemplate'
+import useSearchState from '../hooks/useSearchState'
 
 const DEBOUNCE_TIME = 500 // ms
 
@@ -17,13 +18,21 @@ const PriceRange = ({ title, facets, intl, priceRange }) => {
 
   const navigateTimeoutId = useRef()
 
+  const { fuzzy, operator, searchState } = useSearchState()
+
   const handleChange = ([left, right]) => {
     if (navigateTimeoutId.current) {
       clearTimeout(navigateTimeoutId.current)
     }
 
     navigateTimeoutId.current = setTimeout(() => {
-      setQuery({ priceRange: `${left} TO ${right}`, page: undefined })
+      setQuery({
+        priceRange: `${left} TO ${right}`,
+        page: undefined,
+        fuzzy: fuzzy || undefined,
+        operator: operator || undefined,
+        searchState: searchState || undefined,
+      })
     }, DEBOUNCE_TIME)
   }
 

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -121,23 +121,20 @@ const useCorrectSearchStateVariables = (
   fuzzy,
   operator,
   searchState,
-  shouldReset
+  fullText
 ) => {
-  const fuzzyRef = useRef(fuzzy)
-  const operatorRef = useRef(operator)
-  const searchStateRef = useRef(searchState)
+  const fullTextRef = useRef(fullText)
+  const shouldReset = isCurrentDifferent(fullTextRef, fullText)
 
-  if (shouldReset) {
-    fuzzyRef.current = undefined
-    operatorRef.current = undefined
-    searchStateRef.current = undefined
+  const result = {
+    fuzzy: shouldReset ? undefined : fuzzy,
+    operator: shouldReset ? undefined : operator,
+    searchState: shouldReset ? undefined : searchState,
   }
 
-  return {
-    fuzzy: fuzzyRef.current,
-    operator: operatorRef.current,
-    searchState: searchStateRef.current,
-  }
+  fullTextRef.current = fullText
+
+  return result
 }
 
 const useQueries = (variables, facetsArgs) => {
@@ -230,6 +227,12 @@ const SearchQuery = ({
   searchState: searchStateQuery,
   __unstableProductOriginVtex,
 }) => {
+  const [selectedFacets, fullText] = buildSelectedFacetsAndFullText(
+    query,
+    map,
+    priceRange
+  )
+
   /* This is the page of the first query since the component was rendered. 
   We want this behaviour so we can show the correct items even if the pageQuery
   changes. It should change only on a new render or if the query or orderby 
@@ -243,7 +246,7 @@ const SearchQuery = ({
     fuzzyQuery,
     operatorQuery,
     searchStateQuery,
-    shouldReset
+    fullText
   )
   const { setRedirect } = useRedirect()
 
@@ -255,12 +258,6 @@ const SearchQuery = ({
     facetMap: map,
     withFacets: includeFacets(map, query),
   }
-
-  const [selectedFacets, fullText] = buildSelectedFacetsAndFullText(
-    query,
-    map,
-    priceRange
-  )
 
   const variables = useMemo(() => {
     return {

--- a/react/index.js
+++ b/react/index.js
@@ -7,6 +7,7 @@ import LocalQuery from './components/LocalQuery'
 import { LAYOUT_MODE } from './components/LayoutModeSwitcher'
 import ContextProviders from './components/ContextProviders'
 import { PAGINATION_TYPES } from './constants/paginationType'
+import { SearchPageContext } from 'vtex.search-page-context/SearchPageContext'
 
 const DEFAULT_MAX_ITEMS_PER_PAGE = 10
 
@@ -51,21 +52,27 @@ const SearchResult = props => {
       {...querySchema}
       {...(areFieldsFromQueryStringValid ? fieldsFromQueryString : {})}
       render={localQueryProps => (
-        <ContextProviders
-          queryVariables={localQueryProps.searchQuery.variables}
-          settings={settings}
+        <SearchPageContext.Provider
+          value={{ searchQuery: localQueryProps.searchQuery }}
         >
-          <SearchResultContainer {...localQueryProps} />
-        </ContextProviders>
+          <ContextProviders
+            queryVariables={localQueryProps.searchQuery.variables}
+            settings={settings}
+          >
+            <SearchResultContainer {...localQueryProps} />
+          </ContextProviders>
+        </SearchPageContext.Provider>
       )}
     />
   ) : (
-    <ContextProviders
-      queryVariables={searchQuery.variables}
-      settings={settings}
-    >
-      <SearchResultContainer {...props} />
-    </ContextProviders>
+    <SearchPageContext.Provider value={{ searchQuery: searchQuery }}>
+      <ContextProviders
+        queryVariables={searchQuery.variables}
+        settings={settings}
+      >
+        <SearchResultContainer {...props} />
+      </ContextProviders>
+    </SearchPageContext.Provider>
   )
 }
 
@@ -132,15 +139,17 @@ SearchResult.getSchema = props => {
               ],
             },
             installmentCriteria: {
-              title: 'admin/editor.search-result.query.installmentCriteria.title',
-              description: 'admin/editor.search-result.query.installmentCriteria.description',
+              title:
+                'admin/editor.search-result.query.installmentCriteria.title',
+              description:
+                'admin/editor.search-result.query.installmentCriteria.description',
               type: 'string',
               default: 'MAX_WITHOUT_INTEREST',
               enum: ['MAX_WITHOUT_INTEREST', 'MAX_WITH_INTEREST'],
               enumNames: [
                 'admin/editor.search-result.query.installmentCriteria.max-without-interest',
-                'admin/editor.search-result.query.installmentCriteria.max-with-interest'
-              ]
+                'admin/editor.search-result.query.installmentCriteria.max-with-interest',
+              ],
             },
           },
         },
@@ -160,8 +169,10 @@ SearchResult.getSchema = props => {
                 enum: [true],
               },
               trackingId: {
-                title: 'admin.editor.search-result.advanced-settings.trackingId.title',
-                description: 'admin.editor.search-result.advanced-settings.trackingId.description',
+                title:
+                  'admin.editor.search-result.advanced-settings.trackingId.title',
+                description:
+                  'admin.editor.search-result.advanced-settings.trackingId.description',
                 type: 'string',
               },
             },


### PR DESCRIPTION
#### What is the purpose of this pull request?

`fuzzy`, `operator` and `searchstate` are query strings related to the state of the new search. They provide information about how the engine should find the data.
In some cases, these query strings are not being sent to the backend. This PR aims to fix this problem

#### What problem is this solving?

This PR fix three problems related to the `operator`, `fuzzy` and `searchState` variables.

- the variables were being reset in every filter interaction, but it should reset only when a new `fulltext` term is used.
- The priceRange change event was not adding these variables to the URL
- Stores using the `SearchResult` component were not adding these variables to the URL.

#### How should this be manually tested?

[workspace](https://hiago--alssports.myvtex.com/shirt?_q=shirt&map=ft)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
