### PR TITLE
Add changes to make enableFiltersFetchOptimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Support for the `enableFiltersFetchOptimization` store setting, which makes it possible to fetch only the facets thast were not truncated.
+- Support for the `enableFiltersFetchOptimization` store setting, which makes it possible to fetch only the facets that were not truncated.
 
 ## [3.76.0] - 2020-09-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for the `enableFiltersFetchOptimization` store setting, which makes it possible to fetch only the facets thast were not truncated.
 
 ## [3.76.0] - 2020-09-18
 ### Added

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -74,6 +74,7 @@ const FilterNavigator = ({
   filtersTitleHtmlTag = 'h5',
   scrollToTop = 'none',
   openFiltersMode = 'many',
+  filtersFetchMore,
 }) => {
   const { isMobile } = useDevice()
   const handles = useCssHandles(CSS_HANDLES)
@@ -180,6 +181,7 @@ const FilterNavigator = ({
               preventRouteChange={preventRouteChange}
               initiallyCollapsed={initiallyCollapsed}
               navigateToFacet={navigateToFacet}
+              filtersFetchMore={filtersFetchMore}
               truncateFilters={truncateFilters}
               openFiltersMode={openFiltersMode}
             />

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -1,7 +1,7 @@
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import { flatten } from 'ramda'
-import React, { useMemo, Fragment } from 'react'
+import React, { useMemo, Fragment, useState, useEffect } from 'react'
 import ContentLoader from 'react-content-loader'
 import { ExtensionPoint } from 'vtex.render-runtime'
 import { useDevice } from 'vtex.device-detector'
@@ -22,6 +22,7 @@ import FilterNavigatorTitleTag from './components/FilterNavigatorTitleTag'
 import styles from './searchResult.css'
 import { CATEGORIES_TITLE } from './utils/getFilters'
 import { newFacetPathName } from './utils/slug'
+import { FACETS_RENDER_THRESHOLD } from './constants/filterConstants'
 
 const CSS_HANDLES = [
   'filter__container',
@@ -78,6 +79,46 @@ const FilterNavigator = ({
 }) => {
   const { isMobile } = useDevice()
   const handles = useCssHandles(CSS_HANDLES)
+  const [truncatedFacetsFetched, setTruncatedFacetsFetched] = useState(false)
+
+  useEffect(() => {
+    // This condition confirms if there are facets that still need fetching
+    const needsFetching = !!filters.find(
+      filter => filter.quantity > filter.facets.length
+    )
+    if (truncatedFacetsFetched && needsFetching && !loading) {
+      filtersFetchMore({
+        variables: {
+          from: FACETS_RENDER_THRESHOLD,
+          to: undefined, // to the end of the results
+        },
+        updateQuery: (prevResult, { fetchMoreResult }) => {
+          if (!prevResult || !fetchMoreResult) {
+            return
+          }
+          const prevFacets = prevResult.facets.facets
+          const newFacets = fetchMoreResult.facets.facets
+          const fullFacets = []
+          for (let i = 0; i < prevFacets.length; i++) {
+            const completeFacets = [
+              ...prevFacets[i].facets,
+              ...newFacets[i].facets,
+            ]
+            fullFacets.push({
+              ...prevFacets[i],
+              facets: completeFacets,
+            })
+          }
+          return {
+            facets: {
+              ...prevResult.facets,
+              facets: fullFacets,
+            },
+          }
+        },
+      })
+    }
+  }, [filters, filtersFetchMore, truncatedFacetsFetched, loading])
   const mobileLayout =
     (isMobile && layout === LAYOUT_TYPES.responsive) ||
     layout === LAYOUT_TYPES.mobile
@@ -181,7 +222,8 @@ const FilterNavigator = ({
               preventRouteChange={preventRouteChange}
               initiallyCollapsed={initiallyCollapsed}
               navigateToFacet={navigateToFacet}
-              filtersFetchMore={filtersFetchMore}
+              truncatedFacetsFetched={truncatedFacetsFetched}
+              setTruncatedFacetsFetched={setTruncatedFacetsFetched}
               truncateFilters={truncateFilters}
               openFiltersMode={openFiltersMode}
             />

--- a/react/FilterNavigatorFlexible.js
+++ b/react/FilterNavigatorFlexible.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
 import { useDevice } from 'vtex.device-detector'
-import { pathOr } from 'ramda'
 
 import FilterNavigator from './FilterNavigator'
 import FilterNavigatorContext from './components/FilterNavigatorContext'
@@ -31,7 +30,16 @@ const withSearchPageContextProps = Component => ({
   } = useSearchPage()
   const { isMobile } = useDevice()
 
-  const facets = pathOr({}, ['data', 'facets'], searchQuery)
+  const filtersFetchMore =
+    searchQuery && searchQuery.facets && searchQuery.facets.facetsFetchMore
+      ? searchQuery.facets.facetsFetchMore
+      : undefined
+
+  const facets =
+    searchQuery && searchQuery.data && searchQuery.data.facets
+      ? searchQuery.data.facets
+      : {}
+
   const {
     brands,
     priceRanges,
@@ -39,12 +47,6 @@ const withSearchPageContextProps = Component => ({
     categoriesTrees,
     queryArgs,
   } = facets
-
-  const filtersFetchMore = pathOr(
-    undefined,
-    ['facets', 'facetsFetchMore'],
-    searchQuery
-  )
 
   if (showFacets === false || !map) {
     return null

--- a/react/FilterNavigatorFlexible.js
+++ b/react/FilterNavigatorFlexible.js
@@ -40,6 +40,12 @@ const withSearchPageContextProps = Component => ({
     queryArgs,
   } = facets
 
+  const filtersFetchMore = pathOr(
+    undefined,
+    ['facets', 'facetsFetchMore'],
+    searchQuery
+  )
+
   if (showFacets === false || !map) {
     return null
   }
@@ -61,6 +67,7 @@ const withSearchPageContextProps = Component => ({
           tree={categoriesTrees}
           loading={facetsLoading}
           filters={filters}
+          filtersFetchMore={filtersFetchMore}
           hiddenFacets={hiddenFacets}
           layout={layout}
           initiallyCollapsed={initiallyCollapsed}

--- a/react/SearchResultFlexible.js
+++ b/react/SearchResultFlexible.js
@@ -73,16 +73,23 @@ const SearchResultFlexible = ({
       ? PAGINATION_TYPE.SHOW_MORE
       : pagination
   const facets = pathOr(emptyFacets, ['data', 'facets'], searchQuery)
-  const { brands, priceRanges, specificationFilters, categoriesTrees } = facets
+  const {
+    brands,
+    brandsQuantity,
+    priceRanges,
+    specificationFilters,
+    categoriesTrees,
+  } = facets
   const filters = useMemo(
     () =>
       getFilters({
         specificationFilters,
         priceRanges,
         brands,
+        brandsQuantity,
         hiddenFacets,
       }),
-    [brands, hiddenFacets, priceRanges, specificationFilters]
+    [brands, hiddenFacets, priceRanges, specificationFilters, brandsQuantity]
   )
 
   const handles = useCssHandles(CSS_HANDLES)

--- a/react/components/AvailableFilters.js
+++ b/react/components/AvailableFilters.js
@@ -8,12 +8,15 @@ const LAZY_RENDER_THRESHOLD = 3
 
 const AvailableFilters = ({ filters = [], ...props }) => {
   const [lastOpenFilter, setLastOpenFilter] = useState()
+  const [truncatedFacetsFetched, setTruncatedFacetsFetched] = useState(false)
   return filters.map((filter, i) => (
     <Filter
       filter={filter}
       {...props}
       lastOpenFilter={lastOpenFilter}
       setLastOpenFilter={setLastOpenFilter}
+      truncatedFacetsFetched={truncatedFacetsFetched}
+      setTruncatedFacetsFetched={setTruncatedFacetsFetched}
       key={filter.title}
       lazyRender={i >= LAZY_RENDER_THRESHOLD}
     />
@@ -31,8 +34,11 @@ const Filter = ({
   openFiltersMode = 'many',
   lastOpenFilter,
   setLastOpenFilter,
+  filtersFetchMore,
+  truncatedFacetsFetched,
+  setTruncatedFacetsFetched,
 }) => {
-  const { type, title, facets, oneSelectedCollapse = false } = filter
+  const { type, title, facets, quantity, oneSelectedCollapse = false } = filter
 
   switch (type) {
     case 'PriceRanges':
@@ -51,6 +57,7 @@ const Filter = ({
           key={title}
           title={title}
           facets={facets}
+          quantity={quantity}
           oneSelectedCollapse={oneSelectedCollapse}
           preventRouteChange={preventRouteChange}
           initiallyCollapsed={initiallyCollapsed}
@@ -60,6 +67,9 @@ const Filter = ({
           lastOpenFilter={lastOpenFilter}
           setLastOpenFilter={setLastOpenFilter}
           openFiltersMode={openFiltersMode}
+          filtersFetchMore={filtersFetchMore}
+          truncatedFacetsFetched={truncatedFacetsFetched}
+          setTruncatedFacetsFetched={setTruncatedFacetsFetched}
         />
       )
   }
@@ -78,7 +88,9 @@ AvailableFilters.propTypes = {
   priceRange: PropTypes.string,
   /** Prevent route changes */
   preventRouteChange: PropTypes.bool,
+  /** If filters start collapsed */
   initiallyCollapsed: PropTypes.bool,
+  /** If filters start truncated */
   truncateFilters: PropTypes.bool,
 }
 

--- a/react/components/AvailableFilters.js
+++ b/react/components/AvailableFilters.js
@@ -8,15 +8,12 @@ const LAZY_RENDER_THRESHOLD = 3
 
 const AvailableFilters = ({ filters = [], ...props }) => {
   const [lastOpenFilter, setLastOpenFilter] = useState()
-  const [truncatedFacetsFetched, setTruncatedFacetsFetched] = useState(false)
   return filters.map((filter, i) => (
     <Filter
       filter={filter}
       {...props}
       lastOpenFilter={lastOpenFilter}
       setLastOpenFilter={setLastOpenFilter}
-      truncatedFacetsFetched={truncatedFacetsFetched}
-      setTruncatedFacetsFetched={setTruncatedFacetsFetched}
       key={filter.title}
       lazyRender={i >= LAZY_RENDER_THRESHOLD}
     />
@@ -34,7 +31,6 @@ const Filter = ({
   openFiltersMode = 'many',
   lastOpenFilter,
   setLastOpenFilter,
-  filtersFetchMore,
   truncatedFacetsFetched,
   setTruncatedFacetsFetched,
 }) => {
@@ -67,7 +63,6 @@ const Filter = ({
           lastOpenFilter={lastOpenFilter}
           setLastOpenFilter={setLastOpenFilter}
           openFiltersMode={openFiltersMode}
-          filtersFetchMore={filtersFetchMore}
           truncatedFacetsFetched={truncatedFacetsFetched}
           setTruncatedFacetsFetched={setTruncatedFacetsFetched}
         />

--- a/react/components/FilterOptionTemplate.js
+++ b/react/components/FilterOptionTemplate.js
@@ -20,6 +20,7 @@ import { SearchFilterBar } from './SearchFilterBar'
 import SettingsContext from './SettingsContext'
 
 import { useRenderOnView } from '../hooks/useRenderOnView'
+import { FACETS_RENDER_THRESHOLD } from '../constants/filterConstants'
 
 /** Returns true if elementRef has ever been scrolled */
 const useHasScrolled = elementRef => {
@@ -58,13 +59,6 @@ const CSS_HANDLES = [
 ]
 
 const useSettings = () => useContext(SettingsContext)
-
-const MAX_ITEMS_THRESHOLD = 12
-
-/** Renders only ${RENDER_THRESHOLD} items on the list until the user scrolls or clicks `See more`,
- * for improved rendering performance */
-const RENDER_THRESHOLD = 10
-
 /**
  * Collapsable filters container
  */
@@ -72,6 +66,7 @@ const FilterOptionTemplate = ({
   id,
   selected = false,
   title,
+  quantity,
   collapsable = true,
   children,
   filters,
@@ -81,6 +76,9 @@ const FilterOptionTemplate = ({
   lastOpenFilter,
   setLastOpenFilter,
   openFiltersMode,
+  filtersFetchMore,
+  truncatedFacetsFetched,
+  setTruncatedFacetsFetched,
 }) => {
   const [open, setOpen] = useState(!initiallyCollapsed)
   const { getSettings } = useRuntime()
@@ -92,6 +90,8 @@ const FilterOptionTemplate = ({
 
   const isLazyRenderEnabled = getSettings('vtex.store')
     ?.enableSearchRenderingOptimization
+  const isLazyFacetsFetchEnabled = getSettings('vtex.store')
+    ?.enableFiltersFetchOptimization
 
   const { hasBeenViewed, dummyElement } = useRenderOnView({
     lazyRender: isLazyRenderEnabled && lazyRender,
@@ -110,25 +110,67 @@ const FilterOptionTemplate = ({
     )
   }, [filters, searchTerm, thresholdForFacetSearch])
 
+  const openTruncated = value => {
+    if (
+      filtersFetchMore &&
+      isLazyFacetsFetchEnabled &&
+      !truncatedFacetsFetched
+    ) {
+      setTruncatedFacetsFetched(true)
+      filtersFetchMore({
+        variables: {
+          from: FACETS_RENDER_THRESHOLD,
+          to: undefined, // to the end of the results
+        },
+        updateQuery: (prevResult, { fetchMoreResult }) => {
+          if (!prevResult || !fetchMoreResult) {
+            return
+          }
+          const prevFacets = prevResult.facets.facets
+          const newFacets = fetchMoreResult.facets.facets
+          const fullFacets = []
+          for (let i = 0; i < prevFacets.length; i++) {
+            const completeFacets = [
+              ...prevFacets[i].facets,
+              ...newFacets[i].facets,
+            ]
+            fullFacets.push({
+              ...prevFacets[i],
+              facets: completeFacets,
+            })
+          }
+          return {
+            facets: {
+              ...prevResult.facets,
+              facets: fullFacets,
+            },
+          }
+        },
+      })
+    }
+    setTruncated(value)
+  }
+
   const renderChildren = () => {
     if (typeof children !== 'function') {
       return children
     }
 
     const shouldTruncate =
-      truncateFilters && filteredFacets.length >= MAX_ITEMS_THRESHOLD
+      (truncateFilters || isLazyFacetsFetchEnabled) &&
+      quantity > FACETS_RENDER_THRESHOLD
 
     const shouldLazyRender =
       !shouldTruncate && !hasScrolled && isLazyRenderEnabled
 
     /** Inexact measure but good enough for displaying a properly sized scrollbar */
     const placeholderSize = shouldLazyRender
-      ? (filters.length - RENDER_THRESHOLD) * 34
+      ? (filters.length - FACETS_RENDER_THRESHOLD) * 34
       : 0
 
     const endSlice =
       shouldLazyRender || (shouldTruncate && truncated)
-        ? RENDER_THRESHOLD
+        ? FACETS_RENDER_THRESHOLD
         : filteredFacets.length
 
     return (
@@ -137,7 +179,7 @@ const FilterOptionTemplate = ({
         {placeholderSize > 0 && <div style={{ height: placeholderSize }} />}
         {shouldTruncate && (
           <button
-            onClick={() => setTruncated(truncated => !truncated)}
+            onClick={() => openTruncated(truncated => !truncated)}
             className={`${handles.seeMoreButton} mt2 pv2 bn pointer c-link`}
           >
             <FormattedMessage
@@ -146,7 +188,9 @@ const FilterOptionTemplate = ({
                   ? 'store/filter.more-items'
                   : 'store/filter.less-items'
               }
-              values={{ quantity: filteredFacets.length - RENDER_THRESHOLD }}
+              values={{
+                quantity: quantity - FACETS_RENDER_THRESHOLD,
+              }}
             />
           </button>
         )}
@@ -228,7 +272,9 @@ const FilterOptionTemplate = ({
         })}
         ref={scrollable}
         style={
-          !truncateFilters || isLazyRenderEnabled ? { maxHeight: '200px' } : {}
+          !(truncateFilters || isLazyFacetsFetchEnabled) || isLazyRenderEnabled
+            ? { maxHeight: '200px' }
+            : {}
         }
         aria-hidden={!isOpen}
       >
@@ -271,9 +317,20 @@ FilterOptionTemplate.propTypes = {
   lazyRender: PropTypes.bool,
   /** When `true`, truncates filters with more than 10 options displaying a button to see all */
   truncateFilters: PropTypes.bool,
+  /** Last open filter */
   lastOpenFilter: PropTypes.string,
+  /** Sets the last open filter */
   setLastOpenFilter: PropTypes.func,
+  /** Dictates how many filters can be open at the same time */
   openFiltersMode: PropTypes.string,
+  /** FetchMore of the filters query to fetch new results */
+  filtersFetchMore: PropTypes.func,
+  /** If the truncated facets were fetched */
+  truncatedFacetsFetched: PropTypes.bool,
+  /** Sets if the truncated facets were fetched */
+  setTruncatedFacetsFetched: PropTypes.func,
+  /** Quantity of facets of the current filter */
+  quantity: PropTypes.number,
 }
 
 export default FilterOptionTemplate

--- a/react/components/FilterOptionTemplate.js
+++ b/react/components/FilterOptionTemplate.js
@@ -76,7 +76,6 @@ const FilterOptionTemplate = ({
   lastOpenFilter,
   setLastOpenFilter,
   openFiltersMode,
-  filtersFetchMore,
   truncatedFacetsFetched,
   setTruncatedFacetsFetched,
 }) => {
@@ -111,42 +110,8 @@ const FilterOptionTemplate = ({
   }, [filters, searchTerm, thresholdForFacetSearch])
 
   const openTruncated = value => {
-    if (
-      filtersFetchMore &&
-      isLazyFacetsFetchEnabled &&
-      !truncatedFacetsFetched
-    ) {
+    if (isLazyFacetsFetchEnabled && !truncatedFacetsFetched) {
       setTruncatedFacetsFetched(true)
-      filtersFetchMore({
-        variables: {
-          from: FACETS_RENDER_THRESHOLD,
-          to: undefined, // to the end of the results
-        },
-        updateQuery: (prevResult, { fetchMoreResult }) => {
-          if (!prevResult || !fetchMoreResult) {
-            return
-          }
-          const prevFacets = prevResult.facets.facets
-          const newFacets = fetchMoreResult.facets.facets
-          const fullFacets = []
-          for (let i = 0; i < prevFacets.length; i++) {
-            const completeFacets = [
-              ...prevFacets[i].facets,
-              ...newFacets[i].facets,
-            ]
-            fullFacets.push({
-              ...prevFacets[i],
-              facets: completeFacets,
-            })
-          }
-          return {
-            facets: {
-              ...prevResult.facets,
-              facets: fullFacets,
-            },
-          }
-        },
-      })
     }
     setTruncated(value)
   }
@@ -323,8 +288,6 @@ FilterOptionTemplate.propTypes = {
   setLastOpenFilter: PropTypes.func,
   /** Dictates how many filters can be open at the same time */
   openFiltersMode: PropTypes.string,
-  /** FetchMore of the filters query to fetch new results */
-  filtersFetchMore: PropTypes.func,
   /** If the truncated facets were fetched */
   truncatedFacetsFetched: PropTypes.bool,
   /** Sets if the truncated facets were fetched */

--- a/react/components/SearchFilter.js
+++ b/react/components/SearchFilter.js
@@ -13,6 +13,7 @@ import { getFilterTitle } from '../constants/SearchHelpers'
 const SearchFilter = ({
   title = 'Default Title',
   facets = [],
+  quantity = 0,
   intl,
   preventRouteChange = false,
   initiallyCollapsed = false,
@@ -22,6 +23,9 @@ const SearchFilter = ({
   lastOpenFilter,
   setLastOpenFilter,
   openFiltersMode,
+  filtersFetchMore,
+  truncatedFacetsFetched,
+  setTruncatedFacetsFetched,
 }) => {
   const sampleFacet = facets && facets.length > 0 ? facets[0] : null
   const facetTitle = getFilterTitle(title, intl)
@@ -31,12 +35,16 @@ const SearchFilter = ({
       id={sampleFacet ? sampleFacet.map : null}
       title={facetTitle}
       filters={facets}
+      quantity={quantity}
       initiallyCollapsed={initiallyCollapsed}
       lazyRender={lazyRender}
       truncateFilters={truncateFilters}
       lastOpenFilter={lastOpenFilter}
       setLastOpenFilter={setLastOpenFilter}
       openFiltersMode={openFiltersMode}
+      filtersFetchMore={filtersFetchMore}
+      truncatedFacetsFetched={truncatedFacetsFetched}
+      setTruncatedFacetsFetched={setTruncatedFacetsFetched}
     >
       {facet => (
         <FacetItem
@@ -65,9 +73,20 @@ SearchFilter.propTypes = {
   lazyRender: PropTypes.bool,
   /** When `true`, truncates filters with more than 10 options displaying a button to see all */
   truncateFilters: PropTypes.bool,
+  /** Last open filter */
   lastOpenFilter: PropTypes.string,
+  /** Sets the last open filter */
   setLastOpenFilter: PropTypes.func,
+  /** Dictates how many filters can be open at the same time */
   openFiltersMode: PropTypes.string,
+  /** FetchMore of the filters query to fetch new results */
+  filtersFetchMore: PropTypes.func,
+  /** If the truncated facets were fetched */
+  truncatedFacetsFetched: PropTypes.bool,
+  /** Sets if the truncated facets were fetched */
+  setTruncatedFacetsFetched: PropTypes.func,
+  /** Quantity of facets of the current filter */
+  quantity: PropTypes.number,
 }
 
 export default injectIntl(SearchFilter)

--- a/react/components/SearchFilter.js
+++ b/react/components/SearchFilter.js
@@ -23,7 +23,6 @@ const SearchFilter = ({
   lastOpenFilter,
   setLastOpenFilter,
   openFiltersMode,
-  filtersFetchMore,
   truncatedFacetsFetched,
   setTruncatedFacetsFetched,
 }) => {
@@ -42,7 +41,6 @@ const SearchFilter = ({
       lastOpenFilter={lastOpenFilter}
       setLastOpenFilter={setLastOpenFilter}
       openFiltersMode={openFiltersMode}
-      filtersFetchMore={filtersFetchMore}
       truncatedFacetsFetched={truncatedFacetsFetched}
       setTruncatedFacetsFetched={setTruncatedFacetsFetched}
     >
@@ -79,8 +77,6 @@ SearchFilter.propTypes = {
   setLastOpenFilter: PropTypes.func,
   /** Dictates how many filters can be open at the same time */
   openFiltersMode: PropTypes.string,
-  /** FetchMore of the filters query to fetch new results */
-  filtersFetchMore: PropTypes.func,
   /** If the truncated facets were fetched */
   truncatedFacetsFetched: PropTypes.bool,
   /** Sets if the truncated facets were fetched */

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -145,7 +145,7 @@ const useCorrectSearchStateVariables = (
 }
 
 const useQueries = (variables, facetsArgs) => {
-  const { getSettings } = useRuntime() // Is it okay to call this here?
+  const { getSettings } = useRuntime()
   const isLazyFacetsFetchEnabled = getSettings('vtex.store')
     ?.enableFiltersFetchOptimization
   const productSearchResult = useQuery(productSearchQuery, { variables })
@@ -171,7 +171,7 @@ const useQueries = (variables, facetsArgs) => {
     variables: {
       query: facetsArgs.facetQuery,
       map: facetsArgs.facetMap,
-      from: 0,
+      from: 0, // For some reason, adding `from` and `to` here makes FilterNavigator not render on first render
       to: isLazyFacetsFetchEnabled ? FACETS_RENDER_THRESHOLD : undefined,
       fullText: variables.fullText,
       selectedFacets: variables.selectedFacets,

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -171,7 +171,7 @@ const useQueries = (variables, facetsArgs) => {
     variables: {
       query: facetsArgs.facetQuery,
       map: facetsArgs.facetMap,
-      from: 0, // For some reason, adding `from` and `to` here makes FilterNavigator not render on first render
+      from: 0,
       to: isLazyFacetsFetchEnabled ? FACETS_RENDER_THRESHOLD : undefined,
       fullText: variables.fullText,
       selectedFacets: variables.selectedFacets,

--- a/react/constants/filterConstants.js
+++ b/react/constants/filterConstants.js
@@ -1,0 +1,1 @@
+export const FACETS_RENDER_THRESHOLD = 10

--- a/react/package.json
+++ b/react/package.json
@@ -49,7 +49,7 @@
     "react-dom": "^16.8.3",
     "react-test-renderer": "^16.7.0",
     "regenerator-runtime": "^0.13.1",
-    "typescript": "3.8.3"
+    "typescript": "3.9.7"
   },
   "version": "3.76.0"
 }

--- a/react/utils/compatibilityLayer.js
+++ b/react/utils/compatibilityLayer.js
@@ -63,7 +63,13 @@ export const detachFiltersByType = facets => {
   const groupedFilters = byType(facets)
 
   const brands = pathOr([], ['BRAND', 0, 'facets'], groupedFilters)
-  const brandsQuantity = pathOr(0, ['BRAND', 0, 'quantity'], groupedFilters)
+  const brandsQuantity =
+    groupedFilters &&
+    groupedFilters.BRAND &&
+    groupedFilters.BRAND[0] &&
+    groupedFilters.BRAND[0].quantity != null
+      ? groupedFilters.BRAND[0].quantity
+      : 0
 
   const specificationFilters = (groupedFilters['NUMBER'] || []).concat(
     groupedFilters['TEXT'] || []

--- a/react/utils/compatibilityLayer.js
+++ b/react/utils/compatibilityLayer.js
@@ -63,6 +63,7 @@ export const detachFiltersByType = facets => {
   const groupedFilters = byType(facets)
 
   const brands = pathOr([], ['BRAND', 0, 'facets'], groupedFilters)
+  const brandsQuantity = pathOr(0, ['BRAND', 0, 'quantity'], groupedFilters)
 
   const specificationFilters = (groupedFilters['NUMBER'] || []).concat(
     groupedFilters['TEXT'] || []
@@ -86,6 +87,7 @@ export const detachFiltersByType = facets => {
 
   return {
     brands,
+    brandsQuantity,
     specificationFilters,
     categoriesTrees,
     priceRanges,

--- a/react/utils/getFilters.js
+++ b/react/utils/getFilters.js
@@ -12,6 +12,7 @@ const getFilters = ({
   specificationFilters = [],
   priceRanges = [],
   brands = [],
+  brandsQuantity = 0,
   hiddenFacets = {},
 }) => {
   const hiddenFacetsNames = (
@@ -28,6 +29,7 @@ const getFilters = ({
           type: SPECIFICATION_FILTERS_TYPE,
           title: spec.name,
           facets: spec.facets,
+          quantity: spec.quantity,
         }))
     : []
 
@@ -38,6 +40,7 @@ const getFilters = ({
         type: BRANDS_TYPE,
         title: BRANDS_TITLE,
         facets: brands,
+        quantity: brandsQuantity,
       },
     !hiddenFacets.priceRange &&
       !isEmpty(priceRanges) && {

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5857,12 +5857,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
-
-typescript@^3.3.3333:
+typescript@3.9.7, typescript@^3.3.3333:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==


### PR DESCRIPTION
#### What problem is this solving?

This PR adds some changes necessary to make the store setting enableFiltersFetchOptimization work. This setting is responsible for truncating facets after the 10th one and making it possible to fetch the rest with a refetch.

NEEDS
https://github.com/vtex-apps/search-graphql/pull/94
https://github.com/vtex-apps/search-resolver/pull/101
https://github.com/vtex-apps/store-resources/pull/138

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://iaronaraujo--storecomponents.myvtex.com/apparel---accessories/clothing/)

#### Screenshots or example usage:

Go to the workspace and then check on the graphql that in the FacetsV2 query the `from` value is 0 and `to` is 10 
![image](https://user-images.githubusercontent.com/8443580/94735403-14b38900-0341-11eb-8807-9bdffb44aa0d.png)
Then, on the `Color` filter, click on `show 4 more` and notice that the query was re-fetched, updating the results with every facet available!

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/mDBSZ4k8tMeMqHSYmQ/giphy.gif)
