### PR TITLE
Add specification filters of type number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Allows specification filters of type `number`.
+
 ## [3.59.0] - 2020-05-18
 ### Added
 - Add specific classes to `filterGroup` and `filterItem` of the `filterAccordion` (filter mobile)

--- a/react/utils/compatibilityLayer.js
+++ b/react/utils/compatibilityLayer.js
@@ -59,7 +59,9 @@ export const detachFiltersByType = facets => {
 
   const brands = pathOr([], ['BRAND', 0, 'facets'], groupedFilters)
 
-  const specificationFilters = groupedFilters['TEXT'] || []
+  const specificationFilters = (groupedFilters['NUMBER'] || []).concat(
+    groupedFilters['TEXT'] || []
+  )
 
   const categoriesTrees = pathOr(
     [],


### PR DESCRIPTION
#### What is the purpose of this pull request?
Allows specification filters with type number to be used in a store

<!--- Describe your changes in detail. -->

#### What problem is this solving?
currently, all specification filters are of the text type. therefore, it is not possible to display filters, for example, as buckets.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
