### PR TITLE
remove fuzzy, operator and searchstate from handleFetchMoreNext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Temporarily remove `fuzzy`, `operator` and `searchState` from `handleFetchMoreNext` and `handleFetchMorePrevious`. They are causing a bug where the pagination is being reset.
+
 ## [3.65.0] - 2020-07-13
 ### Added
 - New CSS handles on `order-by` selected item.

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -171,7 +171,7 @@ const useQueries = (variables, facetsArgs) => {
 
   const refetch = useCombinedRefetch(searchRefetch, facetsRefetch)
 
-  const detatachedFilters =
+  const detachedFilters =
     facets && facets.facets
       ? detachFiltersByType(facets.facets)
       : {
@@ -198,7 +198,7 @@ const useQueries = (variables, facetsArgs) => {
       productSearch:
         productSearchResult.data && productSearchResult.data.productSearch,
       facets: {
-        ...detatachedFilters,
+        ...detachedFilters,
         queryArgs,
         breadcrumb: facets && facets.breadcrumb,
       },

--- a/react/hooks/useFetchMore.js
+++ b/react/hooks/useFetchMore.js
@@ -185,9 +185,6 @@ export const useFetchMore = props => {
     setQuery(
       {
         page: pageState.nextPage,
-        fuzzy: fuzzy || undefined,
-        operator: operator || undefined,
-        searchState: searchState || undefined,
       },
       { replace: true }
     )
@@ -224,9 +221,6 @@ export const useFetchMore = props => {
     setQuery(
       {
         page: pageState.previousPage,
-        fuzzy: fuzzy || undefined,
-        operator: operator || undefined,
-        searchState: searchState || undefined,
       },
       { replace: true, merge: true }
     )


### PR DESCRIPTION
#### What problem is this solving?

When the user clicks on the See More/Previous button, we add some query strings related to the search state(`fuzzy`, `operator` and `searchState`). The problem is that those query strings are forcing the page to reset.

You can check it by going to the [alssports](https://www.als.com/north%20face?map=ft) and clicking on the see more button. The oops page will show up, and then the page number will be `1` instead of `2`. 

We already know how to solve it correctly, but it will take some time. I'm removing those queries for now just to solve this problem ASAP. Those queries are not very critical for search performance.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://hiago--alssports.myvtex.com/north%20face?map=ft)
