### PR TITLE
Fix/lazy rendering ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [3.71.0] - 2020-09-07
+### Fixed
+- Always render the container of lazy rendered filter groups; this fixes some issues regarding ordering and CSS customization of filters.
 
 ## [3.71.0] - 2020-09-07
 ### Changed

--- a/react/components/AvailableFilters.js
+++ b/react/components/AvailableFilters.js
@@ -1,11 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import { useRuntime } from 'vtex.render-runtime'
-
 import SearchFilter from './SearchFilter'
 import PriceRange from './PriceRange'
-import { useRenderOnView } from '../hooks/useRenderOnView'
 
 const LAZY_RENDER_THRESHOLD = 3
 
@@ -27,18 +24,6 @@ const Filter = ({
   navigateToFacet,
   lazyRender,
 }) => {
-  const { getSettings } = useRuntime()
-  const isLazyRenderEnabled = getSettings('vtex.store')
-    ?.enableSearchRenderingOptimization
-
-  const { hasBeenViewed, dummyElement } = useRenderOnView({
-    lazyRender: isLazyRenderEnabled && lazyRender,
-  })
-
-  if (!hasBeenViewed) {
-    return dummyElement
-  }
-
   const { type, title, facets, oneSelectedCollapse = false } = filter
 
   switch (type) {
@@ -62,6 +47,7 @@ const Filter = ({
           preventRouteChange={preventRouteChange}
           initiallyCollapsed={initiallyCollapsed}
           navigateToFacet={navigateToFacet}
+          lazyRender={lazyRender}
         />
       )
   }

--- a/react/components/SearchFilter.js
+++ b/react/components/SearchFilter.js
@@ -17,6 +17,7 @@ const SearchFilter = ({
   preventRouteChange = false,
   initiallyCollapsed = false,
   navigateToFacet,
+  lazyRender = false,
 }) => {
   const sampleFacet = facets && facets.length > 0 ? facets[0] : null
   const facetTitle = getFilterTitle(title, intl)
@@ -27,6 +28,7 @@ const SearchFilter = ({
       title={facetTitle}
       filters={facets}
       initiallyCollapsed={initiallyCollapsed}
+      lazyRender={lazyRender}
     >
       {facet => (
         <FacetItem
@@ -52,6 +54,7 @@ SearchFilter.propTypes = {
   preventRouteChange: PropTypes.bool,
   initiallyCollapsed: PropTypes.bool,
   navigateToFacet: PropTypes.func,
+  lazyRender: PropTypes.bool,
 }
 
 export default injectIntl(SearchFilter)

--- a/react/hooks/useRenderOnView.tsx
+++ b/react/hooks/useRenderOnView.tsx
@@ -1,7 +1,11 @@
 import { useOnView } from './useOnView'
 import React, { useState, useRef } from 'react'
 
-const useRenderOnView = ({ lazyRender = false, height = 400 }) => {
+const useRenderOnView = ({
+  lazyRender = false,
+  height = 400,
+  waitForUserInteraction = true,
+}) => {
   const dummy = useRef<HTMLDivElement | null>(null)
   const [hasBeenViewed, setHasBeenViewed] = useState(false)
 
@@ -9,7 +13,7 @@ const useRenderOnView = ({ lazyRender = false, height = 400 }) => {
     ref: dummy,
     onView: () => setHasBeenViewed(true),
     once: true,
-    initializeOnInteraction: true,
+    initializeOnInteraction: waitForUserInteraction,
     bailOut: !lazyRender,
   })
 


### PR DESCRIPTION
#### What problem is this solving?
Always render the container of lazy rendered filter groups; this fixes some issues regarding ordering and CSS customization of filters.


#### How to test it?

https://lbebber--carrefourbr.myvtex.com/Celulares-Smartphones-e-Smartwatches/Smartphones?crfimt=hm-tlink|carrefour|menu|campanha|smartphones|1|120820

Notice the "Marcas" section on the left, and that the products appear properly below.
![Screen Shot 2020-09-08 at 16 26 26](https://user-images.githubusercontent.com/5691711/92519283-11205c80-f1f0-11ea-80a6-69b47d5cb4af.png)

Contrast with https://lbebberlazyfix1control--carrefourbr.myvtex.com/Celulares-Smartphones-e-Smartwatches/Smartphones?crfimt=hm-tlink%7Ccarrefour%7Cmenu%7Ccampanha%7Csmartphones%7C1%7C120820

![Screen Shot 2020-09-08 at 16 25 52](https://user-images.githubusercontent.com/5691711/92519340-2a290d80-f1f0-11ea-9ceb-223fe28ffd60.png)

Notice there's no "Marcas" section on the left and there's a grey rectangle where the products should be (that is, until the user moves their cursor or otherwise interact with the page)

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](Link goes here!)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
