### PR TITLE
Fix/immediate facet selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Regression in immediate facet selection
 
 ## [3.74.0] - 2020-09-14
 ### Added

--- a/react/components/FacetItem.js
+++ b/react/components/FacetItem.js
@@ -39,11 +39,17 @@ const FacetItem = ({
     ? `filterItem--${facet.value}`
     : facet.value
 
+  // This effect fixes the issue described in this PR
+  // https://github.com/vtex-apps/search-result/pull/422
   useEffect(() => {
     if (facet.selected !== selected) {
       setSelected(facet.selected)
     }
-  }, [facet.selected, selected])
+    // however, having `selected` as a dependency causes it
+    // to always reset back to `facet.selected`. So, we remove it,
+    // so only changes in facet.selected affect the state.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [facet.selected])
 
   return (
     <div


### PR DESCRIPTION
#### What problem is this solving?
Fixes regression in immediate facet selection

<!--- What is the motivation and context for this change? -->

#### How to test it?

https://lbebberselection--carrefourbr.myvtex.com/Celulares-Smartphones-e-Smartwatches/Smartphones

Select any brand on the sidebar. It should be marked as "checked" immediately once you click on it.
![Kapture 2020-09-16 at 15 38 50](https://user-images.githubusercontent.com/5691711/93378386-c4153980-f832-11ea-8829-a5d29e55d49b.gif)

The regression was caused by a fix related to a second filter selector, on top of the product gallery. Unchecking it was not updating the checked filter on the sidebar.
<img width="392" alt="Screen Shot 2020-09-16 at 15 36 04" src="https://user-images.githubusercontent.com/5691711/93378178-6da7fb00-f832-11ea-9ccc-70cd771e8ed5.png">

Try to uncheck the filter over there to see that this bug also doesn't regress.


<!--- Don't forget to add a link to a Workspace where this branch is linked -->


[Workspace](Link goes here!)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
