### PR TITLE
decode map before split it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Decode map before split it in `selectedFacets`.
+
 ## [3.59.4] - 2020-06-02
 ### Added
 - Hide facets with property `hidden`.

--- a/react/utils/compatibilityLayer.js
+++ b/react/utils/compatibilityLayer.js
@@ -14,7 +14,7 @@ export const buildSelectedFacetsAndFullText = (query, map, priceRange) => {
   }
 
   const queryValues = query.split('/')
-  const mapValues = map.split(',')
+  const mapValues = decodeURIComponent(map).split(',')
 
   let fullText
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Decode map before split it in `selectedFacets`

#### What problem is this solving?

Sometimes the `,` in`map` is encoded, and it becomes `%2C`. This way, we can't split the `map` correctly.

#### How should this be manually tested?

[Broken workspace](https://search--lionspride.myvtex.com/holiday/1208/dept)
[Fixed workspace](https://hiago--lionspride.myvtex.com/holiday/1208/dept)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.