### PR TITLE
add validation when pushing the collection to the mapSegment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Fixed
-- `Pricerange` event was not adding `fuzzy`, `operator` and `searchState` to the URL.
-- `fuzzy`, `operator` and `searchState` were being reset in any search interaction.
-
 ### Added
 - `SearchResult` now adds `fuzzy`, `operator` and `searchState` to the URL.
+
+### Fixed
+- Deal with the `productClusterIds` differences caused by `search-resolver0.x` and `search-resolver1.x`.
+- `Pricerange` event was not adding `fuzzy`, `operator` and `searchState` to the URL.
+- `fuzzy`, `operator` and `searchState` were being reset in any search interaction.
 
 ## [3.63.2] - 2020-07-08
 

--- a/react/hooks/useFacetNavigation.js
+++ b/react/hooks/useFacetNavigation.js
@@ -165,7 +165,9 @@ export const buildNewQueryMap = (
     mapSegments.push(FULLTEXT_QUERY_KEY)
   }
 
-  if (collection) {
+  // In search-resolver@v1.x, the productClusterIds is sent as a hidden facet, but in 0.x it is not.
+  // This way, we only need to push the collection when it is not in the mapSegments.
+  if (collection && mapSegments.indexOf(PRODUCT_CLUSTER_IDS) === -1) {
     querySegments.push(collection)
     mapSegments.push(PRODUCT_CLUSTER_IDS)
   }


### PR DESCRIPTION
#### What problem is this solving?

TLDR: `search-resolver@1.x` and  `search-resolver@0.x` deals with `productClusterIds` in different ways; this PR makes sure that both methods will work.

In this [workspace](https://hiago2--columbiacl.myvtex.com/158?fuzzy=0&map=productClusterIds&operator=and), when you click in a filter option, the `productClusterIds` is being duplicated in the URL.
This is happening because the `search-resolver@1.x` sends the `productClusterIds ` as a hidden facet, but the `search-resolver@0.x` does not.

While in search-resolver@1.x the URL was being built properly, in search-resolver@0.x this [PR](https://github.com/vtex-apps/search-result/pull/379) was needed to achieve the correctness. This last PR introduced an ambiguity, and now there are two ways to add the `productClusterIds` in the URL. That's why it is being duplicated. The purpose of this PR is to remove this ambiguity.

#### How to test it?

[Workspace](https://hiago--columbiacl.myvtex.com/158?fuzzy=0&map=productClusterIds&operator=and)
