### PR TITLE
SearchTitle Fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed `SearchTitle` be able to parse HTML special characters;
 
 ## [3.63.0] - 2020-06-29
 ### Added

--- a/react/SearchTitle.js
+++ b/react/SearchTitle.js
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import React, { useContext, useMemo } from 'react'
+import React, { useEffect, useState, useContext, useMemo } from 'react'
 import {
   compose,
   equals,
@@ -59,15 +59,17 @@ const SearchTitle = ({
     return null
   }
 
-  const stripHtml = html => {
+  const [ParseTitle, setTitle] = useState('')
+
+  useEffect(() => {
     const tmp = document.createElement('DIV')
-    tmp.innerHTML = html
-    return tmp.textContent || tmp.innerText || ''
-  }
+    tmp.innerHTML = title
+    setTitle(tmp.textContent || tmp.innerText || '')
+  }, [title])
 
   return (
     <h1 className={classNames(wrapperClass, 't-heading-1')}>
-      {stripHtml(decodeURI(title))}
+      {decodeURI(ParseTitle)}
     </h1>
   )
 }

--- a/react/SearchTitle.js
+++ b/react/SearchTitle.js
@@ -19,14 +19,8 @@ import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
 const findFT = findIndex(equals('ft'))
 const findProductCluster = findIndex(equals('productClusterIds'))
 const findLastCategory = findLastIndex(equals('c'))
-const isBrandPage = compose(
-  equals('b'),
-  head
-)
-const getLastName = compose(
-  prop('name'),
-  last
-)
+const isBrandPage = compose(equals('b'), head)
+const getLastName = compose(prop('name'), last)
 const breadcrumbName = (index, breadcrumb) => path([index, 'name'], breadcrumb)
 
 const getQueryNameIndex = mapArray => {
@@ -65,9 +59,15 @@ const SearchTitle = ({
     return null
   }
 
+  const stripHtml = html => {
+    const tmp = document.createElement('DIV')
+    tmp.innerHTML = html
+    return tmp.textContent || tmp.innerText || ''
+  }
+
   return (
     <h1 className={classNames(wrapperClass, 't-heading-1')}>
-      {decodeURI(title)}
+      {stripHtml(decodeURI(title))}
     </h1>
   )
 }


### PR DESCRIPTION
#### What problem is this solving?

The Search Title on category pages was not rendering special characters.

The bug on search title here: https://www.bitofbritain.com/140/men-s?fuzzy=0&map=productClusterIds,department-&operator=and

is showing this: "Men&Apos;S"

the correct is: "Men`s"

#### How to test it?

[Workspace](https://title--bitofbritain.myvtex.com/140/men-s?fuzzy=0&map=productClusterIds,department-&operator=and)

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/SnM6oxhwCISic/giphy.gif)
