### PR TITLE
Feature/prop to change filter title tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- new prop `filtersTitleHtmlTag` for filterNavigatorV3 to change filters title html tag
 
 ## [3.66.2] - 2020-08-04
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -283,7 +283,7 @@ Check out the [**Product Summary documentation**](https://vtex.io/docs/component
 | `maxItemsDepartment` | `number`                 | Maximum number of departments to be displayed before the See More button is triggered.          | `8`             |
 | `maxItemsCategory`   | `number`                 | Maximum number of category items to be displayed before the See More button is triggered.     | `8`             |
 | `initiallyCollapsed` | `Boolean` | Makes the search filters start out collapsed (`true`) or open (`false`). | `false` |
-| `filtersTitleHtmlTag` | `string` | HTML heading tag for the filter's title. | `h5` |
+| `filtersTitleHtmlTag` | `string` | HTML tag for the filter's title. | `h5` |
 
 -  **`order-by` block**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -283,6 +283,7 @@ Check out the [**Product Summary documentation**](https://vtex.io/docs/component
 | `maxItemsDepartment` | `number`                 | Maximum number of departments to be displayed before the See More button is triggered.          | `8`             |
 | `maxItemsCategory`   | `number`                 | Maximum number of category items to be displayed before the See More button is triggered.     | `8`             |
 | `initiallyCollapsed` | `Boolean` | Makes the search filters start out collapsed (`true`) or open (`false`). | `false` |
+| `filtersTitleHtmlTag` | `string` | Change html tag for filters title element. | `h5` |
 
 -  **`order-by` block**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -283,7 +283,7 @@ Check out the [**Product Summary documentation**](https://vtex.io/docs/component
 | `maxItemsDepartment` | `number`                 | Maximum number of departments to be displayed before the See More button is triggered.          | `8`             |
 | `maxItemsCategory`   | `number`                 | Maximum number of category items to be displayed before the See More button is triggered.     | `8`             |
 | `initiallyCollapsed` | `Boolean` | Makes the search filters start out collapsed (`true`) or open (`false`). | `false` |
-| `filtersTitleHtmlTag` | `string` | Change html tag for filters title element. | `h5` |
+| `filtersTitleHtmlTag` | `string` | HTML heading tag for the filter's title. | `h5` |
 
 -  **`order-by` block**
 

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import { flatten } from 'ramda'
 import React, { useMemo, Fragment } from 'react'
 import ContentLoader from 'react-content-loader'
-import { FormattedMessage } from 'react-intl'
 import { ExtensionPoint } from 'vtex.render-runtime'
 import { useDevice } from 'vtex.device-detector'
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
@@ -18,6 +17,7 @@ import {
   hiddenFacetsSchema,
 } from './constants/propTypes'
 import useFacetNavigation from './hooks/useFacetNavigation'
+import FilterNavigatorTitleTag from './components/FilterNavigatorTitleTag'
 
 import styles from './searchResult.css'
 import { CATEGORIES_TITLE } from './utils/getFilters'
@@ -25,7 +25,6 @@ import { newFacetPathName } from './utils/slug'
 
 const CSS_HANDLES = [
   'filter__container',
-  'filterMessage',
   'filtersWrapper',
   'filtersWrapperMobile',
 ]
@@ -71,6 +70,7 @@ const FilterNavigator = ({
   layout = LAYOUT_TYPES.responsive,
   maxItemsDepartment = 8,
   maxItemsCategory = 8,
+  filtersTitleTag = 'h5',
 }) => {
   const { isMobile } = useDevice()
   const handles = useCssHandles(CSS_HANDLES)
@@ -152,9 +152,7 @@ const FilterNavigator = ({
                 'title'
               )} bb b--muted-4`}
             >
-              <h5 className={`${handles.filterMessage} t-heading-5 mv5`}>
-                <FormattedMessage id="store/search-result.filter-button.title" />
-              </h5>
+              <FilterNavigatorTitleTag filtersTitleTag={filtersTitleTag} />
             </div>
             <SelectedFilters
               filters={selectedFilters}
@@ -207,6 +205,7 @@ FilterNavigator.propTypes = {
   loading: PropTypes.bool,
   layout: PropTypes.oneOf(Object.values(LAYOUT_TYPES)),
   initiallyCollapsed: PropTypes.bool,
+  filtersTitleTag: PropTypes.string,
   ...hiddenFacetsSchema,
 }
 

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -70,7 +70,7 @@ const FilterNavigator = ({
   layout = LAYOUT_TYPES.responsive,
   maxItemsDepartment = 8,
   maxItemsCategory = 8,
-  filtersTitleTag = 'h5',
+  filtersTitleHtmlTag = 'h5',
 }) => {
   const { isMobile } = useDevice()
   const handles = useCssHandles(CSS_HANDLES)
@@ -152,7 +152,9 @@ const FilterNavigator = ({
                 'title'
               )} bb b--muted-4`}
             >
-              <FilterNavigatorTitleTag filtersTitleTag={filtersTitleTag} />
+              <FilterNavigatorTitleTag
+                filtersTitleHtmlTag={filtersTitleHtmlTag}
+              />
             </div>
             <SelectedFilters
               filters={selectedFilters}
@@ -205,7 +207,7 @@ FilterNavigator.propTypes = {
   loading: PropTypes.bool,
   layout: PropTypes.oneOf(Object.values(LAYOUT_TYPES)),
   initiallyCollapsed: PropTypes.bool,
-  filtersTitleTag: PropTypes.string,
+  filtersTitleHtmlTag: PropTypes.string,
   ...hiddenFacetsSchema,
 }
 

--- a/react/FilterNavigatorFlexible.js
+++ b/react/FilterNavigatorFlexible.js
@@ -13,7 +13,7 @@ const withSearchPageContextProps = Component => ({
   initiallyCollapsed,
   maxItemsDepartment,
   maxItemsCategory,
-  filtersTitleTag,
+  filtersTitleHtmlTag,
 }) => {
   const {
     searchQuery,
@@ -63,7 +63,7 @@ const withSearchPageContextProps = Component => ({
           initiallyCollapsed={initiallyCollapsed}
           maxItemsDepartment={maxItemsDepartment}
           maxItemsCategory={maxItemsCategory}
-          filtersTitleTag={filtersTitleTag}
+          filtersTitleHtmlTag={filtersTitleHtmlTag}
         />
       </FilterNavigatorContext.Provider>
     </div>

--- a/react/FilterNavigatorFlexible.js
+++ b/react/FilterNavigatorFlexible.js
@@ -13,6 +13,7 @@ const withSearchPageContextProps = Component => ({
   initiallyCollapsed,
   maxItemsDepartment,
   maxItemsCategory,
+  filtersTitleTag,
 }) => {
   const {
     searchQuery,
@@ -62,6 +63,7 @@ const withSearchPageContextProps = Component => ({
           initiallyCollapsed={initiallyCollapsed}
           maxItemsDepartment={maxItemsDepartment}
           maxItemsCategory={maxItemsCategory}
+          filtersTitleTag={filtersTitleTag}
         />
       </FilterNavigatorContext.Provider>
     </div>

--- a/react/components/FilterNavigatorTitleTag.js
+++ b/react/components/FilterNavigatorTitleTag.js
@@ -1,0 +1,49 @@
+import React from 'react'
+import { useCssHandles } from 'vtex.css-handles'
+import { FormattedMessage } from 'react-intl'
+
+const CSS_HANDLES = ['filterMessage']
+
+const FilterNavigatorTitleTags = ({ filtersTitleTag }) => {
+  const handles = useCssHandles(CSS_HANDLES)
+
+  if (filtersTitleTag === 'h1') {
+    return (
+      <h1 className={`${handles.filterMessage} t-heading-1 mv5`}>
+        <FormattedMessage id="store/search-result.filter-button.title" />
+      </h1>
+    )
+  }
+
+  if (filtersTitleTag === 'h2') {
+    return (
+      <h2 className={`${handles.filterMessage} t-heading-2 mv5`}>
+        <FormattedMessage id="store/search-result.filter-button.title" />
+      </h2>
+    )
+  }
+
+  if (filtersTitleTag === 'h3') {
+    return (
+      <h3 className={`${handles.filterMessage} t-heading-3 mv5`}>
+        <FormattedMessage id="store/search-result.filter-button.title" />
+      </h3>
+    )
+  }
+
+  if (filtersTitleTag === 'h4') {
+    return (
+      <h4 className={`${handles.filterMessage} t-heading-4 mv5`}>
+        <FormattedMessage id="store/search-result.filter-button.title" />
+      </h4>
+    )
+  }
+
+  return (
+    <h5 className={`${handles.filterMessage} t-heading-5 mv5`}>
+      <FormattedMessage id="store/search-result.filter-button.title" />
+    </h5>
+  )
+}
+
+export default FilterNavigatorTitleTags

--- a/react/components/FilterNavigatorTitleTag.js
+++ b/react/components/FilterNavigatorTitleTag.js
@@ -4,11 +4,11 @@ import { FormattedMessage } from 'react-intl'
 
 const CSS_HANDLES = ['filterMessage']
 
-const FilterNavigatorTitleTags = ({ filtersTitleTag }) => {
+const FilterNavigatorTitleTags = ({ filtersTitleHtmlTag }) => {
   const handles = useCssHandles(CSS_HANDLES)
-  const CustomTag = filtersTitleTag
+  const CustomTag = filtersTitleHtmlTag
 
-  if (CustomTag && filtersTitleTag !== 'h5') {
+  if (CustomTag && filtersTitleHtmlTag !== 'h5') {
     return (
       <CustomTag className={`${handles.filterMessage} mv5`}>
         <FormattedMessage id="store/search-result.filter-button.title" />

--- a/react/components/FilterNavigatorTitleTag.js
+++ b/react/components/FilterNavigatorTitleTag.js
@@ -4,22 +4,18 @@ import { FormattedMessage } from 'react-intl'
 
 const CSS_HANDLES = ['filterMessage']
 
-const FilterNavigatorTitleTags = ({ filtersTitleHtmlTag }) => {
+const FilterNavigatorTitleTags = ({ filtersTitleHtmlTag = 'h5' }) => {
   const handles = useCssHandles(CSS_HANDLES)
   const CustomTag = filtersTitleHtmlTag
 
-  if (CustomTag && filtersTitleHtmlTag !== 'h5') {
-    return (
-      <CustomTag className={`${handles.filterMessage} mv5`}>
-        <FormattedMessage id="store/search-result.filter-button.title" />
-      </CustomTag>
-    )
-  }
-
   return (
-    <h5 className={`${handles.filterMessage} t-heading-5 mv5`}>
+    <CustomTag
+      className={`${handles.filterMessage} ${
+        filtersTitleHtmlTag === 'h5' ? 't-heading-5' : ''
+      } mv5`}
+    >
       <FormattedMessage id="store/search-result.filter-button.title" />
-    </h5>
+    </CustomTag>
   )
 }
 

--- a/react/components/FilterNavigatorTitleTag.js
+++ b/react/components/FilterNavigatorTitleTag.js
@@ -6,36 +6,13 @@ const CSS_HANDLES = ['filterMessage']
 
 const FilterNavigatorTitleTags = ({ filtersTitleTag }) => {
   const handles = useCssHandles(CSS_HANDLES)
+  const CustomTag = filtersTitleTag
 
-  if (filtersTitleTag === 'h1') {
+  if (CustomTag && filtersTitleTag !== 'h5') {
     return (
-      <h1 className={`${handles.filterMessage} t-heading-1 mv5`}>
+      <CustomTag className={`${handles.filterMessage} mv5`}>
         <FormattedMessage id="store/search-result.filter-button.title" />
-      </h1>
-    )
-  }
-
-  if (filtersTitleTag === 'h2') {
-    return (
-      <h2 className={`${handles.filterMessage} t-heading-2 mv5`}>
-        <FormattedMessage id="store/search-result.filter-button.title" />
-      </h2>
-    )
-  }
-
-  if (filtersTitleTag === 'h3') {
-    return (
-      <h3 className={`${handles.filterMessage} t-heading-3 mv5`}>
-        <FormattedMessage id="store/search-result.filter-button.title" />
-      </h3>
-    )
-  }
-
-  if (filtersTitleTag === 'h4') {
-    return (
-      <h4 className={`${handles.filterMessage} t-heading-4 mv5`}>
-        <FormattedMessage id="store/search-result.filter-button.title" />
-      </h4>
+      </CustomTag>
     )
   }
 


### PR DESCRIPTION
#### What problem is this solving?

Currently in VTEX IO, with FilterNavigatorv3, the filter message heading ´Filters´ is rendered as an HTML h5 tag. However by default we do not have any h4, h3 or h2 tag making it less relevant. 

This PR was created for the addition of a prop to indicate the desired rendering tag of this element.

[Issue](https://github.com/vtex-apps/store-discussion/issues/314)

#### How to test it?

You can test it on this [Workspace](https://task314--carrefourbr.myvtex.com/moveis/aparadores?cfrict=botton&crfimt=home|carrefour|bn|bns|botton_moveis_bns_carrefour-e_250620|2)

#### Screenshots or example usage:

Add a customTag by passing it as a prop
![image](https://user-images.githubusercontent.com/19579091/89106315-49699980-d3ff-11ea-8aee-8d266ca1369b.png)

Result
![image](https://user-images.githubusercontent.com/19579091/89106165-f3e0bd00-d3fd-11ea-98bf-552f3c2a8b7a.png)

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/tIeCLkB8geYtW/giphy.gif)
