### PR TITLE
Feature/prop to add rel attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Added Props `htmlElementForFetchMoreButton` and `htmlElementForFetchPreviousButton` to change the html element rendered for `FetchMoreButton` or `FetchPreviousButton`.
+- Added Prop `htmlElementForButton` to change the html element rendered for `FetchMoreButton` or `FetchPreviousButton`.
 
 ## [3.67.1] - 2020-08-05
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Prop for the addition of the `rel` attribute for fetch more or previous button.
 
 ## [3.67.1] - 2020-08-05
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Prop for the addition of the `rel` attribute for fetch more or previous button.
+- Added Props `htmlElementForFetchMoreButton` and `htmlElementForFetchPreviousButton` to change the html element rendered for `FetchMoreButton` or `FetchPreviousButton`.
 
 ## [3.67.1] - 2020-08-05
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -309,14 +309,14 @@ The "Show More" button that is used to load the results of the next search page.
 
 | Prop name       | Type            | Description                                                                                                  | Default value |
 | --------------- | --------------- | ------------------------------------------------------------------------------------------------------------ | ------------- |
-| `relHtmlAttributeForButton` | `[boolean]` | Indicates if `rel` attribute will be added for the Fetch more button. | `false` |
+| `relHtmlAttributeForButton` | `[boolean]` | Indicates if `rel='next'` attribute will be added for the Fetch more button. | `false` |
 
 - **`search-fetch-previous` block**
 The "Show Previous" button that is used to load the results of the previous search page. This block is not rendered if there is no previous page.
 
 | Prop name       | Type            | Description                                                                                                  | Default value |
 | --------------- | --------------- | ------------------------------------------------------------------------------------------------------------ | ------------- |
-| `relHtmlAttributeForButton` | `[boolean]` | Indicates if `rel` attribute will be added for the Fetch previous button. | `false` |
+| `relHtmlAttributeForButton` | `[boolean]` | Indicates if `rel='prev'` attribute will be added for the Fetch previous button. | `false` |
 
 - **`search-products-count-per-page` block**
 Shows the product count per search page. Does not need any prop.

--- a/docs/README.md
+++ b/docs/README.md
@@ -309,14 +309,14 @@ The `Show More` button is used to load the results of the next search results pa
 
 | Prop name       | Type            | Description                                                                                                  | Default value |
 | --------------- | --------------- | ------------------------------------------------------------------------------------------------------------ | ------------- |
-| `htmlElementForFetchMoreButton` | `[enum]` | Define what type of html element will be rendered for `FetchMoreButton` component. Accept two values: `ANCHOR`, it renders a `<a>` element with `href` and `rel` attributes **OR** `BUTTON`, it renders a `<button>` element without `href` and `rel` attributes | `BUTTON` |
+| `htmlElementForButton` | `Enum` | Define what type of html element will be rendered for `FetchMoreButton` component. Accept two values: `ANCHOR`, it renders a `<a>` element with `href` and `rel` attributes **OR** `BUTTON`, it renders a `<button>` element without `href` and `rel` attributes | `BUTTON` |
 
 - **`search-fetch-previous` block**
 The `Show Previous` button is used to load the results of the previous search results page. Even when declared, this block is not rendered if there is no previous page.
 
 | Prop name       | Type            | Description                                                                                                  | Default value |
 | --------------- | --------------- | ------------------------------------------------------------------------------------------------------------ | ------------- |
-| `htmlElementForFetchPreviousButton` | `[enum]` | Define what type of html element will be rendered for `FetchPreviousButton` component. Accept two values: `ANCHOR`, it renders a `<a>` element with `href` and `rel` attributes **OR** `BUTTON`, it renders a `<button>` element without `href` and `rel` attributes | `BUTTON` |
+| `htmlElementForButton` | `Enum` | Define what type of html element will be rendered for `FetchPreviousButton` component. Accept two values: `ANCHOR`, it renders a `<a>` element with `href` and `rel` attributes **OR** `BUTTON`, it renders a `<button>` element without `href` and `rel` attributes | `BUTTON` |
 
 - **`search-products-count-per-page` block**
 Shows the product count per search page. Does not need any prop.

--- a/docs/README.md
+++ b/docs/README.md
@@ -305,9 +305,19 @@ The sorting options are:
 | Name Descending          | `"OrderByNameDESC"`         |
 
 - **`search-fetch-more` block**
-The "Show More" button that is used to load the results of the next search page. This block is not rendered if there is no next page. Does not need any prop.
+The "Show More" button that is used to load the results of the next search page. This block is not rendered if there is no next page.
+
+| Prop name       | Type            | Description                                                                                                  | Default value |
+| --------------- | --------------- | ------------------------------------------------------------------------------------------------------------ | ------------- |
+| `relHtmlAttributeForButton` | `[boolean]` | Indicates if `rel` attribute will be added for the Fetch more button. | `false` |
+
 - **`search-fetch-previous` block**
