### PR TITLE
Prevent Checkbox components from receiving ids that would equal reserved global variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- HTML elements being rendered with ids equal to reserved global variable names, such as 'global', which would result in these variables being overwritten.
 
 ## [3.66.1] - 2020-07-31
 

--- a/react/components/FacetItem.js
+++ b/react/components/FacetItem.js
@@ -7,6 +7,17 @@ import SettingsContext from './SettingsContext'
 
 const CSS_HANDLES = ['filterItem']
 
+// These are used to prevent creating a <Checkbox /> with id equal
+// to any of these words.
+const reservedVariableNames = [
+  'global',
+  'window',
+  'document',
+  'self',
+  'screen',
+  'parent',
+]
+
 const FacetItem = ({
   navigateToFacet,
   facetTitle,
@@ -23,13 +34,17 @@ const FacetItem = ({
     'lh-copy w-100'
   )
 
+  const checkBoxId = reservedVariableNames.includes(facet.value)
+    ? `filterItem--${facet.value}`
+    : facet.value
+
   return (
     <div
       className={classes}
       style={{ hyphens: 'auto', wordBreak: 'break-word' }}
     >
       <Checkbox
-        id={facet.value}
+        id={checkBoxId}
         checked={facet.selected}
         label={
           showFacetQuantity ? `${facet.name} (${facet.quantity})` : facet.name


### PR DESCRIPTION
#### What problem is this solving?

The `id`s that are passed to `Checkbox` components are just the unchecked values for `facet.value`, this resulted in HTML elements being created by `Checkbox` with `id`s that could collide with certain global variables, since `id`s added to DOM nodes are referenced by global variables in JS, as described by https://2ality.com/2012/08/ids-are-global.html.

We identified this issue due to a certain facet that had its value set to `global`, and that caused the whole page to break since the `global` variable was being overwritten.

#### How to test it?

This is the [Workspace](https://vtexcamilo--realplaza.myvtex.com/lg) that was broken before the fix. Now it should be OK.

#### Screenshots or example usage:

**Before**

<img width="1263" alt="global-filter" src="https://user-images.githubusercontent.com/27777263/89228624-5a104000-d5b6-11ea-9460-7a5a3957478f.png">

**After**

(Notice that the ids that were equal to `global` are now equal to `filterItem--global`)

<img width="1054" alt="Screen Shot 2020-08-03 at 18 24 46" src="https://user-images.githubusercontent.com/27777263/89228796-a3608f80-d5b6-11ea-9a31-6efc353b5b44.png">

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/42wQXwITfQbDGKqUP7/giphy.gif)
