### PR TITLE
remove searchStateProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+- `SearchPageStateContext.Provider`/`SearchPageStateDispatch.Provider` from `SearchResultFlexible`.
+
 ## [3.65.1] - 2020-07-13
 
 ### Fixed

--- a/react/SearchResultFlexible.js
+++ b/react/SearchResultFlexible.js
@@ -3,9 +3,8 @@ import ContextProviders from './components/ContextProviders'
 import SearchResultContainer from './components/SearchResultContainer'
 import {
   SearchPageContext,
-  SearchPageStateContext,
-  SearchPageStateDispatch,
-  useSearchPageStateReducer,
+  useSearchPageState,
+  useSearchPageStateDispatch,
 } from 'vtex.search-page-context/SearchPageContext'
 import { useCssHandles } from 'vtex.css-handles'
 
@@ -59,6 +58,27 @@ const SearchResultFlexible = ({
   facetsLoading,
   trackingId,
 }) => {
+  const {
+    mobileLayout: mobileLayoutState,
+    showContentLoader: showContentLoaderState,
+    isFetchingMore: isFetchingMoreState,
+  } = useSearchPageState()
+  const dispatch = useSearchPageStateDispatch()
+
+  if (typeof mobileLayoutState === 'undefined') {
+    dispatch({
+      type: 'SWITCH_LAYOUT',
+      args: { mobileLayout: mobileLayout.mode1 },
+    })
+  }
+
+  if (typeof showContentLoaderState === 'undefined') {
+    dispatch({
+      type: 'SET_CONTENT_LOADER',
+      args: { showContentLoader: searchQuery.loading },
+    })
+  }
+
   //This makes infinite scroll unavailable.
   //Infinite scroll was deprecated and we have
   //removed it since the flexible search release
@@ -91,10 +111,6 @@ const SearchResultFlexible = ({
     categoriesTrees &&
     categoriesTrees.length > 0
   const showFacets = showCategories || (!hideFacets && !isEmpty(filters))
-  const [state, dispatch] = useSearchPageStateReducer({
-    mobileLayout: mobileLayout.mode1,
-    showContentLoader: searchQuery.loading,
-  })
 
   useShowContentLoader(searchQuery, dispatch)
 
@@ -146,46 +162,42 @@ const SearchResultFlexible = ({
     ]
   )
 
-  const showLoading = searchQuery.loading && !state.isFetchingMore
+  const showLoading = searchQuery.loading && !isFetchingMoreState
   return (
     <SearchPageContext.Provider value={context}>
-      <SearchPageStateContext.Provider value={state}>
-        <SearchPageStateDispatch.Provider value={dispatch}>
-          <ContextProviders
-            queryVariables={searchQuery.variables}
-            settings={settings}
-          >
-            <SearchResultContainer
-              searchQuery={searchQuery}
-              maxItemsPerPage={maxItemsPerPage}
-              pagination={pagination}
-              mobileLayout={mobileLayout}
-              map={map}
-              params={params}
-              priceRange={priceRange}
-              hiddenFacets={hiddenFacets}
-              orderBy={orderBy}
-              page={page}
-              facetsLoading={facetsLoading}
-            >
-              {
-                <LoadingOverlay loading={showLoading}>
-                  <div
-                    className={`${
-                      handles.loadingOverlay
-                    } flex flex-column flex-grow-1 ${generateBlockClass(
-                      styles['container--layout'],
-                      blockClass
-                    )}`}
-                  >
-                    {children}
-                  </div>
-                </LoadingOverlay>
-              }
-            </SearchResultContainer>
-          </ContextProviders>
-        </SearchPageStateDispatch.Provider>
-      </SearchPageStateContext.Provider>
+      <ContextProviders
+        queryVariables={searchQuery.variables}
+        settings={settings}
+      >
+        <SearchResultContainer
+          searchQuery={searchQuery}
+          maxItemsPerPage={maxItemsPerPage}
+          pagination={pagination}
+          mobileLayout={mobileLayout}
+          map={map}
+          params={params}
+          priceRange={priceRange}
+          hiddenFacets={hiddenFacets}
+          orderBy={orderBy}
+          page={page}
+          facetsLoading={facetsLoading}
+        >
+          {
+            <LoadingOverlay loading={showLoading}>
+              <div
+                className={`${
+                  handles.loadingOverlay
+                } flex flex-column flex-grow-1 ${generateBlockClass(
+                  styles['container--layout'],
+                  blockClass
+                )}`}
+              >
+                {children}
+              </div>
+            </LoadingOverlay>
+          }
+        </SearchResultContainer>
+      </ContextProviders>
     </SearchPageContext.Provider>
   )
 }


### PR DESCRIPTION
#### What problem is this solving?

The `mobileLayout`is being reset during the filter selection.

This is happening because when the page change from `store.search#department` to `store.search#category,` for example, the `SearchResultLayout` is remounted, and then, the current `LayoutModeSwitcher` state is lost.

To solve this, I changed the `SearchPageStateContext.Provider/SearchPageStateDispatch.Provider` position from `SearchResultFlexible` to the `SearchContext`.

#### How to test it?

[Workspace](https://newfilternavigator--storecomponents.myvtex.com/kawasaki/top?_q=top&map=b,ft)

#### Screenshots or example usage:

##### Before:
![BAbbpGZRfv](https://user-images.githubusercontent.com/40380674/87701170-e5dc3c80-c76d-11ea-8506-938f96aaf659.gif)

##### After
![KvskSzj0Yd](https://user-images.githubusercontent.com/40380674/87702846-52f0d180-c770-11ea-90ab-e7dedaa42cea.gif)

#### Related to / Depends on

##### Depends on ⚠️ 
- https://github.com/vtex-apps/store/pull/475
- https://github.com/vtex-apps/search-page-context/pull/6