### PR TITLE
Fix useFetchMore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Problem with `useFetchMore` that displayed repeated products.
+
 ## [3.60.5] - 2020-06-15
 
 ### Added

--- a/react/hooks/useFetchMore.js
+++ b/react/hooks/useFetchMore.js
@@ -178,7 +178,7 @@ export const useFetchMore = props => {
   const handleFetchMoreNext = async () => {
     const rollbackState = pageState
     const from = pageState.to + 1
-    const to = min(recordsFiltered, from + maxItemsPerPage) - 1
+    const to = from + maxItemsPerPage - 1
     setInfiniteScrollError(false)
     pageDispatch({ type: 'NEXT_PAGE', args: { to } })
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.

<!--- Describe your changes in detail. -->

#### What problem is this solving?
some products were duplicated when clicking on 'show more' due to a problem with the prop `to` used in `useFetchMore`

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
[workspace](https://thalyta--minisomx.myvtex.com/labial?fuzzy=0&map=ft&operator=and&page=1)

[storecomponents](https://thalyta--storecomponents.myvtex.com/apparel---accessories/)
- Click the 'Show more' button
- note that the first item on the second page is different from the last item on the first page

#### Screenshots or example usage
Before:
![old](https://user-images.githubusercontent.com/20840671/84687156-9b1f9880-af13-11ea-98ec-73e4e780ba40.gif)

After:
![new](https://user-images.githubusercontent.com/20840671/84687169-a246a680-af13-11ea-8c43-e762337110ed.gif)


#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
