### PR TITLE
Feature/keep one filter opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- new prop `keepOneFilterOpened` to keep only one filter with opened state.
+
 ## [3.66.0] - 2020-07-15
 ### Added
 - New CSS handles for `galleryItem` with `displayMode`.

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -71,6 +71,7 @@ const FilterNavigator = ({
   layout = LAYOUT_TYPES.responsive,
   maxItemsDepartment = 8,
   maxItemsCategory = 8,
+  keepOneFilterOpened = false
 }) => {
   const { isMobile } = useDevice()
   const handles = useCssHandles(CSS_HANDLES)
@@ -144,43 +145,44 @@ const FilterNavigator = ({
           </div>
         </div>
       ) : (
-        <Fragment>
-          <div className={`${filterClasses} ${handles.filtersWrapper}`}>
-            <div
-              className={`${applyModifiers(
-                handles.filter__container,
-                'title'
-              )} bb b--muted-4`}
-            >
-              <h5 className={`${handles.filterMessage} t-heading-5 mv5`}>
-                <FormattedMessage id="store/search-result.filter-button.title" />
-              </h5>
+          <Fragment>
+            <div className={`${filterClasses} ${handles.filtersWrapper}`}>
+              <div
+                className={`${applyModifiers(
+                  handles.filter__container,
+                  'title'
+                )} bb b--muted-4`}
+              >
+                <h5 className={`${handles.filterMessage} t-heading-5 mv5`}>
+                  <FormattedMessage id="store/search-result.filter-button.title" />
+                </h5>
+              </div>
+              <SelectedFilters
+                filters={selectedFilters}
+                preventRouteChange={preventRouteChange}
+                navigateToFacet={navigateToFacet}
+              />
+              <DepartmentFilters
+                title={CATEGORIES_TITLE}
+                tree={tree}
+                isVisible={!hiddenFacets.categories}
+                onCategorySelect={navigateToFacet}
+                preventRouteChange={preventRouteChange}
+                maxItemsDepartment={maxItemsDepartment}
+                maxItemsCategory={maxItemsCategory}
+              />
+              <AvailableFilters
+                filters={filters}
+                priceRange={priceRange}
+                preventRouteChange={preventRouteChange}
+                initiallyCollapsed={initiallyCollapsed}
+                navigateToFacet={navigateToFacet}
+                keepOneFilterOpened={keepOneFilterOpened}
+              />
             </div>
-            <SelectedFilters
-              filters={selectedFilters}
-              preventRouteChange={preventRouteChange}
-              navigateToFacet={navigateToFacet}
-            />
-            <DepartmentFilters
-              title={CATEGORIES_TITLE}
-              tree={tree}
-              isVisible={!hiddenFacets.categories}
-              onCategorySelect={navigateToFacet}
-              preventRouteChange={preventRouteChange}
-              maxItemsDepartment={maxItemsDepartment}
-              maxItemsCategory={maxItemsCategory}
-            />
-            <AvailableFilters
-              filters={filters}
-              priceRange={priceRange}
-              preventRouteChange={preventRouteChange}
-              initiallyCollapsed={initiallyCollapsed}
-              navigateToFacet={navigateToFacet}
-            />
-          </div>
-          <ExtensionPoint id="shop-review-summary" />
-        </Fragment>
-      )}
+            <ExtensionPoint id="shop-review-summary" />
+          </Fragment>
+        )}
     </Fragment>
   )
 }
@@ -207,6 +209,7 @@ FilterNavigator.propTypes = {
   loading: PropTypes.bool,
   layout: PropTypes.oneOf(Object.values(LAYOUT_TYPES)),
   initiallyCollapsed: PropTypes.bool,
+  keepOneFilterOpened: PropTypes.bool,
   ...hiddenFacetsSchema,
 }
 

