### PR TITLE
Feature/lazy fetch items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Limits initial search items if option `enableLazySearchQuery` is enabled.
 
 ## [3.74.1] - 2020-09-16
 ### Fixed

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -110,6 +110,7 @@ const Gallery = ({
           <div
             style={{
               width: '100%',
+              // Approximate number, just to add scroll leeway
               height: 300 * Math.ceil(lazyItemsRemaining / itemsPerRow),
             }}
             className="flex justify-center pt10"

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -16,6 +16,8 @@ import GalleryRow from './components/GalleryRow'
 import ProductListEventCaller from './utils/ProductListEventCaller'
 import SettingsContext from './components/SettingsContext'
 
+import { Spinner } from 'vtex.styleguide'
+
 /** Layout with one column */
 const ONE_COLUMN_LAYOUT = 1
 
@@ -39,6 +41,7 @@ const Gallery = ({
   width,
   summary,
   showingFacets,
+  lazyItemsRemaining,
 }) => {
   const { isMobile } = useDevice()
   const { trackingId = 'Search result' } = useContext(SettingsContext) || {}
@@ -103,6 +106,17 @@ const Gallery = ({
             itemsPerRow={itemsPerRow}
           />
         ))}
+        {lazyItemsRemaining && lazyItemsRemaining > 0 && (
+          <div
+            style={{
+              width: '100%',
+              height: 300 * Math.ceil(lazyItemsRemaining / itemsPerRow),
+            }}
+            className="flex justify-center pt10"
+          >
+            <Spinner />
+          </div>
+        )}
       </div>
       <ProductListEventCaller />
     </ProductListProvider>
@@ -124,6 +138,7 @@ Gallery.propTypes = {
   minItemWidth: PropTypes.number,
   showingFacets: PropTypes.bool,
   trackingId: PropTypes.string,
+  lazyItemsRemaining: PropTypes.number,
 }
 
 export default withResizeDetector(Gallery)

--- a/react/Gallery.js
+++ b/react/Gallery.js
@@ -106,7 +106,7 @@ const Gallery = ({
             itemsPerRow={itemsPerRow}
           />
         ))}
-        {lazyItemsRemaining && lazyItemsRemaining > 0 && (
+        {typeof lazyItemsRemaining === 'number' && lazyItemsRemaining > 0 && (
           <div
             style={{
               width: '100%',

--- a/react/SearchContent.js
+++ b/react/SearchContent.js
@@ -7,7 +7,7 @@ import {
 } from 'vtex.search-page-context/SearchPageContext'
 
 const SearchContent = () => {
-  const { searchQuery, showFacets } = useSearchPage()
+  const { searchQuery, showFacets, lazyItemsRemaining } = useSearchPage()
   const { mobileLayout, showContentLoader } = useSearchPageState()
   const products = path(['data', 'productSearch', 'products'], searchQuery)
   const redirect = path(['data', 'productSearch', 'redirect'], searchQuery)
@@ -23,13 +23,16 @@ const SearchContent = () => {
   }
 
   return (
-    <ExtensionPoint
-      id="gallery"
-      products={products}
-      className="bn"
-      mobileLayoutMode={mobileLayout}
-      showingFacets={showFacets}
-    />
+    <>
+      <ExtensionPoint
+        id="gallery"
+        products={products}
+        className="bn"
+        mobileLayoutMode={mobileLayout}
+        showingFacets={showFacets}
+        lazyItemsRemaining={lazyItemsRemaining}
+      />
+    </>
   )
 }
 

--- a/react/SearchResultFlexible.js
+++ b/react/SearchResultFlexible.js
@@ -59,6 +59,7 @@ const SearchResultFlexible = ({
   facetsLoading,
   trackingId,
   thresholdForFacetSearch,
+  lazyItemsRemaining,
 }) => {
   //This makes infinite scroll unavailable.
   //Infinite scroll was deprecated and we have
@@ -136,6 +137,7 @@ const SearchResultFlexible = ({
       showProductsCount,
       preventRouteChange,
       facetsLoading,
+      lazyItemsRemaining,
     }),
     [
       hiddenFacets,
@@ -153,6 +155,7 @@ const SearchResultFlexible = ({
       showProductsCount,
       preventRouteChange,
       facetsLoading,
+      lazyItemsRemaining,
     ]
   )
 
@@ -177,21 +180,20 @@ const SearchResultFlexible = ({
               orderBy={orderBy}
               page={page}
               facetsLoading={facetsLoading}
+              lazyItemsRemaining={lazyItemsRemaining}
             >
-              {
-                <LoadingOverlay loading={showLoading}>
-                  <div
-                    className={`${
-                      handles.loadingOverlay
-                    } w-100 flex flex-column flex-grow-1 ${generateBlockClass(
-                      styles['container--layout'],
-                      blockClass
-                    )}`}
-                  >
-                    {children}
-                  </div>
-                </LoadingOverlay>
-              }
+              <LoadingOverlay loading={showLoading}>
+                <div
+                  className={`${
+                    handles.loadingOverlay
+                  } w-100 flex flex-column flex-grow-1 ${generateBlockClass(
+                    styles['container--layout'],
+                    blockClass
+                  )}`}
+                >
+                  {children}
+                </div>
+              </LoadingOverlay>
             </SearchResultContainer>
           </ContextProviders>
         </SearchPageStateDispatch.Provider>

--- a/react/components/LocalQuery.js
+++ b/react/components/LocalQuery.js
@@ -41,6 +41,7 @@ const LocalQuery = props => {
       pageQuery={pageQuery}
       skusFilter={skusFilter}
       simulationBehavior={simulationBehavior}
+      lazyItemsQuery={false}
       __unstableProductOriginVtex={__unstableProductOriginVtex}
     >
       {(searchQuery, extraParams) => {

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -248,7 +248,9 @@ const SearchQuery = ({
 
   const shouldLimitItems =
     maxItemsPerPage > INITIAL_ITEMS_LIMIT &&
-    (typeof lazyItemsQueryProp !== 'undefined'
+    // Prioritize the `lazyItemsQuery` prop if set, otherwise
+    // uses the value from the `enableLazySearchQuery` setting
+    (typeof lazyItemsQueryProp === 'boolean'
       ? lazyItemsQueryProp
       : lazyItemsQuerySetting)
 

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -234,6 +234,7 @@ const SearchQuery = ({
   operator: operatorQuery,
   fuzzy: fuzzyQuery,
   searchState: searchStateQuery,
+  lazyItemsQuery: lazyItemsQueryProp,
   __unstableProductOriginVtex,
 }) => {
   const [selectedFacets, fullText] = buildSelectedFacetsAndFullText(
@@ -243,10 +244,13 @@ const SearchQuery = ({
   )
 
   const { getSettings } = useRuntime()
+  const lazyItemsQuerySetting = getSettings('vtex.store')?.enableLazySearchQuery
 
   const shouldLimitItems =
     maxItemsPerPage > INITIAL_ITEMS_LIMIT &&
-    getSettings('vtex.store')?.enableLazySearchQuery
+    (typeof lazyItemsQueryProp !== 'undefined'
+      ? lazyItemsQueryProp
+      : lazyItemsQuerySetting)
 
   const itemsLimit = shouldLimitItems ? INITIAL_ITEMS_LIMIT : maxItemsPerPage
 
@@ -390,6 +394,7 @@ const SearchQuery = ({
     shouldLimitItems,
     maxItemsPerPage,
     lazyItemsRemaining,
+    itemsLimit,
   ])
 
   const extraParams = useMemo(() => {

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -332,7 +332,15 @@ const SearchQuery = ({
     setRedirect(redirectUrl)
   }, [redirectUrl, setRedirect])
 
-  const hasFetchedMoreItems = useRef(false)
+  const lazyItemsRemaining = useRef(
+    shouldLimitItems ? maxItemsPerPage - itemsLimit : 0
+  )
+
+  useEffect(() => {
+    lazyItemsRemaining.current = shouldLimitItems
+      ? maxItemsPerPage - itemsLimit
+      : 0
+  }, [map, query, from, shouldLimitItems, maxItemsPerPage, itemsLimit])
 
   useEffect(() => {
     if (!shouldLimitItems) {
@@ -340,11 +348,11 @@ const SearchQuery = ({
     }
 
     const fetchRemainingItems = () => {
-      if (hasFetchedMoreItems.current) {
+      if (lazyItemsRemaining.current === 0) {
         return
       }
 
-      hasFetchedMoreItems.current = true
+      lazyItemsRemaining.current = 0
 
       fetchMore({
         variables: {
@@ -373,17 +381,25 @@ const SearchQuery = ({
     return () => {
       clearTimeout(timeout)
     }
-  }, [fetchMore, from, shouldLimitItems, maxItemsPerPage, hasFetchedMoreItems])
+  }, [data, fetchMore, from, shouldLimitItems, maxItemsPerPage])
 
   const extraParams = useMemo(() => {
     return {
       ...variables,
       ...facetsArgs,
       maxItemsPerPage,
+      lazyItemsRemaining: lazyItemsRemaining.current,
       page,
       facetsLoading,
     }
-  }, [variables, facetsArgs, maxItemsPerPage, page, facetsLoading])
+  }, [
+    variables,
+    facetsArgs,
+    maxItemsPerPage,
+    lazyItemsRemaining,
+    page,
+    facetsLoading,
+  ])
 
   const searchInfo = useMemo(
     () => ({

--- a/react/components/SearchResultContainer.js
+++ b/react/components/SearchResultContainer.js
@@ -38,6 +38,7 @@ const SearchResultContainer = props => {
     pagination,
     page,
     children,
+    lazyItemsRemaining,
   } = props
 
   const queryData = {
@@ -84,6 +85,7 @@ const SearchResultContainer = props => {
       to={to}
       from={from}
       infiniteScrollError={infiniteScrollError}
+      lazyItemsRemaining={lazyItemsRemaining}
     />
   )
 


### PR DESCRIPTION
#### What problem is this solving?
Limits initial search items if option `enableLazySearchQuery` is enabled. The remaining items are loaded lazily afterwards.

This reduces the initial query processing, both on the server and on the client, reduces the size of the cached page, initial data transfer, and consequently makes the initial render of the page much faster. By reducing the size of the cached page, it also may prevent the SSR from breaking due to the page being too large.

This is a simple two-step approach (limited loading first, load the rest soon); a more sophisticated approach might be done in the future.

This feature is enabled by enabling the setting `enableLazySearchQuery` on `vtex.store`

Related PRs:
https://github.com/vtex-apps/search-result/pull/429
https://github.com/vtex-apps/store/pull/488
https://github.com/vtex/render-server/pull/669

Initial query time comparison:
Before:
<img width="639" alt="Screen Shot 2020-09-17 at 15 20 32" src="https://user-images.githubusercontent.com/5691711/93511566-6ac40d80-f8f9-11ea-8381-88c17a8b8940.png">

After:
<img width="631" alt="Screen Shot 2020-09-17 at 15 20 28" src="https://user-images.githubusercontent.com/5691711/93511584-71eb1b80-f8f9-11ea-992f-2e96b2c4f16f.png">

Initial page weight:
Before (even without SSR working):
<img width="347" alt="Screen Shot 2020-09-17 at 15 22 33" src="https://user-images.githubusercontent.com/5691711/93511746-a9f25e80-f8f9-11ea-97bc-f47ccc595030.png">
(595kb gzipped/10.3mb ungzipped)

After:
<img width="345" alt="Screen Shot 2020-09-17 at 15 22 29" src="https://user-images.githubusercontent.com/5691711/93511762-b080d600-f8f9-11ea-9534-5c4663e531d5.png">
(335kb gzipped/4mb ungzipped)

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->
https://www.carrefour.com.br/Celulares-Smartphones-e-Smartwatches/Smartphones?ak-testab=vtex&workspace=lbebberlazysearch5&v=01

There shouldn't be much of a visible difference from master (https://www.carrefour.com.br/Celulares-Smartphones-e-Smartwatches/Smartphones?ak-testab=vtex)

The main visible difference currently is that this fixes SSR, which is currently not working in master, so there might be some issues that are currently happening on server-side-rendered search pages (a temporary "Produto Indisponível"), but it is not related to this PR.

You might also face a spinner if you scroll down too soon, but the products should load soon enough.

There are also other things that slow down this page (too many installments, too many facets) which once fixed should also improve the experience.

In this workspace, all the apps for this feature are installed, but the setting is disabled. There shouldn't be any difference from the version in master https://www.carrefour.com.br/Celulares-Smartphones-e-Smartwatches/Smartphones?workspace=lbebberlazysearchdisabled

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