-The "Show Previous" button that is used to load the results of the previous search page. This block is not rendered if there is no previous page. Does not need any prop.
+The "Show Previous" button that is used to load the results of the previous search page. This block is not rendered if there is no previous page.
+
+| Prop name       | Type            | Description                                                                                                  | Default value |
+| --------------- | --------------- | ------------------------------------------------------------------------------------------------------------ | ------------- |
+| `relHtmlAttributeForButton` | `[boolean]` | Indicates if `rel` attribute will be added for the Fetch previous button. | `false` |
+
 - **`search-products-count-per-page` block**
 Shows the product count per search page. Does not need any prop.
 - **`search-products-progress-bar` block**

--- a/docs/README.md
+++ b/docs/README.md
@@ -305,14 +305,14 @@ The sorting options are:
 | Name Descending          | `"OrderByNameDESC"`         |
 
 - **`search-fetch-more` block**
-The "Show More" button that is used to load the results of the next search page. This block is not rendered if there is no next page.
+The `Show More` button is used to load the results of the next search results page. Even when declared, this block is not rendered if there is no next page.
 
 | Prop name       | Type            | Description                                                                                                  | Default value |
 | --------------- | --------------- | ------------------------------------------------------------------------------------------------------------ | ------------- |
 | `htmlElementForFetchMoreButton` | `[enum]` | Define what type of html element will be rendered for `FetchMoreButton` component. Accept two values: `ANCHOR`, it renders a `<a>` element with `href` and `rel` attributes **OR** `BUTTON`, it renders a `<button>` element without `href` and `rel` attributes | `BUTTON` |
 
 - **`search-fetch-previous` block**
-The "Show Previous" button that is used to load the results of the previous search page. This block is not rendered if there is no previous page.
+The `Show Previous` button is used to load the results of the previous search results page. Even when declared, this block is not rendered if there is no previous page.
 
 | Prop name       | Type            | Description                                                                                                  | Default value |
 | --------------- | --------------- | ------------------------------------------------------------------------------------------------------------ | ------------- |

--- a/docs/README.md
+++ b/docs/README.md
@@ -309,14 +309,14 @@ The `Show More` button is used to load the results of the next search results pa
 
 | Prop name       | Type            | Description                                                                                                  | Default value |
 | --------------- | --------------- | ------------------------------------------------------------------------------------------------------------ | ------------- |
-| `htmlElementForButton` | `Enum` | Define what type of html element will be rendered for `FetchMoreButton` component. Accept two values: `ANCHOR`, it renders a `<a>` element with `href` and `rel` attributes **OR** `BUTTON`, it renders a `<button>` element without `href` and `rel` attributes | `BUTTON` |
+| `htmlElementForButton` | `enum` | Which HTML element will be displayed for `Show more` button component. Possible values are: `ANCHOR` (displays a `<a>` element with `href` and `rel` attributes)  or `BUTTON` (displays a `<button>` element without `href` and `rel` attributes). | `BUTTON` |
 
 - **`search-fetch-previous` block**
 The `Show Previous` button is used to load the results of the previous search results page. Even when declared, this block is not rendered if there is no previous page.
 
 | Prop name       | Type            | Description                                                                                                  | Default value |
 | --------------- | --------------- | ------------------------------------------------------------------------------------------------------------ | ------------- |
-| `htmlElementForButton` | `Enum` | Define what type of html element will be rendered for `FetchPreviousButton` component. Accept two values: `ANCHOR`, it renders a `<a>` element with `href` and `rel` attributes **OR** `BUTTON`, it renders a `<button>` element without `href` and `rel` attributes | `BUTTON` |
+| `htmlElementForButton` | `enum` | Which HTML element will be displayed for `Show previous` button component. Possible values are: `ANCHOR` (displays a `<a>` element with `href` and `rel` attributes)  or `BUTTON` (displays a `<button>` element without `href` and `rel` attributes). | `BUTTON` |
 
 - **`search-products-count-per-page` block**
 Shows the product count per search page. Does not need any prop.

--- a/docs/README.md
+++ b/docs/README.md
@@ -309,14 +309,14 @@ The `Show More` button is used to load the results of the next search results pa
 
 | Prop name       | Type            | Description                                                                                                  | Default value |
 | --------------- | --------------- | ------------------------------------------------------------------------------------------------------------ | ------------- |
-| `htmlElementForButton` | `enum` | Which HTML element will be displayed for `Show more` button component. Possible values are: `ANCHOR` (displays a `<a>` element with `href` and `rel` attributes)  or `BUTTON` (displays a `<button>` element without `href` and `rel` attributes). | `BUTTON` |
+| `htmlElementForButton` | `enum` | Which HTML element will be displayed for `Show more` button component. Possible values are: `a` (displays a `<a>` element with `href` and `rel` attributes)  or `button` (displays a `<button>` element without `href` and `rel` attributes). | `button` |
 
 - **`search-fetch-previous` block**
 The `Show Previous` button is used to load the results of the previous search results page. Even when declared, this block is not rendered if there is no previous page.
 
 | Prop name       | Type            | Description                                                                                                  | Default value |
 | --------------- | --------------- | ------------------------------------------------------------------------------------------------------------ | ------------- |
-| `htmlElementForButton` | `enum` | Which HTML element will be displayed for `Show previous` button component. Possible values are: `ANCHOR` (displays a `<a>` element with `href` and `rel` attributes)  or `BUTTON` (displays a `<button>` element without `href` and `rel` attributes). | `BUTTON` |
+| `htmlElementForButton` | `enum` | Which HTML element will be displayed for `Show previous` button component. Possible values are: `a` (displays a `<a>` element with `href` and `rel` attributes)  or `button` (displays a `<button>` element without `href` and `rel` attributes). | `button` |
 
 - **`search-products-count-per-page` block**
 Shows the product count per search page. Does not need any prop.

