### PR TITLE
add __unstableProductOriginVtex to SearchResultLayoutCustomQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `__unstableProductOriginVtex` prop to the `SearchResultLayoutCustomQuery`.
+
 ## [3.60.2] - 2020-06-09
 ### Fixed
 - Fixed CSS Handles table in README.md file (added the `--` between Handle and its modifier).

--- a/react/SearchResultLayoutCustomQuery.js
+++ b/react/SearchResultLayoutCustomQuery.js
@@ -75,6 +75,9 @@ const SearchResultLayoutCustomQuery = props => {
       facetsBehavior={props.querySchema.facetsBehavior}
       skusFilter={props.querySchema.skusFilter}
       query={props.query}
+      __unstableProductOriginVtex={
+        props.querySchema.__unstableProductOriginVtex
+      }
       render={localSearchQueryData => {
         if (
           foundNothing(localSearchQueryData.searchQuery) &&

--- a/react/components/LocalQuery.js
+++ b/react/components/LocalQuery.js
@@ -24,6 +24,7 @@ const LocalQuery = props => {
       map = mapField,
     } = {},
     render,
+    __unstableProductOriginVtex,
   } = props
 
   const { page: runtimePage } = useRuntime()
@@ -40,6 +41,7 @@ const LocalQuery = props => {
       pageQuery={pageQuery}
       skusFilter={skusFilter}
       simulationBehavior={simulationBehavior}
+      __unstableProductOriginVtex={__unstableProductOriginVtex}
     >
       {(searchQuery, extraParams) => {
         return render({


### PR DESCRIPTION
#### What is the purpose of this pull request?

`SearchQuery` has the prop `__unstableProductOriginVtex`, but this prop is not available when using the `SearchResultLayoutCustomQuery`. This PR solves this problem 

#### How should this be manually tested?

[Workspace](https://dev--dzarm.myvtex.com/novidades)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
