### PR TITLE
Fixed "clear" button on FT searches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed "Clear" button on FT searches.
 
-## [3.62.0] - 2020-06-22
+## [3.62.0] - 2020-06-22 [YANKED]
 ### Changed
 - "Clear" button on mobile filters to uncheck every brand and specification filter.
 

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -18,8 +18,8 @@ import { buildNewQueryMap } from '../hooks/useFacetNavigation'
 import styles from '../searchResult.css'
 import { getFullText } from '../utils/compatibilityLayer'
 import {
-  isCategoryDepartmentOrCollection,
-  filterCategoryDepartmentAndCollection,
+  isCategoryDepartmentCollectionOrFT,
+  filterCategoryDepartmentCollectionAndFT,
 } from '../utils/queryAndMapUtils'
 
 const CSS_HANDLES = [
@@ -84,12 +84,12 @@ const FilterSidebar = ({
     shouldClear.current = true
     // Gets the previously selected facets that should be cleared
     const selectedFacets = selectedFilters.filter(
-      facet => !isCategoryDepartmentOrCollection(facet.key) && facet.selected
+      facet => !isCategoryDepartmentCollectionOrFT(facet.key) && facet.selected
     )
 
     // Should not clear categories, departments and clusterIds
     const selectedRest = filterOperations.filter(facet =>
-      isCategoryDepartmentOrCollection(facet.key)
+      isCategoryDepartmentCollectionOrFT(facet.key)
     )
 
     setFilterOperations([...selectedFacets, ...selectedRest])
@@ -127,7 +127,7 @@ const FilterSidebar = ({
     are important to show the correct facets. */
     if (shouldClear.current) {
       shouldClear.current = false
-      return filterCategoryDepartmentAndCollection(filterContext)
+      return filterCategoryDepartmentCollectionAndFT(filterContext)
     }
 
     /* The spread on selectedFilters was necessary because buildNewQueryMap

--- a/react/utils/queryAndMapUtils.ts
+++ b/react/utils/queryAndMapUtils.ts
@@ -5,37 +5,44 @@ import {
   PATH_SEPARATOR,
   MAP_VALUES_SEP,
   PRODUCT_CLUSTER_IDS,
+  FULLTEXT_QUERY_KEY,
 } from '../constants'
 
-const CATEGORY_DEPARTMENTS_CLUSTER_ID = [
+const CATEGORY_DEPARTMENTS_CLUSTER_ID_FT = [
   MAP_CATEGORY_CHAR,
   PRODUCT_CLUSTER_IDS,
   CATEGORY,
   DEPARTMENT,
+  FULLTEXT_QUERY_KEY,
 ]
 
-const CATEGORY_DEPARTMENTS = [MAP_CATEGORY_CHAR, CATEGORY, DEPARTMENT]
+const CATEGORY_DEPARTMENTS_FT = [
+  MAP_CATEGORY_CHAR,
+  CATEGORY,
+  DEPARTMENT,
+  FULLTEXT_QUERY_KEY,
+]
 
 /* With the addition of the new VTEX search, it is possible to have different maps.
   This function checks the equivalent possibilities for the 'c' map */
 export const isSameMap = (map1: string, map2: string) => {
-  if (CATEGORY_DEPARTMENTS.includes(map1)) {
-    return CATEGORY_DEPARTMENTS.includes(map2)
+  if (CATEGORY_DEPARTMENTS_FT.includes(map1)) {
+    return CATEGORY_DEPARTMENTS_FT.includes(map2)
   }
   return map1 === map2
 }
 
-export const isCategoryDepartmentOrCollection = (term: string) => {
-  return CATEGORY_DEPARTMENTS_CLUSTER_ID.includes(term)
+export const isCategoryDepartmentCollectionOrFT = (term: string) => {
+  return CATEGORY_DEPARTMENTS_CLUSTER_ID_FT.includes(term)
 }
 
-export const filterCategoryDepartmentAndCollection = context => {
+export const filterCategoryDepartmentCollectionAndFT = context => {
   const query = context.query.split(PATH_SEPARATOR)
   const map = context.map.split(MAP_VALUES_SEP)
   const newQuery = []
   const newMap = []
   for (let i = 0; i < map.length; i++) {
-    if (isCategoryDepartmentOrCollection(map[i])) {
+    if (isCategoryDepartmentCollectionOrFT(map[i])) {
       newQuery.push(query[i])
       newMap.push(map[i])
     }


### PR DESCRIPTION
#### What problem is this solving?

When clicking on the "clear" button on an FT page on mobile, the options would disappear.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://iaronaraujo--worldwidegolf.myvtex.com/ball?_q=ball&map=ft)


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
