### PR TITLE
Fix/lazy render filters 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Issue where lazy rendered filter groups wouldn't render its items properly
 
 ## [3.71.1] - 2020-09-08
 ### Fixed

--- a/react/components/FilterOptionTemplate.js
+++ b/react/components/FilterOptionTemplate.js
@@ -152,60 +152,53 @@ const FilterOptionTemplate = ({
 
   return (
     <div className={containerClassName}>
-      {!hasBeenViewed ? (
-        dummyElement
-      ) : (
-        <>
-          <div className={titleContainerClassName}>
-            <div
-              role="button"
-              tabIndex={collapsable ? 0 : undefined}
-              className={collapsable ? 'pointer' : ''}
-              onClick={() => collapsable && setOpen(!open)}
-              onKeyDown={handleKeyDown}
-              aria-disabled={!collapsable}
-            >
-              <div className={titleClassName}>
-                {title}
-                {collapsable && (
-                  <span
-                    className={classNames(
-                      handles.filterIcon,
-                      'flex items-center ph5 c-muted-3'
-                    )}
-                  >
-                    <IconCaret orientation={open ? 'up' : 'down'} size={14} />
-                  </span>
+      <div className={titleContainerClassName}>
+        <div
+          role="button"
+          tabIndex={collapsable ? 0 : undefined}
+          className={collapsable ? 'pointer' : ''}
+          onClick={() => collapsable && setOpen(!open)}
+          onKeyDown={handleKeyDown}
+          aria-disabled={!collapsable}
+        >
+          <div className={titleClassName}>
+            {title}
+            {collapsable && (
+              <span
+                className={classNames(
+                  handles.filterIcon,
+                  'flex items-center ph5 c-muted-3'
                 )}
-              </div>
-            </div>
-          </div>
-          <div
-            className={classNames(handles.filterTemplateOverflow, {
-              'overflow-y-auto': collapsable,
-              pb5: !collapsable || open,
-            })}
-            ref={scrollable}
-            style={{ maxHeight: '200px' }}
-            aria-hidden={!open}
-          >
-            {collapsable ? (
-              <Collapse
-                isOpened={open}
-                theme={{ content: handles.filterContent }}
               >
-                {thresholdForFacetSearch !== undefined &&
-                thresholdForFacetSearch < filters.length ? (
-                  <SearchFilterBar name={title} handleChange={setSearchTerm} />
-                ) : null}
-                {renderChildren()}
-              </Collapse>
-            ) : (
-              renderChildren()
+                <IconCaret orientation={open ? 'up' : 'down'} size={14} />
+              </span>
             )}
           </div>
-        </>
-      )}
+        </div>
+      </div>
+      <div
+        className={classNames(handles.filterTemplateOverflow, {
+          'overflow-y-auto': collapsable,
+          pb5: !collapsable || open,
+        })}
+        ref={scrollable}
+        style={{ maxHeight: '200px' }}
+        aria-hidden={!open}
+      >
+        {!hasBeenViewed ? (
+          dummyElement
+        ) : collapsable ? (
+          <Collapse isOpened={open} theme={{ content: handles.filterContent }}>
+            {thresholdForFacetSearch !== undefined &&
+            thresholdForFacetSearch < filters.length ? (
+              <SearchFilterBar name={title} handleChange={setSearchTerm} />
+            ) : null}
+            {renderChildren()}
+          </Collapse>
+        ) : (
+          renderChildren()
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
#### What problem is this solving?
Fixes issue where lazy rendered filter groups wouldn't render its items properly
<!--- What is the motivation and context for this change? -->

#### How to test it?
https://lbebberfixlazy1--carrefourbr.myvtex.com/Celulares-Smartphones-e-Smartwatches/Smartphones?crfimt=hm-tlink|carrefour|menu|campanha|smartphones|1|120820

Scroll inside the "Marcas" filter group and check if the items are rendered properly.

Compare with https://www.carrefour.com.br/Celulares-Smartphones-e-Smartwatches/Smartphones?workspace=bacelar2, where the items inside "Marcas" turn up blank after around 10

[Workspace](Link goes here!)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
