### PR TITLE
Feature/redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Search redirect.
+
 ## [3.60.6] - 2020-06-16
 
 ### Fixed

--- a/react/SearchContent.js
+++ b/react/SearchContent.js
@@ -10,10 +10,11 @@ const SearchContent = () => {
   const { searchQuery, showFacets } = useSearchPage()
   const { mobileLayout, showContentLoader } = useSearchPageState()
   const products = path(['data', 'productSearch', 'products'], searchQuery)
+  const redirect = path(['data', 'productSearch', 'redirect'], searchQuery)
 
   /* No need to show the spinner if it is loading because
    the LoadingOverlay already takes care of this */
-  if (showContentLoader === undefined || showContentLoader) {
+  if (showContentLoader === undefined || showContentLoader || redirect) {
     return null
   }
 

--- a/react/SearchResultLayout.js
+++ b/react/SearchResultLayout.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useChildBlock, ExtensionPoint } from 'vtex.render-runtime'
 import { useDevice } from 'vtex.device-detector'
-import { path, compose, equals, pathOr, isEmpty } from 'ramda'
+import { path, compose, equals, pathOr, isEmpty, isNil } from 'ramda'
 
 import OldSearchResult from './index'
 import { removeTreePath } from './utils/removeTreePath'
@@ -16,6 +16,11 @@ const isFtOnly = compose(
   path(['variables', 'map'])
 )
 
+const noRedirect = compose(
+  isNil,
+  path(['data', 'productSearch', 'redirect'])
+)
+
 const foundNothing = searchQuery => {
   const { loading } = searchQuery || {}
   return isFtOnly(searchQuery) && !loading && noProducts(searchQuery)
@@ -27,7 +32,11 @@ const SearchResultLayout = props => {
   const hasCustomNotFound = !!useChildBlock({ id: 'search-not-found-layout' })
   const { isMobile } = useDevice()
 
-  if (foundNothing(searchQuery) && hasCustomNotFound) {
+  if (
+    foundNothing(searchQuery) &&
+    hasCustomNotFound &&
+    noRedirect(searchQuery)
+  ) {
     return <ExtensionPoint id="search-not-found-layout" {...removeTreePath(props)} />
   }
 

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -1,5 +1,6 @@
-import { useMemo, useRef, useCallback } from 'react'
+import { useMemo, useRef, useCallback, useEffect } from 'react'
 import { useQuery } from 'react-apollo'
+import { path } from 'ramda'
 
 import productSearchQuery from 'vtex.store-resources/QueryProductSearchV3'
 import searchMetadataQuery from 'vtex.store-resources/QuerySearchMetadataV2'
@@ -10,7 +11,7 @@ import {
   detachFiltersByType,
   buildQueryArgsFromSelectedFacets,
 } from '../utils/compatibilityLayer'
-import { path } from 'ramda'
+import useRedirect from '../hooks/useRedirect'
 
 const DEFAULT_PAGE = 1
 
@@ -188,8 +189,13 @@ const useQueries = (variables, facetsArgs) => {
     selectedFacetsOutput &&
     buildQueryArgsFromSelectedFacets(selectedFacetsOutput)
 
+  const redirect = path(
+    ['data', 'productSearch', 'redirect'],
+    productSearchResult
+  )
+
   return {
-    loading: searchLoading,
+    loading: searchLoading || redirect,
     facetsLoading,
     data: {
       productSearch:
@@ -239,6 +245,7 @@ const SearchQuery = ({
     searchStateQuery,
     shouldReset
   )
+  const { setRedirect } = useRedirect()
 
   const from = (page - 1) * maxItemsPerPage
   const to = from + maxItemsPerPage - 1
@@ -303,6 +310,12 @@ const SearchQuery = ({
     productSearchResult,
     facetsLoading,
   } = useQueries(variables, facetsArgs)
+
+  const redirectUrl = path(['productSearch', 'redirect'], data)
+
+  useEffect(() => {
+    setRedirect(redirectUrl)
+  }, [redirectUrl, setRedirect])
 
   const extraParams = useMemo(() => {
     return {

--- a/react/hooks/useRedirect.js
+++ b/react/hooks/useRedirect.js
@@ -1,0 +1,37 @@
+import { useRuntime } from 'vtex.render-runtime'
+import { useState, useEffect } from 'react'
+
+const useRedirect = () => {
+  const { navigate } = useRuntime()
+
+  const setRedirect = redirect => {
+    if (!redirect) {
+      return
+    }
+
+    const urlRegex = /((http(s)?:)?\/\/|www\.)/
+
+    if (!urlRegex.test(redirect)) {
+      navigate({
+        to: redirect,
+      })
+
+      return
+    }
+
+    const originRedirect = redirect.replace(urlRegex, '')
+    const origin = window.location.origin.replace(/(http(s)?:)?\/\//, '')
+
+    if (originRedirect.startsWith(origin)) {
+      navigate({
+        to: originRedirect.replace(origin, ''),
+      })
+    } else {
+      window.location.replace(redirect.replace(/www\./, 'http://'))
+    }
+  }
+
+  return { setRedirect }
+}
+
+export default useRedirect


### PR DESCRIPTION
#### What is the purpose of this pull request?

The new search provides a redirect feature based on the search query. For example, you can set a redirect when some user searches for the word `green` or select `green` as a filter.

![image](https://user-images.githubusercontent.com/40380674/84951422-c991a500-b0c6-11ea-989c-a99ecb2bb38a.png)

But our APIs are not integrated with the client-side yet.

#### What problem is this solving?

This PR makes the redirect possible by getting the redirect URL info from the `productSearch` query and redirecting the user on the client-side.

#### How should this be manually tested?
[workspace](https://searchredirect--storecomponents.myvtex.com/)
Search for `about` and you will be redirected to the about-us page

You can add new redirects [here](https://searchredirect--storecomponents.myvtex.com/admin/search/redirects/) if you want to.

#### Screenshots or example usage

![LNdJRGwzhx](https://user-images.githubusercontent.com/40380674/84953103-4d4c9100-b0c9-11ea-83fa-1bdcfcf8a2b8.gif)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
