### PR TITLE
Fix/mobile departments facets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- crashes happening when clicking on a department filter twice on mobile.
+- crashes happening when clicking on a department filter on mobile.
 
 ## [3.60.0] - 2020-06-05
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- crashes happening when clicking on a department filter twice on mobile.
 
 ## [3.60.0] - 2020-06-05
 ### Added
 - New CSS handles: `filterBreadcrumbsItem` and `filterBreadcrumbsItemName`.
 
 ## [3.59.5] - 2020-06-03
-
 ### Fixed
 - Decode map before split it in `selectedFacets`.
 

--- a/react/components/CategoryFilter.js
+++ b/react/components/CategoryFilter.js
@@ -65,7 +65,7 @@ const CategoryFilter = ({
     }
 
     if (shallow) {
-      onCategorySelect()
+      onCategorySelect(category)
     } else {
       // deselect root category
       handleUnselectCategories(0)

--- a/react/hooks/useFacetNavigation.js
+++ b/react/hooks/useFacetNavigation.js
@@ -95,7 +95,8 @@ const buildQueryAndMap = (
   selectedFacets
 ) => {
   const queryAndMap = facets.reduce(
-    ({ query, map }, facet) => {
+    // The spread on facet is important so we can assign facet.newQuerySegment
+    ({ query, map }, { ...facet }) => {
       const facetValue = facet.value
       facet.newQuerySegment = newFacetPathName(facet)
       if (facet.selected) {


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR fixes two bugs on the mobile filter sidebar:
- When selecting root departments the page would break
- When clicking on a department twice the page would break on a dev workspace 

#### How should this be manually tested?

Open these on mobile and check that the `Departments` filters are working correctly:
[Storecomponents](https://iaronaraujo--storecomponents.myvtex.com/top?_q=top&map=ft)
[Als](https://iaronaraujo--alssports.myvtex.com/swim?_q=swim&map=ft)
[Motorolaus](https://iaronaraujo--motorolaus.myvtex.com/)
[Boticario](https://iaronaraujo--boticario.myvtex.com/perfumaria)


#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