--- a/react/FilterNavigatorFlexible.js
+++ b/react/FilterNavigatorFlexible.js
@@ -13,6 +13,7 @@ const withSearchPageContextProps = Component => ({
   initiallyCollapsed,
   maxItemsDepartment,
   maxItemsCategory,
+  keepOneFilterOpened,
 }) => {
   const {
     searchQuery,
@@ -44,7 +45,7 @@ const withSearchPageContextProps = Component => ({
     <div
       className={`${styles['filters--layout']} ${
         layout === 'desktop' && isMobile ? 'w-100 mh5' : ''
-      }`}
+        }`}
     >
       <FilterNavigatorContext.Provider value={queryArgs}>
         <Component
@@ -62,6 +63,7 @@ const withSearchPageContextProps = Component => ({
           initiallyCollapsed={initiallyCollapsed}
           maxItemsDepartment={maxItemsDepartment}
           maxItemsCategory={maxItemsCategory}
+          keepOneFilterOpened={keepOneFilterOpened}
         />
       </FilterNavigatorContext.Provider>
     </div>

--- a/react/components/AvailableFilters.js
+++ b/react/components/AvailableFilters.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 
 import SearchFilter from './SearchFilter'
@@ -10,8 +10,11 @@ const AvailableFilters = ({
   preventRouteChange = false,
   initiallyCollapsed = false,
   navigateToFacet,
-}) =>
-  filters.map(filter => {
+  keepOneFilterOpened = false,
+}) => {
+  const [open, setOpen] = useState({})
+
+  return filters.map(filter => {
     const { type, title, facets, oneSelectedCollapse = false } = filter
 
     switch (type) {
@@ -35,10 +38,14 @@ const AvailableFilters = ({
             preventRouteChange={preventRouteChange}
             initiallyCollapsed={initiallyCollapsed}
             navigateToFacet={navigateToFacet}
+            keepOneFilterOpened={keepOneFilterOpened}
+            open={open}
+            setOpen={setOpen}
           />
         )
     }
   })
+}
 
 AvailableFilters.propTypes = {
   /** Filters to be displayed */
@@ -54,6 +61,7 @@ AvailableFilters.propTypes = {
   /** Prevent route changes */
   preventRouteChange: PropTypes.bool,
   initiallyCollapsed: PropTypes.bool,
+  keepOneFilterOpened: PropTypes.bool
 }
 
 export default AvailableFilters

--- a/react/components/FilterOptionTemplateV2.js
+++ b/react/components/FilterOptionTemplateV2.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { useState, useCallback } from 'react'
+import React, { useState, useCallback, useEffect } from 'react'
 import { Collapse } from 'react-collapse'
 import classNames from 'classnames'
 
@@ -21,7 +21,7 @@ const CSS_HANDLES = [
 /**
  * Collapsable filters container
  */
-const FilterOptionTemplate = ({
+const FilterOptionTemplateV2 = ({
   id,
   selected = false,
   title,
@@ -29,8 +29,9 @@ const FilterOptionTemplate = ({
   children,
   filters,
   initiallyCollapsed = false,
+  open,
+  setOpen
 }) => {
-  const [open, setOpen] = useState(!initiallyCollapsed)
   const handles = useCssHandles(CSS_HANDLES)
 
   const renderChildren = () => {
@@ -41,11 +42,15 @@ const FilterOptionTemplate = ({
     return filters.map(children)
   }
 
+  const handleCollapse = () => {
+    setOpen(open === title ? null : title)
+  }
+
   const handleKeyDown = useCallback(
     e => {
       if (e.key === ' ' && collapsable) {
         e.preventDefault()
-        setOpen(!open)
+        handleCollapse()
       }
     },
     [collapsable, open]
@@ -77,7 +82,7 @@ const FilterOptionTemplate = ({
           role="button"
           tabIndex={collapsable ? 0 : undefined}
           className={collapsable ? 'pointer' : ''}
-          onClick={() => collapsable && setOpen(!open)}
+          onClick={() => collapsable && handleCollapse()}
           onKeyDown={handleKeyDown}
           aria-disabled={!collapsable}
         >
@@ -90,7 +95,7 @@ const FilterOptionTemplate = ({
                   'flex items-center ph5 c-muted-3'
                 )}
               >
-                <IconCaret orientation={open ? 'up' : 'down'} size={14} />
+                <IconCaret orientation={title === open ? 'up' : 'down'} size={14} />
               </span>
             )}
           </div>
@@ -105,7 +110,7 @@ const FilterOptionTemplate = ({
         aria-hidden={!open}
       >
         {collapsable ? (
-          <Collapse isOpened={open} theme={{ content: handles.filterContent }}>
+          <Collapse isOpened={title === open} theme={{ content: handles.filterContent }}>
             {renderChildren()}
           </Collapse>
         ) : (
@@ -116,7 +121,7 @@ const FilterOptionTemplate = ({
   )
 }
 
-FilterOptionTemplate.propTypes = {
+FilterOptionTemplateV2.propTypes = {
   /** Identifier to be used by CSS handles */
   id: PropTypes.string,
   /** Filters to be shown, if no filter is provided, treat the children as simple node */
@@ -132,4 +137,4 @@ FilterOptionTemplate.propTypes = {
   initiallyCollapsed: PropTypes.bool,
 }
 
-export default FilterOptionTemplate
+export default FilterOptionTemplateV2

--- a/react/components/SearchFilter.js
+++ b/react/components/SearchFilter.js
@@ -3,6 +3,7 @@ import React from 'react'
 import { injectIntl, intlShape } from 'react-intl'
 
 import FilterOptionTemplate from './FilterOptionTemplate'
+import FilterOptionTemplateV2 from './FilterOptionTemplateV2'
 import FacetItem from './FacetItem'
 import { facetOptionShape } from '../constants/propTypes'
 import { getFilterTitle } from '../constants/SearchHelpers'
@@ -16,10 +17,36 @@ const SearchFilter = ({
   intl,
   preventRouteChange = false,
   initiallyCollapsed = false,
+  keepOneFilterOpened = false,
   navigateToFacet,
+  open,
+  setOpen
 }) => {
   const sampleFacet = facets && facets.length > 0 ? facets[0] : null
   const facetTitle = getFilterTitle(title, intl)
+
+  if (keepOneFilterOpened) {
+    return (
+      <FilterOptionTemplateV2
+        id={sampleFacet ? sampleFacet.map : null}
+        title={facetTitle}
+        filters={facets}
+        initiallyCollapsed={initiallyCollapsed}
+        open={open}
+        setOpen={setOpen}
+      >
+        {facet => (
+          <FacetItem
+            key={facet.name}
+            facetTitle={facetTitle}
+            facet={facet}
+            preventRouteChange={preventRouteChange}
+            navigateToFacet={navigateToFacet}
+          />
+        )}
+      </FilterOptionTemplateV2>
+    )
+  }
 
   return (
     <FilterOptionTemplate
@@ -51,6 +78,7 @@ SearchFilter.propTypes = {
   /** Prevent route changes */
   preventRouteChange: PropTypes.bool,
   initiallyCollapsed: PropTypes.bool,
+  keepOneFilterOpened: PropTypes.bool,
   navigateToFacet: PropTypes.func,
 }
 


### PR DESCRIPTION
#### What problem is this solving?
On `filter-navigator` there is no way to close a filter opening other.

#### How to test it?
You can test this feature [Here](https://filternavigator--dzarm.myvtex.com/blusas)

#### Screenshots or example usage:
Before this feature, on filter-navigator with horizontally layout was possible to open more than one filter keeping one above others - https://prnt.sc/tp8eqp

Now there is a prop that change this behavior and keep only one filter with opened state - https://prnt.sc/tp8hmt

#### How does this PR make you feel? [:link:](http://giphy.com/)
![](https://media.giphy.com/media/hSi4jPFdeoEed62SBS/giphy.gif)
