### PR TITLE
Add prop `truncateFilters`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Prop `truncateFilters` that truncates filters with more than 10 options and displays a button to see all.
+
 ## [3.72.0] - 2020-09-09
 ### Added
 - Default seller search to make filters work as well

--- a/docs/README.md
+++ b/docs/README.md
@@ -288,7 +288,7 @@ Check out the [**Product Summary documentation**](https://vtex.io/docs/component
 | `initiallyCollapsed` | `Boolean` | Makes the search filters start out collapsed (`true`) or open (`false`). | `false` |
 | `filtersTitleHtmlTag` | `string` | HTML tag for the filter's title. | `h5` |
 | `scrollToTop` | `enum` | Scrolls the page to the top (`auto` or `smooth`) or not (`none`) when selecting a facet. | `none` |
-| `truncateFilters` | `boolean` | Truncates filters with more than 10 options displaying a button to see all | `false` |
+| `truncateFilters` | `boolean` | Whether a filter selector with more than 10 filter options should shorten the list and display a `See more` button (`true`) or not (`false`). | `false` |
 
 -  **`order-by` block**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -288,6 +288,7 @@ Check out the [**Product Summary documentation**](https://vtex.io/docs/component
 | `initiallyCollapsed` | `Boolean` | Makes the search filters start out collapsed (`true`) or open (`false`). | `false` |
 | `filtersTitleHtmlTag` | `string` | HTML tag for the filter's title. | `h5` |
 | `scrollToTop` | `enum` | Scrolls the page to the top (`auto` or `smooth`) or not (`none`) when selecting a facet. | `none` |
+| `truncateFilters` | `boolean` | Truncates filters with more than 10 options displaying a button to see all | `false` |
 
 -  **`order-by` block**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -426,6 +426,7 @@ In order to apply CSS customization in this and other blocks, follow the instruc
 | `searchNotFoundWhatToDoDots`          |
 | `searchNotFound`                      |
 | `searchResultContainer`               |
+| `seeMoreButton`                       |
 | `selectedFilterItem`                  |
 | `showingProductsContainer`            |
 | `showingProductsCount`                |

--- a/messages/context.json
+++ b/messages/context.json
@@ -59,7 +59,7 @@
   "store/search.filter.title.categories": "Departments",
   "store/filter.more-departments": "See {quantity} more departments",
   "store/filter.more-categories": "See {quantity} more categories",
-  "store/filter.more-items": "See more",
+  "store/filter.more-items": "See {quantity} more",
   "store/filter.less-items": "See less",
   "store/search.filter.placeholder": "Search by {filterName}",
   "store/search.filter.title.brands": "Brands",

--- a/messages/en.json
+++ b/messages/en.json
@@ -59,7 +59,7 @@
   "store/search.filter.title.categories": "Departments",
   "store/filter.more-departments": "See {quantity} more departments",
   "store/filter.more-categories": "See {quantity} more categories",
-  "store/filter.more-items": "See more",
+  "store/filter.more-items": "See {quantity} more",
   "store/filter.less-items": "See less",
   "store/search.filter.placeholder": "Search by {filterName}",
   "store/search.filter.title.brands": "Brands",

--- a/messages/es.json
+++ b/messages/es.json
@@ -59,7 +59,7 @@
   "store/search.filter.title.categories": "Departamentos",
   "store/filter.more-departments": "Ver más {quantity} departamentos",
   "store/filter.more-categories": "Ver más {quantity} categorías",
-  "store/filter.more-items": "Ver más",
+  "store/filter.more-items": "Ver más {quantity}",
   "store/filter.less-items": "Ver menos",
   "store/search.filter.placeholder": "Buscar por {filterName}",
   "store/search.filter.title.brands": "Marcas",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -59,7 +59,7 @@
   "store/search.filter.title.categories": "Departamentos",
   "store/filter.more-departments": "Ver mais {quantity} departamentos",
   "store/filter.more-categories": "Ver mais {quantity} categorias",
-  "store/filter.more-items": "Ver mais",
+  "store/filter.more-items": "Ver mais {quantity}",
   "store/filter.less-items": "Ver menos",
   "store/search.filter.placeholder": "Buscar por {filterName}",
   "store/search.filter.title.brands": "Marcas",

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -67,6 +67,7 @@ const FilterNavigator = ({
   preventRouteChange = false,
   hiddenFacets = {},
   initiallyCollapsed = false,
+  truncateFilters = false,
   layout = LAYOUT_TYPES.responsive,
   maxItemsDepartment = 8,
   maxItemsCategory = 8,
@@ -178,6 +179,7 @@ const FilterNavigator = ({
               preventRouteChange={preventRouteChange}
               initiallyCollapsed={initiallyCollapsed}
               navigateToFacet={navigateToFacet}
+              truncateFilters={truncateFilters}
             />
           </div>
           <ExtensionPoint id="shop-review-summary" />
@@ -209,6 +211,7 @@ FilterNavigator.propTypes = {
   loading: PropTypes.bool,
   layout: PropTypes.oneOf(Object.values(LAYOUT_TYPES)),
   initiallyCollapsed: PropTypes.bool,
+  truncateFilters: PropTypes.bool,
   filtersTitleHtmlTag: PropTypes.string,
   ...hiddenFacetsSchema,
 }

--- a/react/FilterNavigatorFlexible.js
+++ b/react/FilterNavigatorFlexible.js
@@ -15,6 +15,7 @@ const withSearchPageContextProps = Component => ({
   maxItemsDepartment,
   maxItemsCategory,
   filtersTitleHtmlTag,
+  truncateFilters,
 }) => {
   const {
     searchQuery,
@@ -66,6 +67,7 @@ const withSearchPageContextProps = Component => ({
           maxItemsDepartment={maxItemsDepartment}
           maxItemsCategory={maxItemsCategory}
           filtersTitleHtmlTag={filtersTitleHtmlTag}
+          truncateFilters={truncateFilters}
         />
       </FilterNavigatorContext.Provider>
     </div>

--- a/react/components/AvailableFilters.js
+++ b/react/components/AvailableFilters.js
@@ -23,6 +23,7 @@ const Filter = ({
   initiallyCollapsed,
   navigateToFacet,
   lazyRender,
+  truncateFilters = false,
 }) => {
   const { type, title, facets, oneSelectedCollapse = false } = filter
 
@@ -48,6 +49,7 @@ const Filter = ({
           initiallyCollapsed={initiallyCollapsed}
           navigateToFacet={navigateToFacet}
           lazyRender={lazyRender}
+          truncateFilters={truncateFilters}
         />
       )
   }
@@ -67,6 +69,7 @@ AvailableFilters.propTypes = {
   /** Prevent route changes */
   preventRouteChange: PropTypes.bool,
   initiallyCollapsed: PropTypes.bool,
+  truncateFilters: PropTypes.bool,
 }
 
 export default AvailableFilters

--- a/react/components/FilterOptionTemplate.js
+++ b/react/components/FilterOptionTemplate.js
@@ -83,6 +83,7 @@ const FilterOptionTemplate = ({
   const { thresholdForFacetSearch } = useSettings()
   const [searchTerm, setSearchTerm] = useState('')
   const [truncated, setTruncated] = useState(true)
+  const maxItemsThreshold = 12
 
   const isLazyRenderEnabled = getSettings('vtex.store')
     ?.enableSearchRenderingOptimization
@@ -116,7 +117,9 @@ const FilterOptionTemplate = ({
 
     const endSlice =
       shouldLazyRender ||
-      (truncateFilters && truncated && filteredFacets.length >= 12)
+      (truncateFilters &&
+        truncated &&
+        filteredFacets.length >= maxItemsThreshold)
         ? RENDER_THRESHOLD
         : filteredFacets.length
 
@@ -124,7 +127,7 @@ const FilterOptionTemplate = ({
       <>
         {filteredFacets.slice(0, endSlice).map(children)}
         {placeholderSize > 0 && <div style={{ height: placeholderSize }} />}
-        {truncateFilters && filteredFacets.length >= 12 && (
+        {truncateFilters && filteredFacets.length >= maxItemsThreshold && (
           <button
             onClick={() => setTruncated(truncated => !truncated)}
             className="mt2 pv2 bn pointer"
@@ -243,7 +246,7 @@ FilterOptionTemplate.propTypes = {
   initiallyCollapsed: PropTypes.bool,
   /** Internal prop, whether this component should be rendered only on view */
   lazyRender: PropTypes.bool,
-  /** When `true`, truncates filters with more than ten options displaying a button to see all */
+  /** When `true`, truncates filters with more than 10 options displaying a button to see all */
   truncateFilters: PropTypes.bool,
 }
 

--- a/react/components/FilterOptionTemplate.js
+++ b/react/components/FilterOptionTemplate.js
@@ -106,9 +106,6 @@ const FilterOptionTemplate = ({
     )
   }, [filters, searchTerm, thresholdForFacetSearch])
 
-  const shouldTruncate =
-    truncateFilters && filteredFacets.length >= MAX_ITEMS_THRESHOLD
-
   const renderChildren = () => {
     if (typeof children !== 'function') {
       return children
@@ -119,6 +116,11 @@ const FilterOptionTemplate = ({
     const placeholderSize = shouldLazyRender
       ? (filters.length - RENDER_THRESHOLD) * 34
       : 0
+
+    const shouldTruncate =
+      !isLazyRenderEnabled &&
+      truncateFilters &&
+      filteredFacets.length >= MAX_ITEMS_THRESHOLD
 
     const endSlice =
       shouldLazyRender || (shouldTruncate && truncated)
@@ -209,7 +211,9 @@ const FilterOptionTemplate = ({
           pb5: !collapsable || open,
         })}
         ref={scrollable}
-        style={!truncateFilters ? { maxHeight: '200px' } : {}}
+        style={
+          !truncateFilters || isLazyRenderEnabled ? { maxHeight: '200px' } : {}
+        }
         aria-hidden={!open}
       >
         {!hasBeenViewed ? (

--- a/react/components/SearchFilter.js
+++ b/react/components/SearchFilter.js
@@ -57,7 +57,7 @@ SearchFilter.propTypes = {
   initiallyCollapsed: PropTypes.bool,
   navigateToFacet: PropTypes.func,
   lazyRender: PropTypes.bool,
-  /** When `true`, truncates filters with more than ten options displaying a button to see all */
+  /** When `true`, truncates filters with more than 10 options displaying a button to see all */
   truncateFilters: PropTypes.bool,
 }
 

--- a/react/components/SearchFilter.js
+++ b/react/components/SearchFilter.js
@@ -18,6 +18,7 @@ const SearchFilter = ({
   initiallyCollapsed = false,
   navigateToFacet,
   lazyRender = false,
+  truncateFilters = false,
 }) => {
   const sampleFacet = facets && facets.length > 0 ? facets[0] : null
   const facetTitle = getFilterTitle(title, intl)
@@ -29,6 +30,7 @@ const SearchFilter = ({
       filters={facets}
       initiallyCollapsed={initiallyCollapsed}
       lazyRender={lazyRender}
+      truncateFilters={truncateFilters}
     >
       {facet => (
         <FacetItem
@@ -55,6 +57,8 @@ SearchFilter.propTypes = {
   initiallyCollapsed: PropTypes.bool,
   navigateToFacet: PropTypes.func,
   lazyRender: PropTypes.bool,
+  /** When `true`, truncates filters with more than ten options displaying a button to see all */
+  truncateFilters: PropTypes.bool,
 }
 
 export default injectIntl(SearchFilter)


### PR DESCRIPTION
#### What problem is this solving?
Following the [Baymard guidelines](https://baymard.com/premium/guidelines/470), it allows to display the filters truncated, followed by a button with the option to see all or see less.

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://truncate--alssports.myvtex.com/shirts?_q=shirts&fuzzy=0&map=ft&operator=and&query=/shirts)

#### Screenshots or example usage:
![truncated](https://user-images.githubusercontent.com/20840671/91992087-1a01c180-ed0a-11ea-8bfc-421f41548a4e.gif)


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
