### PR TITLE
change Checkbox id to avoid repetition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Deal with repeated filter options.
+
 ## [3.85.3] - 2020-11-13
 
 ### Fixed

--- a/react/components/FacetItem.js
+++ b/react/components/FacetItem.js
@@ -36,8 +36,8 @@ const FacetItem = ({
   )
 
   const checkBoxId = reservedVariableNames.includes(facet.value)
-    ? `filterItem--${facet.value}`
-    : facet.value
+    ? `filterItem--${facet.key}-${facet.value}`
+    : `${facet.key}-${facet.value}`
 
   // This effect fixes the issue described in this PR
   // https://github.com/vtex-apps/search-result/pull/422


### PR DESCRIPTION
#### What problem is this solving?

When there are two filter options with the same value, only the first one is selected.

Example:
There are two filter: `Ano fabircação` and `Ano modelo` 
Both of them have the `2018` as a value.
When you select `Ano modelo - 2018`, the `Ano fabricação - 2018` is selected instead.

![repeated](https://user-images.githubusercontent.com/40380674/88066637-5efbdb00-cb44-11ea-9cb0-87b533db673b.gif)


#### How to test it?

[Workspace](https://duplicatedvalues--storecomponents.myvtex.com/sedan?_q=sedan&map=ft)
