### PR TITLE
add validation to reset search variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Bug where the search is reset to the first page when `fetchMore` sets `fuzzy`, `operator` and `searchState`.
+
 ## [3.65.1] - 2020-07-13
 
 ### Fixed

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -121,20 +121,35 @@ const useCorrectSearchStateVariables = (
   fuzzy,
   operator,
   searchState,
-  fullText
+  fullText,
+  shouldReset
 ) => {
+  const variablesRef = useRef({
+    fuzzy,
+    operator,
+    searchState,
+  })
   const fullTextRef = useRef(fullText)
-  const shouldReset = isCurrentDifferent(fullTextRef, fullText)
 
-  const result = {
-    fuzzy: shouldReset ? undefined : fuzzy,
-    operator: shouldReset ? undefined : operator,
-    searchState: shouldReset ? undefined : searchState,
+  if (shouldReset) {
+    variablesRef.current = {
+      fuzzy,
+      operator,
+      searchState,
+    }
   }
 
-  fullTextRef.current = fullText
+  if (isCurrentDifferent(fullTextRef, fullText)) {
+    variablesRef.current = {
+      fuzzy: undefined,
+      operator: undefined,
+      searchState: undefined,
+    }
 
-  return result
+    fullTextRef.current = fullText
+  }
+
+  return variablesRef.current
 }
 
 const useQueries = (variables, facetsArgs) => {
@@ -246,7 +261,8 @@ const SearchQuery = ({
     fuzzyQuery,
     operatorQuery,
     searchStateQuery,
-    fullText
+    fullText,
+    shouldReset
   )
   const { setRedirect } = useRedirect()
 

--- a/react/hooks/useFetchMore.js
+++ b/react/hooks/useFetchMore.js
@@ -1,5 +1,5 @@
 import { useState, useRef, useCallback, useEffect, useReducer } from 'react'
-import { min, max } from 'ramda'
+import { max } from 'ramda'
 import { useRuntime } from 'vtex.render-runtime'
 import {
   useSearchPageStateDispatch,
@@ -143,7 +143,6 @@ const useFetchingMore = () => {
 export const useFetchMore = props => {
   const {
     page,
-    recordsFiltered,
     maxItemsPerPage,
     fetchMore,
     products,
@@ -185,6 +184,9 @@ export const useFetchMore = props => {
     setQuery(
       {
         page: pageState.nextPage,
+        fuzzy: fuzzy || undefined,
+        operator: operator || undefined,
+        searchState: searchState || undefined,
       },
       { replace: true }
     )
@@ -221,6 +223,9 @@ export const useFetchMore = props => {
     setQuery(
       {
         page: pageState.previousPage,
+        fuzzy: fuzzy || undefined,
+        operator: operator || undefined,
+        searchState: searchState || undefined,
       },
       { replace: true, merge: true }
     )


### PR DESCRIPTION
#### What problem is this solving?

When the `fetchmore` sets the query string `fuzzy`, `operator`, and `searchState` the search query is being reset to the initial page. You can check it [here](https://hiago2--alssports.myvtex.com/north%20face?map=ft) by clicking in the show more button.

![5AuMIFx42S](https://user-images.githubusercontent.com/40380674/87469163-3b3f0f00-c5f1-11ea-91f4-df9f0e3e2881.gif)

This is happening because the [variables `useMemo`](https://github.com/vtex-apps/search-result/blob/master/react/components/SearchQuery.js#L262) is being reset and, consequently, the search will be reset as well.

This PR fixes this problem by changing the `useCorrectSearchStateVariables` to have the following behavior:
- On the first page load, the query will use the variables set in URL.
- On facet selection and orderBy selection, the variables will be undefined.
- On fetchMore, the variables will be the same as the beginning.

#### How to test it?

[Workspace](https://hiago--alssports.myvtex.com/north%20face?map=ft)
