### PR TITLE
Fix/truncation when lazy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Allows truncating filters when lazy rendering is enabled
 
 ## [3.73.1] - 2020-09-11
 ### Changed

--- a/react/components/FilterOptionTemplate.js
+++ b/react/components/FilterOptionTemplate.js
@@ -111,16 +111,16 @@ const FilterOptionTemplate = ({
       return children
     }
 
-    const shouldLazyRender = !hasScrolled && isLazyRenderEnabled
+    const shouldTruncate =
+      truncateFilters && filteredFacets.length >= MAX_ITEMS_THRESHOLD
+
+    const shouldLazyRender =
+      !shouldTruncate && !hasScrolled && isLazyRenderEnabled
+
     /** Inexact measure but good enough for displaying a properly sized scrollbar */
     const placeholderSize = shouldLazyRender
       ? (filters.length - RENDER_THRESHOLD) * 34
       : 0
-
-    const shouldTruncate =
-      !isLazyRenderEnabled &&
-      truncateFilters &&
-      filteredFacets.length >= MAX_ITEMS_THRESHOLD
 
     const endSlice =
       shouldLazyRender || (shouldTruncate && truncated)


### PR DESCRIPTION
#### What problem is this solving?

Allows truncating filters when lazy rendering is enabled.


<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](Link goes here!)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
