### PR TITLE
Fix/render on view offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Increase offset on GalleryRow view detection.
 
 ## [3.73.0] - 2020-09-10
 

--- a/react/components/FacetItem.js
+++ b/react/components/FacetItem.js
@@ -40,8 +40,10 @@ const FacetItem = ({
     : facet.value
 
   useEffect(() => {
-    setSelected(facet.selected)
-  }, [facet.selected])
+    if (facet.selected !== selected) {
+      setSelected(facet.selected)
+    }
+  }, [facet.selected, selected])
 
   return (
     <div

--- a/react/components/GalleryRow.js
+++ b/react/components/GalleryRow.js
@@ -21,7 +21,10 @@ const GalleryRow = ({
     maxWidth: `${100 / itemsPerRow}%`,
   }
 
-  const { hasBeenViewed, dummyElement } = useRenderOnView({ lazyRender })
+  const { hasBeenViewed, dummyElement } = useRenderOnView({
+    lazyRender,
+    offset: 900,
+  })
 
   if (!hasBeenViewed) {
     return dummyElement

--- a/react/hooks/useRenderOnView.tsx
+++ b/react/hooks/useRenderOnView.tsx
@@ -4,6 +4,7 @@ import React, { useState, useRef } from 'react'
 const useRenderOnView = ({
   lazyRender = false,
   height = 400,
+  offset = 200,
   waitForUserInteraction = true,
 }) => {
   const dummy = useRef<HTMLDivElement | null>(null)
@@ -19,16 +20,25 @@ const useRenderOnView = ({
 
   const dummyElement = (
     <div
-      ref={dummy}
       style={{
         width: '100%',
         height,
         position: 'relative',
-        /** Pulls the object 200px up so it renders a bit earlier,
-         * before the user would actually see the content */
-        top: -200,
       }}
-    />
+    >
+      <div
+        ref={dummy}
+        style={{
+          /** Allows detecting the view a bit earlier, allowing rendering before the user
+           * sees the whitespace where the component should be */
+          top: -offset,
+          bottom: 0,
+          left: 0,
+          right: 0,
+          position: 'absolute',
+        }}
+      />
+    </div>
   )
 
   return { hasBeenViewed: hasBeenViewed || !lazyRender, dummyElement }


### PR DESCRIPTION
#### What problem is this solving?
Increases view detection offset on Gallery Row

This mitigates the issue of "holes" appearing on the search results where the products should be

![image (11)](https://user-images.githubusercontent.com/5691711/92966740-740f2f00-f44e-11ea-94e3-d5394a7f347b.png)

(this issue ☝️ , the missing products on the bottom right)

It might still appear when scrolling fast, but should not maintain that state

https://lbebber3--carrefourbr.myvtex.com/Celulares-Smartphones-e-Smartwatches/Smartphones?crfimt=hm-tlink|carrefour|menu|campanha|smartphones|1|120820

<!--- What is the motivation and context for this change? -->

#### How to test it?


https://lbebber3--carrefourbr.myvtex.com/Celulares-Smartphones-e-Smartwatches/Smartphones?crfimt=hm-tlink|carrefour|menu|campanha|smartphones|1|120820

Just scroll down, a bit slowly at first, then faster. Try to catch the issue on the screenshot above (where it stays that way, not when it just takes a while for the products to appear)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
