### PR TITLE
Feature/new extensions search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Fixed
-- Search Progress bar and Count Per Page components in "search-result"
+### Added
+- Be able to use `search-products-progress-bar` in `search-result`
 
 ## [3.62.2] - 2020-06-23
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Search Progress bar and Count Per Page components in "search-result"
 
 ## [3.62.2] - 2020-06-23
 ### Fixed

--- a/react/ProductsProgressBar.js
+++ b/react/ProductsProgressBar.js
@@ -5,8 +5,12 @@ import { useCssHandles } from 'vtex.css-handles'
 
 const CSS_HANDLES = ['progressBarContainer', 'progressBar', 'progressBarFiller']
 
-const ProductsProgressBar = () => {
+const ProductsProgressBar = ({
+  recordsFiltered: recordsFilteredProp,
+  products: productsProp,
+}) => {
   const { searchQuery } = useSearchPage()
+  let productsLoadedPercentage
 
   const handles = useCssHandles(CSS_HANDLES)
   const products =
@@ -16,10 +20,17 @@ const ProductsProgressBar = () => {
     searchQuery
   )
 
-  const productsLoadedPercentage = Math.round(
-    (100 * products.length) / recordsFiltered
-  )
-  if (products.length === 0) {
+  if (!recordsFiltered || !products.length) {
+    productsLoadedPercentage = Math.round(
+      (100 * productsProp.length) / recordsFilteredProp
+    )
+  } else {
+    productsLoadedPercentage = Math.round(
+      (100 * products.length) / recordsFiltered
+    )
+  }
+
+  if (products.length === 0 && productsProp.length === 0) {
     return null
   }
 

--- a/react/ProductsProgressBar.js
+++ b/react/ProductsProgressBar.js
@@ -5,32 +5,22 @@ import { useCssHandles } from 'vtex.css-handles'
 
 const CSS_HANDLES = ['progressBarContainer', 'progressBar', 'progressBarFiller']
 
-const ProductsProgressBar = ({
-  recordsFiltered: recordsFilteredProp,
-  products: productsProp,
-}) => {
+const ProductsProgressBar = props => {
   const { searchQuery } = useSearchPage()
-  let productsLoadedPercentage
-
   const handles = useCssHandles(CSS_HANDLES)
   const products =
-    path(['data', 'productSearch', 'products'], searchQuery) || []
-  const recordsFiltered = path(
-    ['data', 'productSearch', 'recordsFiltered'],
-    searchQuery
+    path(['data', 'productSearch', 'products'], searchQuery) ||
+    props.products ||
+    []
+  const recordsFiltered =
+    path(['data', 'productSearch', 'recordsFiltered'], searchQuery) ||
+    props.recordsFiltered ||
+    0
+
+  const productsLoadedPercentage = Math.round(
+    (100 * products.length) / recordsFiltered
   )
-
-  if (!recordsFiltered || !products.length) {
-    productsLoadedPercentage = Math.round(
-      (100 * productsProp.length) / recordsFilteredProp
-    )
-  } else {
-    productsLoadedPercentage = Math.round(
-      (100 * products.length) / recordsFiltered
-    )
-  }
-
-  if (products.length === 0 && productsProp.length === 0) {
+  if (products.length === 0) {
     return null
   }
 

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -251,8 +251,11 @@ class SearchResult extends Component {
                   loading={fetchMoreLoading}
                   showProductsCount={showProductsCount}
                 />
-                <ExtensionPoint id="search-products-count-per-page" />
-                <ExtensionPoint id="search-products-progress-bar" />
+                <ExtensionPoint
+                  id="search-products-progress-bar"
+                  recordsFiltered={recordsFiltered}
+                  products={products}
+                />
               </>
             ) : (
               <LoadingSpinner loading={fetchMoreLoading} />

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -242,14 +242,18 @@ class SearchResult extends Component {
               </div>
             )}
             {pagination === PAGINATION_TYPE.SHOW_MORE || infiniteScrollError ? (
-              <FetchMoreButton
-                products={products}
-                to={to}
-                recordsFiltered={recordsFiltered}
-                onFetchMore={onFetchMore}
-                loading={fetchMoreLoading}
-                showProductsCount={showProductsCount}
-              />
+              <>
+                <FetchMoreButton
+                  products={products}
+                  to={to}
+                  recordsFiltered={recordsFiltered}
+                  onFetchMore={onFetchMore}
+                  loading={fetchMoreLoading}
+                  showProductsCount={showProductsCount}
+                />
+                <ExtensionPoint id="search-products-count-per-page" />
+                <ExtensionPoint id="search-products-progress-bar" />
+              </>
             ) : (
               <LoadingSpinner loading={fetchMoreLoading} />
             )}

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -8,7 +8,6 @@
       "order-by",
       "search-title",
       "rich-text",
-      "search-products-count-per-page",
       "search-products-progress-bar"
     ],
     "required": ["gallery"],

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -7,7 +7,9 @@
       "total-products",
       "order-by",
       "search-title",
-      "rich-text"
+      "rich-text",
+      "search-products-count-per-page",
+      "search-products-progress-bar"
     ],
     "required": ["gallery"],
     "component": "index"


### PR DESCRIPTION
#### What problem is this solving?
Be able to use `search-products-progress-bar` in the block `search-result`.

Change the `search-result` block to `search-result-layout` is not viable to the client, so I created this PR to be able to use this block. As we talked on Office Hours. 
 
#### How to test it?
[progress](https://progress--lionspride.myvtex.com/womens/500/dept)

#### Describe alternatives you've considered, if any.

Would be great if was possible to change for the `search-result-layout` without losing all the changes on site editor 


#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/l0NwNrl4BtDD7JCx2/giphy.gif)
