### PR TITLE
Feature/add breadcrumb to facets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Accept `facets` breadcrumb as fallback.
+
 ## [3.60.4] - 2020-06-15
 ### Fixed
 - crashes happening when clicking on a department filter on mobile.

--- a/react/SearchTitleFlexible.js
+++ b/react/SearchTitleFlexible.js
@@ -8,7 +8,10 @@ import styles from './searchResult.css'
 
 const withSearchPageContextProps = Component => () => {
   const { searchQuery } = useSearchPage()
-  const breadcrumb = path(['data', 'productSearch', 'breadcrumb'], searchQuery)
+  const breadcrumb =
+    path(['data', 'productSearch', 'breadcrumb'], searchQuery) ||
+    path(['data', 'facets', 'breadcrumb'], searchQuery)
+
   return (
     <Component
       breadcrumb={breadcrumb}

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -194,7 +194,11 @@ const useQueries = (variables, facetsArgs) => {
     data: {
       productSearch:
         productSearchResult.data && productSearchResult.data.productSearch,
-      facets: { ...detatachedFilters, queryArgs },
+      facets: {
+        ...detatachedFilters,
+        queryArgs,
+        breadcrumb: facets && facets.breadcrumb,
+      },
       searchMetadata,
     },
     productSearchResult,


### PR DESCRIPTION
#### What is the purpose of this pull request?

Since breadcrumb is a "list" of selected facets, the `vtex.search-resolver@1.x` performs better if this info comes from the `facets` query instead of the `productSearch` query.

This PR adds the `facets` breadcrumb as a fallback. 

#### How should this be manually tested?
[Workpace](https://hiago--storecomponents.myvtex.com/)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
