### PR TITLE
Feature/lazy rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Lazy renders gallery rows
 
 ## [3.70.0] - 2020-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Changed
-- Lazy renders gallery rows
+### Added
+- Lazy gallery rows rendering
+- Lazy facet rendering, both individual facets and facet groups
 
 ## [3.70.0] - 2020-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Immediate feedback on facet selection
+
 ### Added
 - Lazy gallery rows rendering
 - Lazy facet rendering, both individual facets and facet groups

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -18,6 +18,8 @@ import SettingsContext from './components/SettingsContext'
 /** Layout with one column */
 const ONE_COLUMN_LAYOUT = 1
 
+const LAZY_RENDER_THRESHOLD = 2
+
 const CSS_HANDLES = ['gallery']
 
 const { ProductListProvider } = ProductListContext
@@ -89,6 +91,7 @@ const Gallery = ({
             key={index.toString()}
             widthAvailable={width != null}
             products={rowProducts}
+            lazyRender={index >= LAZY_RENDER_THRESHOLD}
             summary={summary}
             displayMode={layoutMode}
             rowIndex={index}

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -7,6 +7,7 @@ import { useDevice } from 'vtex.device-detector'
 import { ProductListContext } from 'vtex.product-list-context'
 import { useResponsiveValue } from 'vtex.responsive-values'
 import { useCssHandles } from 'vtex.css-handles'
+import { useRuntime } from 'vtex.render-runtime'
 
 import { LAYOUT_MODE } from './components/LayoutModeSwitcher'
 import { productShape } from './constants/propTypes'
@@ -42,6 +43,7 @@ const Gallery = ({
   const { isMobile } = useDevice()
   const { trackingId = 'Search result' } = useContext(SettingsContext) || {}
   const handles = useCssHandles(CSS_HANDLES)
+  const { getSettings } = useRuntime()
   const responsiveMaxItemsPerRow = useResponsiveValue(maxItemsPerRow)
 
   const layoutMode = isMobile ? mobileLayoutMode : 'normal'
@@ -83,6 +85,9 @@ const Gallery = ({
     }
   )
 
+  const isLazyRenderEnabled = getSettings('vtex.store')
+    ?.enableSearchRenderingOptimization
+
   return (
     <ProductListProvider listName={trackingId}>
       <div className={galleryClasses}>
@@ -91,7 +96,7 @@ const Gallery = ({
             key={index.toString()}
             widthAvailable={width != null}
             products={rowProducts}
-            lazyRender={index >= LAZY_RENDER_THRESHOLD}
+            lazyRender={isLazyRenderEnabled && index >= LAZY_RENDER_THRESHOLD}
             summary={summary}
             displayMode={layoutMode}
             rowIndex={index}

--- a/react/__tests__/FilterNavigator.test.js
+++ b/react/__tests__/FilterNavigator.test.js
@@ -15,10 +15,11 @@ const mockNavigate = jest.fn()
 const mockSetQuery = jest.fn()
 beforeEach(() => {
   jest.clearAllMocks()
-  
+
   mockUseRuntime.mockImplementation(() => ({
     navigate: mockNavigate,
     setQuery: mockSetQuery,
+    getSettings: () => ({}),
   }))
 })
 

--- a/react/__tests__/Gallery.test.js
+++ b/react/__tests__/Gallery.test.js
@@ -6,6 +6,17 @@ import { products, summary } from 'GalleryMocks'
 
 import Gallery from '../Gallery'
 
+import { useRuntime } from '../__mocks__/vtex.render-runtime'
+const mockUseRuntime = useRuntime
+
+beforeEach(() => {
+  jest.clearAllMocks()
+
+  mockUseRuntime.mockImplementation(() => ({
+    getSettings: () => ({}),
+  }))
+})
+
 describe('<Gallery />', () => {
   const renderComponent = customProps => {
     const props = {

--- a/react/components/AvailableFilters.js
+++ b/react/components/AvailableFilters.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
+import { useRuntime } from 'vtex.render-runtime'
+
 import SearchFilter from './SearchFilter'
 import PriceRange from './PriceRange'
 import { useRenderOnView } from '../hooks/useRenderOnView'
@@ -25,7 +27,13 @@ const Filter = ({
   navigateToFacet,
   lazyRender,
 }) => {
-  const { hasBeenViewed, dummyElement } = useRenderOnView({ lazyRender })
+  const { getSettings } = useRuntime()
+  const isLazyRenderEnabled = getSettings('vtex.store')
+    ?.enableSearchRenderingOptimization
+
+  const { hasBeenViewed, dummyElement } = useRenderOnView({
+    lazyRender: isLazyRenderEnabled && lazyRender,
+  })
 
   if (!hasBeenViewed) {
     return dummyElement

--- a/react/components/AvailableFilters.js
+++ b/react/components/AvailableFilters.js
@@ -7,7 +7,7 @@ import SearchFilter from './SearchFilter'
 import PriceRange from './PriceRange'
 import { useRenderOnView } from '../hooks/useRenderOnView'
 
-const LAZY_RENDER_THRESHOD = 3
+const LAZY_RENDER_THRESHOLD = 3
 
 const AvailableFilters = ({ filters = [], ...props }) =>
   filters.map((filter, i) => (
@@ -15,7 +15,7 @@ const AvailableFilters = ({ filters = [], ...props }) =>
       filter={filter}
       {...props}
       key={filter.title}
-      lazyRender={i >= LAZY_RENDER_THRESHOD}
+      lazyRender={i >= LAZY_RENDER_THRESHOLD}
     />
   ))
 

--- a/react/components/AvailableFilters.js
+++ b/react/components/AvailableFilters.js
@@ -3,42 +3,61 @@ import PropTypes from 'prop-types'
 
 import SearchFilter from './SearchFilter'
 import PriceRange from './PriceRange'
+import { useRenderOnView } from '../hooks/useRenderOnView'
 
-const AvailableFilters = ({
-  filters = [],
+const LAZY_RENDER_THRESHOD = 3
+
+const AvailableFilters = ({ filters = [], ...props }) =>
+  filters.map((filter, i) => (
+    <Filter
+      filter={filter}
+      {...props}
+      key={filter.title}
+      lazyRender={i >= LAZY_RENDER_THRESHOD}
+    />
+  ))
+
+const Filter = ({
+  filter,
   priceRange,
-  preventRouteChange = false,
-  initiallyCollapsed = false,
+  preventRouteChange,
+  initiallyCollapsed,
   navigateToFacet,
-}) =>
-  filters.map(filter => {
-    const { type, title, facets, oneSelectedCollapse = false } = filter
+  lazyRender,
+}) => {
+  const { hasBeenViewed, dummyElement } = useRenderOnView({ lazyRender })
 
-    switch (type) {
-      case 'PriceRanges':
-        return (
-          <PriceRange
-            key={title}
-            title={title}
-            facets={facets}
-            priceRange={priceRange}
-            preventRouteChange={preventRouteChange}
-          />
-        )
-      default:
-        return (
-          <SearchFilter
-            key={title}
-            title={title}
-            facets={facets}
-            oneSelectedCollapse={oneSelectedCollapse}
-            preventRouteChange={preventRouteChange}
-            initiallyCollapsed={initiallyCollapsed}
-            navigateToFacet={navigateToFacet}
-          />
-        )
-    }
-  })
+  if (!hasBeenViewed) {
+    return dummyElement
+  }
+
+  const { type, title, facets, oneSelectedCollapse = false } = filter
+
+  switch (type) {
+    case 'PriceRanges':
+      return (
+        <PriceRange
+          key={title}
+          title={title}
+          facets={facets}
+          priceRange={priceRange}
+          preventRouteChange={preventRouteChange}
+        />
+      )
+    default:
+      return (
+        <SearchFilter
+          key={title}
+          title={title}
+          facets={facets}
+          oneSelectedCollapse={oneSelectedCollapse}
+          preventRouteChange={preventRouteChange}
+          initiallyCollapsed={initiallyCollapsed}
+          navigateToFacet={navigateToFacet}
+        />
+      )
+  }
+}
 
 AvailableFilters.propTypes = {
   /** Filters to be displayed */

--- a/react/components/FacetItem.js
+++ b/react/components/FacetItem.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { useContext, useState } from 'react'
 import { Checkbox } from 'vtex.styleguide'
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 import classNames from 'classnames'
@@ -26,6 +26,7 @@ const FacetItem = ({
   preventRouteChange,
 }) => {
   const { showFacetQuantity } = useContext(SettingsContext)
+  const [selected, setSelected] = useState(facet.selected)
   const handles = useCssHandles(CSS_HANDLES)
   const classes = classNames(
     applyModifiers(handles.filterItem, facet.value),
@@ -45,14 +46,15 @@ const FacetItem = ({
     >
       <Checkbox
         id={checkBoxId}
-        checked={facet.selected}
+        checked={selected}
         label={
           showFacetQuantity ? `${facet.name} (${facet.quantity})` : facet.name
         }
         name={facet.name}
-        onChange={() =>
+        onChange={() => {
+          setSelected(!selected)
           navigateToFacet({ ...facet, title: facetTitle }, preventRouteChange)
-        }
+        }}
         value={facet.name}
       />
     </div>

--- a/react/components/FilterOptionTemplate.js
+++ b/react/components/FilterOptionTemplate.js
@@ -89,7 +89,7 @@ const FilterOptionTemplate = ({
 
     /** Renders only ${threshold} items on the list until the user scrolls,
      * for improved rendering performance */
-    const threshold = 7
+    const threshold = 10
 
     /** Inexact measure but good enough for displaying a properly sized scrollbar */
     const placeholderSize = hasScrolled ? 0 : (filters.length - threshold) * 34

--- a/react/components/GalleryRow.js
+++ b/react/components/GalleryRow.js
@@ -1,5 +1,5 @@
-import React, { useRef, memo, useState } from 'react'
-import { useOnView } from '../hooks/useOnView'
+import React, { memo } from 'react'
+import { useRenderOnView } from '../hooks/useRenderOnView'
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 import classNames from 'classnames'
 
@@ -14,57 +14,37 @@ const GalleryRow = ({
   itemsPerRow,
   lazyRender,
 }) => {
-  const dummy = useRef()
   const handles = useCssHandles(CSS_HANDLES)
-  const [hasBeenViewed, setHasBeenViewed] = useState(!lazyRender)
 
   const style = {
     flexBasis: `${100 / itemsPerRow}%`,
     maxWidth: `${100 / itemsPerRow}%`,
   }
 
-  /** if lazyRender is true, only renders the actual content once "dummy"
-   * is inside the viewport
-   */
-  useOnView({
-    ref: dummy,
-    onView: () => setHasBeenViewed(true),
-    once: true,
-    initializeOnInteraction: true,
-  })
+  const { hasBeenViewed, dummyElement } = useRenderOnView({ lazyRender })
 
-  return hasBeenViewed ? (
-    products.map(product => {
-      return (
-        <div
-          key={product.productId}
-          style={style}
-          className={classNames(
-            applyModifiers(handles.galleryItem, displayMode),
-            'pa4'
-          )}
-        >
-          <GalleryItem
-            item={product}
-            summary={summary}
-            displayMode={displayMode}
-          />
-        </div>
-      )
-    })
-  ) : (
-    <div
-      ref={dummy}
-      style={{
-        width: '100%',
-        height: 400,
-        position: 'relative',
-        /** Pulls the object 200px up so it renders a bit earlier,
-         * before the user would actually see the content */
-        top: -200,
-      }}
-    />
-  )
+  if (!hasBeenViewed) {
+    return dummyElement
+  }
+
+  return products.map(product => {
+    return (
+      <div
+        key={product.productId}
+        style={style}
+        className={classNames(
+          applyModifiers(handles.galleryItem, displayMode),
+          'pa4'
+        )}
+      >
+        <GalleryItem
+          item={product}
+          summary={summary}
+          displayMode={displayMode}
+        />
+      </div>
+    )
+  })
 }
 
 export default memo(GalleryRow)

--- a/react/components/GalleryRow.js
+++ b/react/components/GalleryRow.js
@@ -23,6 +23,9 @@ const GalleryRow = ({
     maxWidth: `${100 / itemsPerRow}%`,
   }
 
+  /** if lazyRender is true, only renders the actual content once "dummy"
+   * is inside the viewport
+   */
   useOnView({
     ref: dummy,
     onView: () => setHasBeenViewed(true),
@@ -56,6 +59,8 @@ const GalleryRow = ({
         width: '100%',
         height: 400,
         position: 'relative',
+        /** Pulls the object 200px up so it renders a bit earlier,
+         * before the user would actually see the content */
         top: -200,
       }}
     />

--- a/react/components/GalleryRow.js
+++ b/react/components/GalleryRow.js
@@ -1,6 +1,5 @@
-import React, { useRef, useEffect, memo } from 'react'
-import { useInView } from 'react-intersection-observer'
-import { usePixel } from 'vtex.pixel-manager/PixelContext'
+import React, { useRef, memo, useState } from 'react'
+import { useOnView } from '../hooks/useOnView'
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 import classNames from 'classnames'
 
@@ -8,31 +7,59 @@ import GalleryItem from './GalleryItem'
 
 const CSS_HANDLES = ['galleryItem']
 
-const GalleryRow = ({ products, summary, displayMode, itemsPerRow }) => {
+const GalleryRow = ({
+  products,
+  summary,
+  displayMode,
+  itemsPerRow,
+  lazyRender,
+}) => {
+  const dummy = useRef()
   const handles = useCssHandles(CSS_HANDLES)
+  const [hasBeenViewed, setHasBeenViewed] = useState(!lazyRender)
 
   const style = {
     flexBasis: `${100 / itemsPerRow}%`,
     maxWidth: `${100 / itemsPerRow}%`,
   }
-  return products.map(product => {
-    return (
-      <div
-        key={product.productId}
-        style={style}
-        className={classNames(
-          applyModifiers(handles.galleryItem, displayMode),
-          'pa4'
-        )}
-      >
-        <GalleryItem
-          item={product}
-          summary={summary}
-          displayMode={displayMode}
-        />
-      </div>
-    )
+
+  useOnView({
+    ref: dummy,
+    onView: () => setHasBeenViewed(true),
+    once: true,
+    initializeOnInteraction: true,
   })
+
+  return hasBeenViewed ? (
+    products.map(product => {
+      return (
+        <div
+          key={product.productId}
+          style={style}
+          className={classNames(
+            applyModifiers(handles.galleryItem, displayMode),
+            'pa4'
+          )}
+        >
+          <GalleryItem
+            item={product}
+            summary={summary}
+            displayMode={displayMode}
+          />
+        </div>
+      )
+    })
+  ) : (
+    <div
+      ref={dummy}
+      style={{
+        width: '100%',
+        height: 400,
+        position: 'relative',
+        top: -200,
+      }}
+    />
+  )
 }
 
 export default memo(GalleryRow)

--- a/react/hooks/useOnView.ts
+++ b/react/hooks/useOnView.ts
@@ -1,0 +1,103 @@
+import { useEffect, useRef, MutableRefObject } from 'react'
+
+interface IntersectionEvent {
+  entry: IntersectionObserverEntry
+  unobserve: () => void
+}
+
+interface HookOptions {
+  ref: MutableRefObject<HTMLElement | null>
+  onView?: (event: IntersectionEvent) => any
+  threshold?: number
+  once?: boolean
+  bailOut?: boolean
+  initializeOnInteraction?: boolean
+}
+
+/** Hook for detecting when an element is inside the viewport.
+ * Differs from react-intersection-observer (https://www.npmjs.com/package/react-intersection-observer)
+ * in that this hook doesn't use setState, using a callback approach instead, to improve
+ * performance by preventing re-rendering.
+ */
+const useOnView = ({
+  ref,
+  onView,
+  threshold = 0,
+  once = false,
+  bailOut = false,
+  initializeOnInteraction = false,
+}: HookOptions) => {
+  const isObserving = useRef(false)
+  const didIntersect = useRef(false)
+
+  useEffect(() => {
+    const initializeObserver = () => {
+      const element = ref.current
+
+      if (
+        bailOut ||
+        isObserving.current ||
+        !element ||
+        !onView ||
+        (once && didIntersect.current)
+      ) {
+        return () => {}
+      }
+
+      isObserving.current = true
+
+      const unobserve = () => {
+        if (isObserving.current) {
+          observer.unobserve(element)
+          isObserving.current = false
+        }
+      }
+
+      const observer = new IntersectionObserver(([entry]) => {
+        if (!entry.isIntersecting) {
+          return
+        }
+
+        if (entry.intersectionRatio < threshold) {
+          return
+        }
+
+        if (once) {
+          unobserve()
+        }
+
+        didIntersect.current = true
+        onView({ entry, unobserve })
+      })
+
+      observer.observe(element)
+
+      return unobserve
+    }
+
+    if (initializeOnInteraction) {
+      const cleanUpEvents = () => {
+        window?.document?.removeEventListener('scroll', handleInteraction)
+        window?.document?.removeEventListener('mouseover', handleInteraction)
+      }
+
+      let unobserve = () => {
+        cleanUpEvents()
+      }
+
+      const handleInteraction = () => {
+        cleanUpEvents()
+        unobserve = initializeObserver()
+      }
+
+      window?.document?.addEventListener('scroll', handleInteraction)
+      window?.document?.addEventListener('mouseover', handleInteraction)
+
+      return unobserve
+    }
+
+    return initializeObserver()
+  }, [bailOut, initializeOnInteraction, onView, once, ref, threshold])
+}
+
+export { useOnView }

--- a/react/hooks/useOnView.ts
+++ b/react/hooks/useOnView.ts
@@ -1,3 +1,4 @@
+/** Code borrowed from vtex.render-runtime. Maybe it should export this in the future */
 import { useEffect, useRef, MutableRefObject } from 'react'
 
 interface IntersectionEvent {

--- a/react/hooks/useRenderOnView.tsx
+++ b/react/hooks/useRenderOnView.tsx
@@ -1,0 +1,33 @@
+import { useOnView } from './useOnView'
+import React, { useState, useRef } from 'react'
+
+const useRenderOnView = ({ lazyRender = false, height = 400 }) => {
+  const dummy = useRef<HTMLDivElement | null>(null)
+  const [hasBeenViewed, setHasBeenViewed] = useState(false)
+
+  useOnView({
+    ref: dummy,
+    onView: () => setHasBeenViewed(true),
+    once: true,
+    initializeOnInteraction: true,
+    bailOut: !lazyRender,
+  })
+
+  const dummyElement = (
+    <div
+      ref={dummy}
+      style={{
+        width: '100%',
+        height,
+        position: 'relative',
+        /** Pulls the object 200px up so it renders a bit earlier,
+         * before the user would actually see the content */
+        top: -200,
+      }}
+    />
+  )
+
+  return { hasBeenViewed: hasBeenViewed || !lazyRender, dummyElement }
+}
+
+export { useRenderOnView }


### PR DESCRIPTION
#### What problem is this solving?
Lazy renders search content (both facets and items), enabled under a setting (https://github.com/vtex-apps/store/pull/485)

There might be minor visual issues while scrolling (blank items for a fraction of a second while scrolling) which should be adjusted later, but performance is the more pressing issue currently.

Before (rendering time of page components, dev workspace, react profiler):
<img width="1018" alt="Screen Shot 2020-09-07 at 17 04 40" src="https://user-images.githubusercontent.com/5691711/92417520-08208400-f139-11ea-96b3-92ffbd8ff8a9.png">

After (rendering time of page components, dev workspace, react profiler):
<img width="564" alt="Screen Shot 2020-09-07 at 17 06 05" src="https://user-images.githubusercontent.com/5691711/92417530-14a4dc80-f139-11ea-8b32-200fba87a145.png">

Before (total hydration time, prod workspace)
<img width="725" alt="Screen Shot 2020-09-07 at 17 13 03" src="https://user-images.githubusercontent.com/5691711/92417553-28e8d980-f139-11ea-836d-6f48ab3c9c12.png">

After (total hydration time, prod workspace)
<img width="459" alt="Screen Shot 2020-09-07 at 17 11 47" src="https://user-images.githubusercontent.com/5691711/92417563-3900b900-f139-11ea-8bb1-0cbb7aa4f241.png">

(Note that most of the remaining hydration time is spent processing the huge query, not on the components themselves)
<img width="506" alt="Screen Shot 2020-09-07 at 17 12 03" src="https://user-images.githubusercontent.com/5691711/92417590-57ff4b00-f139-11ea-8d2a-30d1674b93df.png">
<img width="512" alt="Screen Shot 2020-09-07 at 17 12 09" src="https://user-images.githubusercontent.com/5691711/92417593-59c90e80-f139-11ea-93a5-880d901c896e.png">


#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

Just scroll around the page and the facets to see if it's okay

Dev workspace:
https://lbebberlazy2--carrefourbr.myvtex.com/Celulares-Smartphones-e-Smartwatches/Smartphones?crfimt=hm-tlink|carrefour|menu|campanha|smartphones|1|120820

Prod workspace:
https://www.carrefour.com.br/Celulares-Smartphones-e-Smartwatches/Smartphones?workspace=lbebberlazysearch2&ak-testab=vtex

Navigate between "TV" and "Smartphones" a few times to see the performance difference, comparing with  https://www.carrefour.com.br/Celulares-Smartphones-e-Smartwatches/Smartphones?ak-testab=vtex


#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
