### PR TITLE
Prevent 'SearchResultFlexible' from overflowing on mobile devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Prevent `SearchResultFlexible` from overflowing on mobile devices by setting its width.
 
 ## [3.69.2] - 2020-08-20
 ### Fixed

--- a/react/SearchResultFlexible.js
+++ b/react/SearchResultFlexible.js
@@ -174,7 +174,7 @@ const SearchResultFlexible = ({
                   <div
                     className={`${
                       handles.loadingOverlay
-                    } flex flex-column flex-grow-1 ${generateBlockClass(
+                    } w-100 flex flex-column flex-grow-1 ${generateBlockClass(
                       styles['container--layout'],
                       blockClass
                     )}`}


### PR DESCRIPTION
#### What problem is this solving?

The inner container rendered by the `LoadingOverlay` component doesn't have a set `width` property. This detail allowed it to overflow on mobile devices depending on the components rendered alongside it.

This can be seen on mobile in https://exploding--menudigital.myvtex.com/place/vistacorona.

#### How to test it?

Check these workspaces on mobile. Nothing should be visually different from what you can see in each account's `master` workspace.

- [Store Components](https://victormiranda3--storecomponents.myvtex.com/apparel---accessories)
- [Als](https://victormiranda--alssports.myvtex.com/clothing/Mens?map=c,specificationFilter_7721)
- [Motorola US](https://victormiranda--motorolaus.myvtex.com/smartphones)
- [Erik's Bikes](https://victormiranda--eriksbikeshop.myvtex.com/cycling/bicycles/road)
- [Baby Cottons AR](https://victormiranda--babycottonsar.myvtex.com/ninos/nino)


#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behavior or layout. Example: Before and after images -->

#### Related to / Depends on

This was reported in this card: https://vtex-dev.atlassian.net/browse/SF-283

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/fefZ2NUMZmIjWNokVi/giphy.gif)
