### PR TITLE
Lazy render gallery rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Lazy renders gallery rows
 
 ## [3.70.0] - 2020-09-03
 

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -18,6 +18,8 @@ import SettingsContext from './components/SettingsContext'
 /** Layout with one column */
 const ONE_COLUMN_LAYOUT = 1
 
+const LAZY_RENDER_THRESHOLD = 2
+
 const CSS_HANDLES = ['gallery']
 
 const { ProductListProvider } = ProductListContext
@@ -89,6 +91,7 @@ const Gallery = ({
             key={index.toString()}
             widthAvailable={width != null}
             products={rowProducts}
+            lazyRender={index >= LAZY_RENDER_THRESHOLD}
             summary={summary}
             displayMode={layoutMode}
             rowIndex={index}

--- a/react/components/GalleryRow.js
+++ b/react/components/GalleryRow.js
@@ -23,6 +23,9 @@ const GalleryRow = ({
     maxWidth: `${100 / itemsPerRow}%`,
   }
 
+  /** if lazyRender is true, only renders the actual content once "dummy"
+   * is inside the viewport
+   */
   useOnView({
     ref: dummy,
     onView: () => setHasBeenViewed(true),
@@ -56,6 +59,8 @@ const GalleryRow = ({
         width: '100%',
         height: 400,
         position: 'relative',
+        /** Pulls the object 200px up so it renders a bit earlier,
+         * before the user would actually see the content */
         top: -200,
       }}
     />

--- a/react/components/GalleryRow.js
+++ b/react/components/GalleryRow.js
@@ -1,6 +1,5 @@
-import React, { useRef, useEffect, memo } from 'react'
-import { useInView } from 'react-intersection-observer'
-import { usePixel } from 'vtex.pixel-manager/PixelContext'
+import React, { useRef, memo, useState } from 'react'
+import { useOnView } from '../hooks/useOnView'
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 import classNames from 'classnames'
 
@@ -8,31 +7,59 @@ import GalleryItem from './GalleryItem'
 
 const CSS_HANDLES = ['galleryItem']
 
-const GalleryRow = ({ products, summary, displayMode, itemsPerRow }) => {
+const GalleryRow = ({
+  products,
+  summary,
+  displayMode,
+  itemsPerRow,
+  lazyRender,
+}) => {
+  const dummy = useRef()
   const handles = useCssHandles(CSS_HANDLES)
+  const [hasBeenViewed, setHasBeenViewed] = useState(!lazyRender)
 
   const style = {
     flexBasis: `${100 / itemsPerRow}%`,
     maxWidth: `${100 / itemsPerRow}%`,
   }
-  return products.map(product => {
-    return (
-      <div
-        key={product.productId}
-        style={style}
-        className={classNames(
-          applyModifiers(handles.galleryItem, displayMode),
-          'pa4'
-        )}
-      >
-        <GalleryItem
-          item={product}
-          summary={summary}
-          displayMode={displayMode}
-        />
-      </div>
-    )
+
+  useOnView({
+    ref: dummy,
+    onView: () => setHasBeenViewed(true),
+    once: true,
+    initializeOnInteraction: true,
   })
+
+  return hasBeenViewed ? (
+    products.map(product => {
+      return (
+        <div
+          key={product.productId}
+          style={style}
+          className={classNames(
+            applyModifiers(handles.galleryItem, displayMode),
+            'pa4'
+          )}
+        >
+          <GalleryItem
+            item={product}
+            summary={summary}
+            displayMode={displayMode}
+          />
+        </div>
+      )
+    })
+  ) : (
+    <div
+      ref={dummy}
+      style={{
+        width: '100%',
+        height: 400,
+        position: 'relative',
+        top: -200,
+      }}
+    />
+  )
 }
 
 export default memo(GalleryRow)

--- a/react/hooks/useOnView.ts
+++ b/react/hooks/useOnView.ts
@@ -1,0 +1,103 @@
+import { useEffect, useRef, MutableRefObject } from 'react'
+
+interface IntersectionEvent {
+  entry: IntersectionObserverEntry
+  unobserve: () => void
+}
+
+interface HookOptions {
+  ref: MutableRefObject<HTMLElement | null>
+  onView?: (event: IntersectionEvent) => any
+  threshold?: number
+  once?: boolean
+  bailOut?: boolean
+  initializeOnInteraction?: boolean
+}
+
+/** Hook for detecting when an element is inside the viewport.
+ * Differs from react-intersection-observer (https://www.npmjs.com/package/react-intersection-observer)
+ * in that this hook doesn't use setState, using a callback approach instead, to improve
+ * performance by preventing re-rendering.
+ */
+const useOnView = ({
+  ref,
+  onView,
+  threshold = 0,
+  once = false,
+  bailOut = false,
+  initializeOnInteraction = false,
+}: HookOptions) => {
+  const isObserving = useRef(false)
+  const didIntersect = useRef(false)
+
+  useEffect(() => {
+    const initializeObserver = () => {
+      const element = ref.current
+
+      if (
+        bailOut ||
+        isObserving.current ||
+        !element ||
+        !onView ||
+        (once && didIntersect.current)
+      ) {
+        return () => {}
+      }
+
+      isObserving.current = true
+
+      const unobserve = () => {
+        if (isObserving.current) {
+          observer.unobserve(element)
+          isObserving.current = false
+        }
+      }
+
+      const observer = new IntersectionObserver(([entry]) => {
+        if (!entry.isIntersecting) {
+          return
+        }
+
+        if (entry.intersectionRatio < threshold) {
+          return
+        }
+
+        if (once) {
+          unobserve()
+        }
+
+        didIntersect.current = true
+        onView({ entry, unobserve })
+      })
+
+      observer.observe(element)
+
+      return unobserve
+    }
+
+    if (initializeOnInteraction) {
+      const cleanUpEvents = () => {
+        window?.document?.removeEventListener('scroll', handleInteraction)
+        window?.document?.removeEventListener('mouseover', handleInteraction)
+      }
+
+      let unobserve = () => {
+        cleanUpEvents()
+      }
+
+      const handleInteraction = () => {
+        cleanUpEvents()
+        unobserve = initializeObserver()
+      }
+
+      window?.document?.addEventListener('scroll', handleInteraction)
+      window?.document?.addEventListener('mouseover', handleInteraction)
+
+      return unobserve
+    }
+
+    return initializeObserver()
+  }, [bailOut, initializeOnInteraction, onView, once, ref, threshold])
+}
+
+export { useOnView }


### PR DESCRIPTION
#### What problem is this solving?
As the title says.

Improves performance a bit, and is relatively simple and safe.

Before:
<img width="456" alt="Screen Shot 2020-09-05 at 16 22 32" src="https://user-images.githubusercontent.com/5691711/92312279-a4118a80-ef95-11ea-88e2-e8642179cbaa.png">

After:
<img width="710" alt="Screen Shot 2020-09-05 at 16 22 29" src="https://user-images.githubusercontent.com/5691711/92312281-aa076b80-ef95-11ea-8482-fb1734719b30.png">



<!--- What is the motivation and context for this change? -->

#### How to test it?
https://www.carrefour.com.br/Celulares-Smartphones-e-Smartwatches/Smartphones?crfimt=hm-tlink|carrefour|menu|campanha|smartphones|1|120820&workspace=lbebbersearch1&ak-testab=vtex

Scroll down fast to see the content appearing. Scroll down at a normal pace to see how the user would perceive it.

<!--- Don't forget to add a link to a Workspace where this branch is linked -->


#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