--- a/docs/README.md
+++ b/docs/README.md
@@ -309,14 +309,14 @@ The "Show More" button that is used to load the results of the next search page.
 
 | Prop name       | Type            | Description                                                                                                  | Default value |
 | --------------- | --------------- | ------------------------------------------------------------------------------------------------------------ | ------------- |
-| `relHtmlAttributeForButton` | `[boolean]` | Indicates if `rel='next'` attribute will be added for the Fetch more button. | `false` |
+| `htmlElementForFetchMoreButton` | `[enum]` | Define what type of html element will be rendered for `FetchMoreButton` component. Accept two values: `ANCHOR`, it renders a `<a>` element with `href` and `rel` attributes **OR** `BUTTON`, it renders a `<button>` element without `href` and `rel` attributes | `BUTTON` |
 
 - **`search-fetch-previous` block**
 The "Show Previous" button that is used to load the results of the previous search page. This block is not rendered if there is no previous page.
 
 | Prop name       | Type            | Description                                                                                                  | Default value |
 | --------------- | --------------- | ------------------------------------------------------------------------------------------------------------ | ------------- |
-| `relHtmlAttributeForButton` | `[boolean]` | Indicates if `rel='prev'` attribute will be added for the Fetch previous button. | `false` |
+| `htmlElementForFetchPreviousButton` | `[enum]` | Define what type of html element will be rendered for `FetchPreviousButton` component. Accept two values: `ANCHOR`, it renders a `<a>` element with `href` and `rel` attributes **OR** `BUTTON`, it renders a `<button>` element without `href` and `rel` attributes | `BUTTON` |
 
 - **`search-products-count-per-page` block**
 Shows the product count per search page. Does not need any prop.

--- a/react/FetchMore.js
+++ b/react/FetchMore.js
@@ -10,7 +10,7 @@ import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
 
 import styles from './searchResult.css'
 
