### PR TITLE
New css handle on filter mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New CSS handles: `filterBreadcrumbsItem` and `filterBreadcrumbsItemName`.
 
 ## [3.59.2] - 2020-05-29
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -343,6 +343,8 @@ In order to apply CSS customization in this and other blocks, follow the instruc
 | `dropdownMobile`                      |
 | `filter`                              |
 | `filterAccordionBreadcrumbs`          |
+| `filterBreadcrumbsItem`               |
+| `filterBreadcrumbsItemName`           |
 | `filterAccordionItemBox`              |
 | `filterApplyButtonWrapper`            |
 | `filterAvailable`                     |

--- a/react/components/AccordionFilterContainer.js
+++ b/react/components/AccordionFilterContainer.js
@@ -8,7 +8,9 @@ import AccordionFilterItem from './AccordionFilterItem'
 import DepartmentFilters from './DepartmentFilters'
 import AccordionFilterGroup from './AccordionFilterGroup'
 import AccordionFilterPriceRange from './AccordionFilterPriceRange'
+import { useCssHandles } from 'vtex.css-handles'
 
+const CSS_HANDLES = ['filterBreadcrumbsItem', 'filterBreadcrumbsItemName']
 import styles from '../searchResult.css'
 
 const CATEGORIES_TITLE = 'store/search.filter.title.categories'
@@ -22,6 +24,7 @@ const AccordionFilterContainer = ({
   priceRange,
 }) => {
   const [openItem, setOpenItem] = useState(null)
+  const handles = useCssHandles(CSS_HANDLES)
 
   const handleOpen = id => e => {
     e.preventDefault()
@@ -75,9 +78,13 @@ const AccordionFilterContainer = ({
           </div>
         </div>
         {openItem && (
-          <div className="pa4 flex items-center">
+          <div
+            className={`${handles.filterBreadcrumbsItem} pv4 flex items-center`}
+          >
             <IconCaret orientation="right" size={13} />
-            <div className="pl3 t-heading-4 c-on-base">
+            <div
+              className={`${handles.filterBreadcrumbsItemName} pl3 t-heading-4 c-on-base`}
+            >
               {intl.formatMessage({ id: openItem })}
             </div>
           </div>


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add new CSS handles on mobile filter

#### What problem is this solving?
Be able to edit the CSS on the mobile filter breadcrumb

#### How should this be manually tested?
https://mobilefilter--equishopper.myvtex.com/riding-apparel
open the mobile filter and inspect the breadcrumb item 

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
