### PR TITLE
add facets breadcrumb as fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- `SearchResult` doesn't use the `facets` breadcrumb as fallback.
+
 ## [3.63.0] - 2020-06-29
 ### Added
 - Be able to use `search-products-progress-bar` in `search-result`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
-- `SearchResult` doesn't use the `facets` breadcrumb as fallback.
+- `SearchResult` use the `facets` breadcrumb as fallback.
 
 ## [3.63.0] - 2020-06-29
 ### Added

--- a/react/components/SearchResultContainer.js
+++ b/react/components/SearchResultContainer.js
@@ -24,8 +24,13 @@ const SearchResultContainer = props => {
           specificationFilters = [],
           priceRanges = [],
           categoriesTrees,
+          breadcrumb: facetsBreadcrumb = [],
         } = {},
-        productSearch: { products = [], recordsFiltered, breadcrumb = [] } = {},
+        productSearch: {
+          products = [],
+          recordsFiltered,
+          breadcrumb: productBreadcrumb = [],
+        } = {},
       } = {},
       loading,
       variables: { query, map, orderBy, priceRange },
@@ -57,6 +62,8 @@ const SearchResultContainer = props => {
     queryData,
   })
   const handles = useCssHandles(CSS_HANDLES)
+
+  const breadcrumb = productBreadcrumb || facetsBreadcrumb
 
   const resultComponent = children || (
     <SearchResult


### PR DESCRIPTION
#### What problem is this solving?

The breadcrumb has two different origins: the `productSearch` query, and the `facets` query. Each search-engine decides how to implement it.
The problem is that the `SearchResult` is not considering the `facets` breadcrumb as a fallback.

#### How to test it?

[Workspace](https://hiago--redoxx.myvtex.com/bags/duffel?map=c,specificationFilter_818&page=1)

#### Screenshots or example usage:

Before
![image](https://user-images.githubusercontent.com/40380674/86170607-c26c8d00-baf1-11ea-95f5-f576a33098bc.png)

After
![image](https://user-images.githubusercontent.com/40380674/86170695-e8922d00-baf1-11ea-96f0-12dfb8cdbd2d.png)


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/4gFLidmCmJFK0/giphy.gif)