-const FetchMore = () => {
+const FetchMore = ({ relHtmlAttributeForButton = false }) => {
   const { pagination, searchQuery, maxItemsPerPage, page } = useSearchPage()
   const products = path(['data', 'productSearch', 'products'], searchQuery)
   const recordsFiltered = path(
@@ -51,6 +51,7 @@ const FetchMore = () => {
           onFetchMore={handleFetchMoreNext}
           loading={loading}
           showProductsCount={false}
+          hasRelHtmlAttributeForButton={relHtmlAttributeForButton}
         />
       </div>
     )

--- a/react/FetchMore.js
+++ b/react/FetchMore.js
@@ -11,7 +11,7 @@ import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
 
 import styles from './searchResult.css'
 
-const FetchMore = ({ htmlElementForButton }) => {
+const FetchMore = ({ htmlElementForButton = 'button '}) => {
   const { pagination, searchQuery, maxItemsPerPage, page } = useSearchPage()
   const products = path(['data', 'productSearch', 'products'], searchQuery)
   const recordsFiltered = path(
@@ -64,10 +64,6 @@ const FetchMore = ({ htmlElementForButton }) => {
 FetchMore.propTypes = {
   /* html element to render for fetch more button */
   htmlElementForButton: PropTypes.string,
-}
-
-FetchMore.defaultProps = {
-  htmlElementForButton: 'BUTTON',
 }
 
 export default FetchMore

--- a/react/FetchMore.js
+++ b/react/FetchMore.js
@@ -51,7 +51,7 @@ const FetchMore = ({ relHtmlAttributeForButton = false }) => {
           onFetchMore={handleFetchMoreNext}
           loading={loading}
           showProductsCount={false}
-          hasRelHtmlAttributeForButton={relHtmlAttributeForButton}
+          hasRelHtmlAttribute={relHtmlAttributeForButton}
         />
       </div>
     )

--- a/react/FetchMore.js
+++ b/react/FetchMore.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { path } from 'ramda'
 import classNames from 'classnames'
+import PropTypes from 'prop-types'
 import FetchMoreButton from './components/loaders/FetchMoreButton'
 import LoadingSpinner from './components/loaders/LoadingSpinner'
 import { PAGINATION_TYPE } from './constants/paginationType'
@@ -10,7 +11,7 @@ import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
 
 import styles from './searchResult.css'
 
-const FetchMore = ({ relHtmlAttributeForButton = false }) => {
+const FetchMore = ({ htmlElementForFetchMoreButton }) => {
   const { pagination, searchQuery, maxItemsPerPage, page } = useSearchPage()
   const products = path(['data', 'productSearch', 'products'], searchQuery)
   const recordsFiltered = path(
@@ -51,13 +52,22 @@ const FetchMore = ({ relHtmlAttributeForButton = false }) => {
           onFetchMore={handleFetchMoreNext}
           loading={loading}
           showProductsCount={false}
-          hasRelHtmlAttribute={relHtmlAttributeForButton}
+          htmlElementForFetchMoreButton={htmlElementForFetchMoreButton}
         />
       </div>
     )
   }
 
   return <LoadingSpinner loading={loading} />
+}
+
+FetchMore.propTypes = {
+  /* html element to render for fetch more button */
+  htmlElementForFetchMoreButton: PropTypes.string,
+}
+
+FetchMore.defaultProps = {
+  htmlElementForFetchMoreButton: 'BUTTON',
 }
 
 export default FetchMore

--- a/react/FetchMore.js
+++ b/react/FetchMore.js
@@ -11,7 +11,7 @@ import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
 
 import styles from './searchResult.css'
 
-const FetchMore = ({ htmlElementForFetchMoreButton }) => {
+const FetchMore = ({ htmlElementForButton }) => {
   const { pagination, searchQuery, maxItemsPerPage, page } = useSearchPage()
   const products = path(['data', 'productSearch', 'products'], searchQuery)
   const recordsFiltered = path(
@@ -52,7 +52,7 @@ const FetchMore = ({ htmlElementForFetchMoreButton }) => {
           onFetchMore={handleFetchMoreNext}
           loading={loading}
           showProductsCount={false}
-          htmlElementForFetchMoreButton={htmlElementForFetchMoreButton}
+          htmlElementForButton={htmlElementForButton}
         />
       </div>
     )
@@ -63,11 +63,11 @@ const FetchMore = ({ htmlElementForFetchMoreButton }) => {
 
 FetchMore.propTypes = {
   /* html element to render for fetch more button */
-  htmlElementForFetchMoreButton: PropTypes.string,
+  htmlElementForButton: PropTypes.string,
 }
 
 FetchMore.defaultProps = {
-  htmlElementForFetchMoreButton: 'BUTTON',
+  htmlElementForButton: 'BUTTON',
 }
 
 export default FetchMore

--- a/react/FetchPrevious.js
+++ b/react/FetchPrevious.js
@@ -8,7 +8,7 @@ import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
 
 import styles from './searchResult.css'
 
-const FetchPrevious = ({ htmlElementForFetchPreviousButton }) => {
+const FetchPrevious = ({ htmlElementForButton }) => {
   const { searchQuery, maxItemsPerPage, page } = useSearchPage()
   const products = path(['data', 'productSearch', 'products'], searchQuery)
   const recordsFiltered = path(
@@ -46,7 +46,7 @@ const FetchPrevious = ({ htmlElementForFetchPreviousButton }) => {
         recordsFiltered={recordsFiltered}
         onFetchPrevious={handleFetchMorePrevious}
         loading={loading}
-        htmlElementForFetchPreviousButton={htmlElementForFetchPreviousButton}
+        htmlElementForButton={htmlElementForButton}
       />
     </div>
   )
@@ -54,11 +54,11 @@ const FetchPrevious = ({ htmlElementForFetchPreviousButton }) => {
 
 FetchPrevious.propTypes = {
   /* html element to render for fetch previous button */
-  htmlElementForFetchPreviousButton: PropTypes.string,
+  htmlElementForButton: PropTypes.string,
 }
 
 FetchPrevious.defaultProps = {
-  htmlElementForFetchPreviousButton: 'BUTTON',
+  htmlElementForButton: 'BUTTON',
 }
 
 export default FetchPrevious

--- a/react/FetchPrevious.js
+++ b/react/FetchPrevious.js
@@ -8,7 +8,7 @@ import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
 
 import styles from './searchResult.css'
 
-const FetchPrevious = ({ htmlElementForButton }) => {
+const FetchPrevious = ({ htmlElementForButton = 'button' }) => {
   const { searchQuery, maxItemsPerPage, page } = useSearchPage()
   const products = path(['data', 'productSearch', 'products'], searchQuery)
   const recordsFiltered = path(
@@ -55,10 +55,6 @@ const FetchPrevious = ({ htmlElementForButton }) => {
 FetchPrevious.propTypes = {
   /* html element to render for fetch previous button */
   htmlElementForButton: PropTypes.string,
-}
-
-FetchPrevious.defaultProps = {
-  htmlElementForButton: 'BUTTON',
 }
 
 export default FetchPrevious

--- a/react/FetchPrevious.js
+++ b/react/FetchPrevious.js
@@ -45,7 +45,7 @@ const FetchPrevious = ({ relHtmlAttributeForButton = false }) => {
         recordsFiltered={recordsFiltered}
         onFetchPrevious={handleFetchMorePrevious}
         loading={loading}
-        hasRelHtmlAttributeForButton={relHtmlAttributeForButton}
+        hasRelHtmlAttribute={relHtmlAttributeForButton}
       />
     </div>
   )

--- a/react/FetchPrevious.js
+++ b/react/FetchPrevious.js
@@ -7,7 +7,7 @@ import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
 
 import styles from './searchResult.css'
 
-const FetchPrevious = () => {
+const FetchPrevious = ({ relHtmlAttributeForButton = false }) => {
   const { searchQuery, maxItemsPerPage, page } = useSearchPage()
   const products = path(['data', 'productSearch', 'products'], searchQuery)
   const recordsFiltered = path(
@@ -45,6 +45,7 @@ const FetchPrevious = () => {
         recordsFiltered={recordsFiltered}
         onFetchPrevious={handleFetchMorePrevious}
         loading={loading}
+        hasRelHtmlAttributeForButton={relHtmlAttributeForButton}
       />
     </div>
   )

--- a/react/FetchPrevious.js
+++ b/react/FetchPrevious.js
@@ -1,13 +1,14 @@
 import React from 'react'
 import { path } from 'ramda'
 import classNames from 'classnames'
+import PropTypes from 'prop-types'
 import FetchPreviousButton from './components/loaders/FetchPreviousButton'
 import { useFetchMore } from './hooks/useFetchMore'
 import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
 
 import styles from './searchResult.css'
 
-const FetchPrevious = ({ relHtmlAttributeForButton = false }) => {
+const FetchPrevious = ({ htmlElementForFetchPreviousButton }) => {
   const { searchQuery, maxItemsPerPage, page } = useSearchPage()
   const products = path(['data', 'productSearch', 'products'], searchQuery)
   const recordsFiltered = path(
@@ -45,10 +46,19 @@ const FetchPrevious = ({ relHtmlAttributeForButton = false }) => {
         recordsFiltered={recordsFiltered}
         onFetchPrevious={handleFetchMorePrevious}
         loading={loading}
-        hasRelHtmlAttribute={relHtmlAttributeForButton}
+        htmlElementForFetchPreviousButton={htmlElementForFetchPreviousButton}
       />
     </div>
   )
+}
+
+FetchPrevious.propTypes = {
+  /* html element to render for fetch previous button */
+  htmlElementForFetchPreviousButton: PropTypes.string,
+}
+
+FetchPrevious.defaultProps = {
+  htmlElementForFetchPreviousButton: 'BUTTON',
 }
 
 export default FetchPrevious

--- a/react/SearchResultFlexible.js
+++ b/react/SearchResultFlexible.js
@@ -48,7 +48,6 @@ const SearchResultFlexible = ({
   blockClass,
   preventRouteChange = false,
   showFacetQuantity = false,
-  relHtmlAttributeForFetchButtons = false,
   // Below are set by SearchContext
   searchQuery,
   maxItemsPerPage,
@@ -106,17 +105,9 @@ const SearchResultFlexible = ({
       pagination,
       mobileLayout,
       showFacetQuantity,
-      relHtmlAttributeForFetchButtons,
       trackingId,
     }),
-    [
-      hiddenFacets,
-      mobileLayout,
-      pagination,
-      showFacetQuantity,
-      relHtmlAttributeForFetchButtons,
-      trackingId,
-    ]
+    [hiddenFacets, mobileLayout, pagination, showFacetQuantity, trackingId]
   )
 
   const context = useMemo(
@@ -177,7 +168,6 @@ const SearchResultFlexible = ({
               orderBy={orderBy}
               page={page}
               facetsLoading={facetsLoading}
-              relHtmlAttributeForFetchButtons={relHtmlAttributeForFetchButtons}
             >
               {
                 <LoadingOverlay loading={showLoading}>

--- a/react/SearchResultFlexible.js
+++ b/react/SearchResultFlexible.js
@@ -48,6 +48,7 @@ const SearchResultFlexible = ({
   blockClass,
   preventRouteChange = false,
   showFacetQuantity = false,
+  relHtmlAttributeForFetchButtons = false,
   // Below are set by SearchContext
   searchQuery,
   maxItemsPerPage,
@@ -82,6 +83,7 @@ const SearchResultFlexible = ({
       }),
     [brands, hiddenFacets, priceRanges, specificationFilters]
   )
+
   const handles = useCssHandles(CSS_HANDLES)
 
   const hideFacets = !map
@@ -104,9 +106,17 @@ const SearchResultFlexible = ({
       pagination,
       mobileLayout,
       showFacetQuantity,
+      relHtmlAttributeForFetchButtons,
       trackingId,
     }),
-    [hiddenFacets, mobileLayout, pagination, showFacetQuantity, trackingId]
+    [
+      hiddenFacets,
+      mobileLayout,
+      pagination,
+      showFacetQuantity,
+      relHtmlAttributeForFetchButtons,
+      trackingId,
+    ]
   )
 
   const context = useMemo(
@@ -167,6 +177,7 @@ const SearchResultFlexible = ({
               orderBy={orderBy}
               page={page}
               facetsLoading={facetsLoading}
+              relHtmlAttributeForFetchButtons={relHtmlAttributeForFetchButtons}
             >
               {
                 <LoadingOverlay loading={showLoading}>

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -131,7 +131,6 @@ class SearchResult extends Component {
       pagination,
       infiniteScrollError,
       facetsLoading,
-      relHtmlAttributeForFetchButtons,
     } = this.props
 
     const {
@@ -221,7 +220,6 @@ class SearchResult extends Component {
               from={from}
               onFetchPrevious={onFetchPrevious}
               loading={fetchMoreLoading}
-              relHtmlAttributeForFetchButtons={relHtmlAttributeForFetchButtons}
             />
             {showContentLoader ? (
               <div className="w-100 flex justify-center">
@@ -252,9 +250,6 @@ class SearchResult extends Component {
                   onFetchMore={onFetchMore}
                   loading={fetchMoreLoading}
                   showProductsCount={showProductsCount}
-                  relHtmlAttributeForFetchButtons={
-                    relHtmlAttributeForFetchButtons
-                  }
                 />
                 <ExtensionPoint
                   id="search-products-progress-bar"

--- a/react/components/SearchResult.js
+++ b/react/components/SearchResult.js
@@ -131,6 +131,7 @@ class SearchResult extends Component {
       pagination,
       infiniteScrollError,
       facetsLoading,
+      relHtmlAttributeForFetchButtons,
     } = this.props
 
     const {
@@ -220,6 +221,7 @@ class SearchResult extends Component {
               from={from}
               onFetchPrevious={onFetchPrevious}
               loading={fetchMoreLoading}
+              relHtmlAttributeForFetchButtons={relHtmlAttributeForFetchButtons}
             />
             {showContentLoader ? (
               <div className="w-100 flex justify-center">
@@ -250,6 +252,9 @@ class SearchResult extends Component {
                   onFetchMore={onFetchMore}
                   loading={fetchMoreLoading}
                   showProductsCount={showProductsCount}
+                  relHtmlAttributeForFetchButtons={
+                    relHtmlAttributeForFetchButtons
+                  }
                 />
                 <ExtensionPoint
                   id="search-products-progress-bar"

--- a/react/components/loaders/FetchMoreButton.js
+++ b/react/components/loaders/FetchMoreButton.js
@@ -32,6 +32,12 @@ const FetchMoreButton = props => {
     showProductsCount,
     hasRelHtmlAttributeForButton,
   } = props
+
+  const handleFetchMoreClick = ev => {
+    hasRelHtmlAttributeForButton && ev.preventDefault()
+    onFetchMore()
+  }
+
   const showButton = useShowButton(to, products, loading, recordsFiltered)
   const handles = useCssHandles(CSS_HANDLES)
 
@@ -40,7 +46,8 @@ const FetchMoreButton = props => {
       <div className={`${handles.buttonShowMore} w-100 flex justify-center`}>
         {showButton && (
           <Button
-            onClick={onFetchMore}
+            onClick={ev => handleFetchMoreClick(ev)}
+            href={hasRelHtmlAttributeForButton && '#'}
             rel={hasRelHtmlAttributeForButton && 'next'}
             isLoading={loading}
             size="small"

--- a/react/components/loaders/FetchMoreButton.js
+++ b/react/components/loaders/FetchMoreButton.js
@@ -30,11 +30,11 @@ const FetchMoreButton = props => {
     onFetchMore,
     loading,
     showProductsCount,
-    hasRelHtmlAttributeForButton,
+    hasRelHtmlAttribute,
   } = props
 
   const handleFetchMoreClick = ev => {
-    hasRelHtmlAttributeForButton && ev.preventDefault()
+    hasRelHtmlAttribute && ev.preventDefault()
     onFetchMore()
   }
 
@@ -47,8 +47,8 @@ const FetchMoreButton = props => {
         {showButton && (
           <Button
             onClick={ev => handleFetchMoreClick(ev)}
-            href={hasRelHtmlAttributeForButton && '#'}
-            rel={hasRelHtmlAttributeForButton && 'next'}
+            href={hasRelHtmlAttribute && '#'}
+            rel={hasRelHtmlAttribute && 'next'}
             isLoading={loading}
             size="small"
             key={to} // Necessary to prevent focus after click

--- a/react/components/loaders/FetchMoreButton.js
+++ b/react/components/loaders/FetchMoreButton.js
@@ -30,7 +30,7 @@ const FetchMoreButton = props => {
     onFetchMore,
     loading,
     showProductsCount,
-    relHtmlAttributeForFetchButtons,
+    hasRelHtmlAttributeForButton,
   } = props
   const showButton = useShowButton(to, products, loading, recordsFiltered)
   const handles = useCssHandles(CSS_HANDLES)
@@ -41,7 +41,7 @@ const FetchMoreButton = props => {
         {showButton && (
           <Button
             onClick={onFetchMore}
-            rel={relHtmlAttributeForFetchButtons && 'next'}
+            rel={hasRelHtmlAttributeForButton && 'next'}
             isLoading={loading}
             size="small"
             key={to} // Necessary to prevent focus after click

--- a/react/components/loaders/FetchMoreButton.js
+++ b/react/components/loaders/FetchMoreButton.js
@@ -33,12 +33,12 @@ const FetchMoreButton = props => {
     htmlElementForButton,
   } = props
 
-  const isAnchor = Boolean(htmlElementForButton === 'ANCHOR')
+  const isAnchor = htmlElementForButton === 'a'
   const showButton = useShowButton(to, products, loading, recordsFiltered)
   const handles = useCssHandles(CSS_HANDLES)
 
   const handleFetchMoreClick = ev => {
-    htmlElementForFetchMoreButton && ev.preventDefault()
+    isAnchor && ev.preventDefault()
     onFetchMore()
   }
 

--- a/react/components/loaders/FetchMoreButton.js
+++ b/react/components/loaders/FetchMoreButton.js
@@ -30,6 +30,7 @@ const FetchMoreButton = props => {
     onFetchMore,
     loading,
     showProductsCount,
+    relHtmlAttributeForFetchButtons,
   } = props
   const showButton = useShowButton(to, products, loading, recordsFiltered)
   const handles = useCssHandles(CSS_HANDLES)
@@ -40,6 +41,7 @@ const FetchMoreButton = props => {
         {showButton && (
           <Button
             onClick={onFetchMore}
+            rel={relHtmlAttributeForFetchButtons && 'next'}
             isLoading={loading}
             size="small"
             key={to} // Necessary to prevent focus after click

--- a/react/components/loaders/FetchMoreButton.js
+++ b/react/components/loaders/FetchMoreButton.js
@@ -38,11 +38,9 @@ const FetchMoreButton = props => {
   const handles = useCssHandles(CSS_HANDLES)
 
   const handleFetchMoreClick = ev => {
-    isAnchor && ev.preventDefault()
+    htmlElementForFetchMoreButton && ev.preventDefault()
     onFetchMore()
   }
-
-  console.log(htmlElementForFetchMoreButton)
 
   return (
     <Fragment>

--- a/react/components/loaders/FetchMoreButton.js
+++ b/react/components/loaders/FetchMoreButton.js
@@ -30,16 +30,19 @@ const FetchMoreButton = props => {
     onFetchMore,
     loading,
     showProductsCount,
-    hasRelHtmlAttribute,
+    htmlElementForFetchMoreButton,
   } = props
 
+  const isAnchor = Boolean(htmlElementForFetchMoreButton === 'ANCHOR')
+  const showButton = useShowButton(to, products, loading, recordsFiltered)
+  const handles = useCssHandles(CSS_HANDLES)
+
   const handleFetchMoreClick = ev => {
-    hasRelHtmlAttribute && ev.preventDefault()
+    isAnchor && ev.preventDefault()
     onFetchMore()
   }
 
-  const showButton = useShowButton(to, products, loading, recordsFiltered)
-  const handles = useCssHandles(CSS_HANDLES)
+  console.log(htmlElementForFetchMoreButton)
 
   return (
     <Fragment>
@@ -47,8 +50,8 @@ const FetchMoreButton = props => {
         {showButton && (
           <Button
             onClick={ev => handleFetchMoreClick(ev)}
-            href={hasRelHtmlAttribute && '#'}
-            rel={hasRelHtmlAttribute && 'next'}
+            href={isAnchor && '#'}
+            rel={isAnchor && 'next'}
             isLoading={loading}
             size="small"
             key={to} // Necessary to prevent focus after click

--- a/react/components/loaders/FetchMoreButton.js
+++ b/react/components/loaders/FetchMoreButton.js
@@ -30,10 +30,10 @@ const FetchMoreButton = props => {
     onFetchMore,
     loading,
     showProductsCount,
-    htmlElementForFetchMoreButton,
+    htmlElementForButton,
   } = props
 
-  const isAnchor = Boolean(htmlElementForFetchMoreButton === 'ANCHOR')
+  const isAnchor = Boolean(htmlElementForButton === 'ANCHOR')
   const showButton = useShowButton(to, products, loading, recordsFiltered)
   const handles = useCssHandles(CSS_HANDLES)
 

--- a/react/components/loaders/FetchPreviousButton.js
+++ b/react/components/loaders/FetchPreviousButton.js
@@ -24,24 +24,25 @@ const FetchPreviousButton = props => {
     from,
     onFetchPrevious,
     loading,
-    hasRelHtmlAttribute,
+    htmlElementForFetchPreviousButton,
   } = props
 
-  const handleFetchMoreClick = ev => {
-    hasRelHtmlAttribute && ev.preventDefault()
-    onFetchPrevious()
-  }
-
+  const isAnchor = Boolean(htmlElementForFetchPreviousButton === 'ANCHOR')
   const showButton = useShowButton(from, products, loading)
   const handles = useCssHandles(CSS_HANDLES)
+
+  const handleFetchMoreClick = ev => {
+    isAnchor && ev.preventDefault()
+    onFetchPrevious()
+  }
 
   return (
     <div className={`${handles.buttonShowMore} w-100 flex justify-center`}>
       {showButton && (
         <Button
           onClick={ev => handleFetchMoreClick(ev)}
-          href={hasRelHtmlAttribute && '#'}
-          rel={hasRelHtmlAttribute && 'prev'}
+          href={isAnchor && '#'}
+          rel={isAnchor && 'prev'}
           isLoading={loading}
           size="small"
           key={from} // Necessary to prevent focus after click

--- a/react/components/loaders/FetchPreviousButton.js
+++ b/react/components/loaders/FetchPreviousButton.js
@@ -24,11 +24,11 @@ const FetchPreviousButton = props => {
     from,
     onFetchPrevious,
     loading,
-    hasRelHtmlAttributeForButton,
+    hasRelHtmlAttribute,
   } = props
 
   const handleFetchMoreClick = ev => {
-    hasRelHtmlAttributeForButton && ev.preventDefault()
+    hasRelHtmlAttribute && ev.preventDefault()
     onFetchPrevious()
   }
 
@@ -40,8 +40,8 @@ const FetchPreviousButton = props => {
       {showButton && (
         <Button
           onClick={ev => handleFetchMoreClick(ev)}
-          href={hasRelHtmlAttributeForButton && '#'}
-          rel={hasRelHtmlAttributeForButton && 'prev'}
+          href={hasRelHtmlAttribute && '#'}
+          rel={hasRelHtmlAttribute && 'prev'}
           isLoading={loading}
           size="small"
           key={from} // Necessary to prevent focus after click

--- a/react/components/loaders/FetchPreviousButton.js
+++ b/react/components/loaders/FetchPreviousButton.js
@@ -24,10 +24,10 @@ const FetchPreviousButton = props => {
     from,
     onFetchPrevious,
     loading,
-    htmlElementForFetchPreviousButton,
+    htmlElementForButton,
   } = props
 
-  const isAnchor = Boolean(htmlElementForFetchPreviousButton === 'ANCHOR')
+  const isAnchor = Boolean(htmlElementForButton === 'ANCHOR')
   const showButton = useShowButton(from, products, loading)
   const handles = useCssHandles(CSS_HANDLES)
 

--- a/react/components/loaders/FetchPreviousButton.js
+++ b/react/components/loaders/FetchPreviousButton.js
@@ -24,7 +24,7 @@ const FetchPreviousButton = props => {
     from,
     onFetchPrevious,
     loading,
-    relHtmlAttributeForFetchButtons,
+    hasRelHtmlAttributeForButton,
   } = props
   const showButton = useShowButton(from, products, loading)
   const handles = useCssHandles(CSS_HANDLES)
@@ -33,7 +33,7 @@ const FetchPreviousButton = props => {
       {showButton && (
         <Button
           onClick={onFetchPrevious}
-          rel={relHtmlAttributeForFetchButtons && 'prev'}
+          rel={hasRelHtmlAttributeForButton && 'prev'}
           isLoading={loading}
           size="small"
           key={from} // Necessary to prevent focus after click

--- a/react/components/loaders/FetchPreviousButton.js
+++ b/react/components/loaders/FetchPreviousButton.js
@@ -26,13 +26,21 @@ const FetchPreviousButton = props => {
     loading,
     hasRelHtmlAttributeForButton,
   } = props
+
+  const handleFetchMoreClick = ev => {
+    hasRelHtmlAttributeForButton && ev.preventDefault()
+    onFetchPrevious()
+  }
+
   const showButton = useShowButton(from, products, loading)
   const handles = useCssHandles(CSS_HANDLES)
+
   return (
     <div className={`${handles.buttonShowMore} w-100 flex justify-center`}>
       {showButton && (
         <Button
-          onClick={onFetchPrevious}
+          onClick={ev => handleFetchMoreClick(ev)}
+          href={hasRelHtmlAttributeForButton && '#'}
           rel={hasRelHtmlAttributeForButton && 'prev'}
           isLoading={loading}
           size="small"

--- a/react/components/loaders/FetchPreviousButton.js
+++ b/react/components/loaders/FetchPreviousButton.js
@@ -27,7 +27,7 @@ const FetchPreviousButton = props => {
     htmlElementForButton,
   } = props
 
-  const isAnchor = Boolean(htmlElementForButton === 'ANCHOR')
+  const isAnchor = htmlElementForButton === 'a'
   const showButton = useShowButton(from, products, loading)
   const handles = useCssHandles(CSS_HANDLES)
 

--- a/react/components/loaders/FetchPreviousButton.js
+++ b/react/components/loaders/FetchPreviousButton.js
@@ -19,7 +19,13 @@ const useShowButton = (from, products, loading) => {
 }
 
 const FetchPreviousButton = props => {
-  const { products, from, onFetchPrevious, loading } = props
+  const {
+    products,
+    from,
+    onFetchPrevious,
+    loading,
+    relHtmlAttributeForFetchButtons,
+  } = props
   const showButton = useShowButton(from, products, loading)
   const handles = useCssHandles(CSS_HANDLES)
   return (
@@ -27,6 +33,7 @@ const FetchPreviousButton = props => {
       {showButton && (
         <Button
           onClick={onFetchPrevious}
+          rel={relHtmlAttributeForFetchButtons && 'prev'}
           isLoading={loading}
           size="small"
           key={from} // Necessary to prevent focus after click


### PR DESCRIPTION
#### What problem is this solving?

Currently in VTEX IO, with search result app, the Show More button is rendered without the HTML property rel="next" (or rel="prev" for the Show Previous Button). Since these props are used for SEO we believe their addition would be beneficial

This PR was created for the addition of a prop that allows the rendering of such HTML properties to the Show More or Previous Button.

[issue](https://github.com/vtex-apps/store-discussion/issues/315)

#### How to test it?

You can test it on this [Workspace](https://task315--carrefourbr.myvtex.com/celulares-e-smartphones?crfint=hm|header-menu-departamentos|celular-e-smartphones|1&page=2)

#### Screenshots or example usage:

First you need to add the prop in the `search-fetch-previous` or `search-fetch-more`
![image](https://user-images.githubusercontent.com/19579091/89545542-ddf64200-d7d9-11ea-9624-07daaca9f145.png)

Result
![image](https://user-images.githubusercontent.com/19579091/89353323-872f2200-d68c-11ea-8419-af424c373684.png)

With the addition of this prop the `Button` component turns into a `<a>` html tag.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/NDjtmyXAAUWKQ/giphy.gif)
