### PR TITLE
Fixing default layout types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fixing check if layout prop is set to mobile, however it will be 
+always false. Probably causing troubles setting `mobileLayout` value
 
 ## [3.60.6] - 2020-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Fixing check if layout prop is set to mobile, however it will be 
-always false. Probably causing troubles setting `mobileLayout` value
+### Fixed
+- Consider passing `mobile` for prop `layout` on `filter-navigator.v3`.
 
 ## [3.60.6] - 2020-06-16
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -279,7 +279,7 @@ Check out the [**Product Summary documentation**](https://vtex.io/docs/component
 
 | Prop name | Type                      | Description                                                                                       | Default value |
 | --------- | ------------------------- | ------------------------------------------------------------------------------------------------- | ------------- |
-| `layout`  | `Enum` | Whether the Filter Navigator layout should be responsive (`responsive`), mobile (`mobile`) or desktop (`desktop`). You may use `desktop` when the Filter Navigator was configured to be displayed in a [drawer](https://vtex.io/docs/components/content-blocks/vtex.store-drawer@0.9.0). | `responsive`  |
+| `layout`  | `enum` | Whether the Filter Navigator layout is designed to work with mobile devices (`mobile`), desktop (`desktop`), or if it should adapt itself to work with both - mobile and desktop (`responsive`). You may use `desktop` when the Filter Navigator was already configured to be displayed in a [drawer](https://vtex.io/docs/components/content-blocks/vtex.store-drawer). | `responsive`  |
 | `maxItemsDepartment` | `number`                 | Maximum number of departments to be displayed before the See More button is triggered.          | `8`             |
 | `maxItemsCategory`   | `number`                 | Maximum number of category items to be displayed before the See More button is triggered.     | `8`             |
 | `initiallyCollapsed` | `Boolean` | Makes the search filters start out collapsed (`true`) or open (`false`). | `false` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -279,7 +279,7 @@ Check out the [**Product Summary documentation**](https://vtex.io/docs/component
 
 | Prop name | Type                      | Description                                                                                       | Default value |
 | --------- | ------------------------- | ------------------------------------------------------------------------------------------------- | ------------- |
-| `layout`  | `Enum` | Whether the Filter Navigator layout should be responsive (`responsive`) or not (`desktop`). You may use `desktop` when the Filter Navigator was configured to be displayed in a [drawer](https://vtex.io/docs/components/content-blocks/vtex.store-drawer@0.9.0). | `responsive`  |
+| `layout`  | `Enum` | Whether the Filter Navigator layout should be responsive (`responsive`), mobile (`mobile`) or desktop (`desktop`). You may use `desktop` when the Filter Navigator was configured to be displayed in a [drawer](https://vtex.io/docs/components/content-blocks/vtex.store-drawer@0.9.0). | `responsive`  |
 | `maxItemsDepartment` | `number`                 | Maximum number of departments to be displayed before the See More button is triggered.          | `8`             |
 | `maxItemsCategory`   | `number`                 | Maximum number of category items to be displayed before the See More button is triggered.     | `8`             |
 | `initiallyCollapsed` | `Boolean` | Makes the search filters start out collapsed (`true`) or open (`false`). | `false` |

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -33,7 +33,7 @@ const CSS_HANDLES = [
 const LAYOUT_TYPES = {
   responsive: 'responsive',
   desktop: 'desktop',
-  mobile: 'mobile'
+  mobile: 'mobile',
 }
 
 const getSelectedCategories = tree => {

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -33,6 +33,7 @@ const CSS_HANDLES = [
 const LAYOUT_TYPES = {
   responsive: 'responsive',
   desktop: 'desktop',
+  mobile: 'mobile'
 }
 
 const getSelectedCategories = tree => {


### PR DESCRIPTION
#### What problem is this solving?
Fixing check if layout prop is set to mobile, however it will be always false. Probably causing troubles setting `mobileLayout` value

<!--- What is the motivation and context for this change? -->

#### How to test it?
Just search for `mobileLayout` value attribution to see that is checking if `layout` is equals to mobile on `LAYOUT_TYPES`. But there is no 'mobile' value on `LAYOUT_TYPES`.
