### PR TITLE
replace map by mapfield

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Replace `map` by `mapField` in the `LocalQuery` component.
+
 ## [3.69.0] - 2020-08-14
 ### Added
 - Prop `scrollToTop` to `filter-navigator.v3` that scrolls the page to the top when selecting a facet.

--- a/react/components/LocalQuery.js
+++ b/react/components/LocalQuery.js
@@ -33,7 +33,7 @@ const LocalQuery = props => {
     <SearchQuery
       maxItemsPerPage={maxItemsPerPage}
       query={queryField}
-      map={map}
+      map={mapField}
       orderBy={orderBy}
       priceRange={priceRange}
       hideUnavailableItems={hideUnavailableItems}


### PR DESCRIPTION
#### What problem is this solving?

For some reason, the `LocalQuery` is using the `map` parameter in the `SearchQuery` instead of the `mapField`. This is causing a bug: when you search for something and you are redirected to an LP, the map used in the query is `ft` instead of the map set in the LP page.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

Search for `moletom`. On the wrong one, the search will use `ft` as a parameter. On the fixed one, the search will use `productClusterIds` as a parameter.

[Wrong](https://hiago--dzarm.myvtex.com/)
[Fixed](https://hiago--dzarm.myvtex.com/)

