### PR TITLE
Fixed focus on `show-more`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Added `key` on `show-more` buttons to prevent focus after pressing them, which was causing the page to be fixed on the button after rendering more results on Google Chrome.
 
 ## [3.67.0] - 2020-08-04
 ### Added

--- a/react/components/loaders/FetchMoreButton.js
+++ b/react/components/loaders/FetchMoreButton.js
@@ -38,7 +38,12 @@ const FetchMoreButton = props => {
     <Fragment>
       <div className={`${handles.buttonShowMore} w-100 flex justify-center`}>
         {showButton && (
-          <Button onClick={onFetchMore} isLoading={loading} size="small">
+          <Button
+            onClick={onFetchMore}
+            isLoading={loading}
+            size="small"
+            key={to}
+          >
             <FormattedMessage id="store/search-result.show-more-button" />
           </Button>
         )}

--- a/react/components/loaders/FetchMoreButton.js
+++ b/react/components/loaders/FetchMoreButton.js
@@ -42,7 +42,7 @@ const FetchMoreButton = props => {
             onClick={onFetchMore}
             isLoading={loading}
             size="small"
-            key={to}
+            key={to} //Necessary to prevent focus after click
           >
             <FormattedMessage id="store/search-result.show-more-button" />
           </Button>

--- a/react/components/loaders/FetchMoreButton.js
+++ b/react/components/loaders/FetchMoreButton.js
@@ -42,7 +42,7 @@ const FetchMoreButton = props => {
             onClick={onFetchMore}
             isLoading={loading}
             size="small"
-            key={to} //Necessary to prevent focus after click
+            key={to} // Necessary to prevent focus after click
           >
             <FormattedMessage id="store/search-result.show-more-button" />
           </Button>

--- a/react/components/loaders/FetchPreviousButton.js
+++ b/react/components/loaders/FetchPreviousButton.js
@@ -25,7 +25,12 @@ const FetchPreviousButton = props => {
   return (
     <div className={`${handles.buttonShowMore} w-100 flex justify-center`}>
       {showButton && (
-        <Button onClick={onFetchPrevious} isLoading={loading} size="small">
+        <Button
+          onClick={onFetchPrevious}
+          isLoading={loading}
+          size="small"
+          key={from}
+        >
           <FormattedMessage id="store/search-result.show-previous-button" />
         </Button>
       )}

--- a/react/components/loaders/FetchPreviousButton.js
+++ b/react/components/loaders/FetchPreviousButton.js
@@ -29,7 +29,7 @@ const FetchPreviousButton = props => {
           onClick={onFetchPrevious}
           isLoading={loading}
           size="small"
-          key={from}
+          key={from} //Necessary to prevent focus after click
         >
           <FormattedMessage id="store/search-result.show-previous-button" />
         </Button>

--- a/react/components/loaders/FetchPreviousButton.js
+++ b/react/components/loaders/FetchPreviousButton.js
@@ -29,7 +29,7 @@ const FetchPreviousButton = props => {
           onClick={onFetchPrevious}
           isLoading={loading}
           size="small"
-          key={from} //Necessary to prevent focus after click
+          key={from} // Necessary to prevent focus after click
         >
           <FormattedMessage id="store/search-result.show-previous-button" />
         </Button>


### PR DESCRIPTION
#### What problem is this solving?

Due to some recent changes on Google Chrome, the `show-more` buttons were having a weird behavior in which the page would keep focused on the button at the bottom of the page, even though new products were rendered:
![Aug-05-2020 14-23-28](https://user-images.githubusercontent.com/8443580/89443935-5ea83600-d727-11ea-92fa-9ee487f7556b.gif)
This PR fixes this issue by adding `key` to these buttons!

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://iaronaraujo--storecomponents.myvtex.com/%20?_q=&map=ft)
Click on show more and check that the page continues where it was before!

![Aug-05-2020 14-27-37](https://user-images.githubusercontent.com/8443580/89444288-e0985f00-d727-11ea-9eb5-894c46e805db.gif)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

My internet is pretty awful right now and I can't open giphy 😭
