### PR TITLE
Feature/filter outside click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- New prop `closeOnOutsideClick` on FilterNavigator to close filter on outside click.
+- Prop `closeOnOutsideClick` on `filter-navigator.v3` to close filter on outside click.
 
 ## [3.79.1] - 2020-10-20
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New prop `closeOnOutsideClick` on FilterNavigator to close filter on outside click.
 
 ## [3.79.1] - 2020-10-20
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -292,6 +292,7 @@ Check out the [**Product Summary documentation**](https://vtex.io/docs/component
 | `filtersTitleHtmlTag` | `string` | HTML tag for the filter's title. | `h5` |
 | `scrollToTop` | `enum` | Scrolls the page to the top (`auto` or `smooth`) or not (`none`) when selecting a facet. | `none` |
 | `truncateFilters` | `boolean` | Whether a filter selector with more than 10 filter options should shorten the list and display a `See more` button (`true`) or not (`false`). | `false` |
+| `closeOnOutsideClick` | `boolean` | Whether close the filter in the outside click (`true`) or not (`false`). This prop will only works with `openFiltersMode === 'one'`  | `false` |
 
 -  **`order-by` block**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -292,7 +292,7 @@ Check out the [**Product Summary documentation**](https://vtex.io/docs/component
 | `filtersTitleHtmlTag` | `string` | HTML tag for the filter's title. | `h5` |
 | `scrollToTop` | `enum` | Scrolls the page to the top (`auto` or `smooth`) or not (`none`) when selecting a facet. | `none` |
 | `truncateFilters` | `boolean` | Whether a filter selector with more than 10 filter options should shorten the list and display a `See more` button (`true`) or not (`false`). | `false` |
-| `closeOnOutsideClick` | `boolean` | Whether close the filter in the outside click (`true`) or not (`false`). This prop will only works with `openFiltersMode === 'one'`  | `false` |
+| `closeOnOutsideClick` | `boolean` | Whether the Filter Navigator component should be closed when users click outside of it (`true`) or not (`false`). Caution: This prop only works when the `openFiltersMode` prop is set as `one`.  | `false` |
 
 -  **`order-by` block**
 

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -76,6 +76,7 @@ const FilterNavigator = ({
   scrollToTop = 'none',
   openFiltersMode = 'many',
   filtersFetchMore,
+  closeOnOutsideClick = false,
 }) => {
   const { isMobile } = useDevice()
   const handles = useCssHandles(CSS_HANDLES)
@@ -229,6 +230,7 @@ const FilterNavigator = ({
               setTruncatedFacetsFetched={setTruncatedFacetsFetched}
               truncateFilters={truncateFilters}
               openFiltersMode={openFiltersMode}
+              closeOnOutsideClick={closeOnOutsideClick}
             />
           </div>
           <ExtensionPoint id="shop-review-summary" />

--- a/react/FilterNavigatorFlexible.js
+++ b/react/FilterNavigatorFlexible.js
@@ -16,6 +16,7 @@ const withSearchPageContextProps = Component => ({
   filtersTitleHtmlTag,
   truncateFilters,
   openFiltersMode,
+  closeOnOutsideClick
 }) => {
   const {
     searchQuery,
@@ -79,6 +80,7 @@ const withSearchPageContextProps = Component => ({
           filtersTitleHtmlTag={filtersTitleHtmlTag}
           truncateFilters={truncateFilters}
           openFiltersMode={openFiltersMode}
+          closeOnOutsideClick={closeOnOutsideClick}
         />
       </FilterNavigatorContext.Provider>
     </div>

--- a/react/components/AvailableFilters.js
+++ b/react/components/AvailableFilters.js
@@ -33,6 +33,7 @@ const Filter = ({
   setLastOpenFilter,
   truncatedFacetsFetched,
   setTruncatedFacetsFetched,
+  closeOnOutsideClick,
 }) => {
   const { type, title, facets, quantity, oneSelectedCollapse = false } = filter
 
@@ -65,6 +66,7 @@ const Filter = ({
           openFiltersMode={openFiltersMode}
           truncatedFacetsFetched={truncatedFacetsFetched}
           setTruncatedFacetsFetched={setTruncatedFacetsFetched}
+          closeOnOutsideClick={closeOnOutsideClick}
         />
       )
   }

--- a/react/components/FilterOptionTemplate.js
+++ b/react/components/FilterOptionTemplate.js
@@ -182,7 +182,10 @@ const FilterOptionTemplate = ({
     }
   }, [lastOpenFilter, open, openFiltersMode, setLastOpenFilter, title])
 
-  closeOnOutsideClick && useOutsideClick(filterRef, handleCollapse, isOpen)
+  // closeOnOutsideClick only works with openFiltersMode == 'one'
+  if (closeOnOutsideClick && openFiltersMode === 'one') {
+    useOutsideClick(filterRef, handleCollapse, isOpen)
+  }
 
   const handleKeyDown = useCallback(
     e => {

--- a/react/components/FilterOptionTemplate.js
+++ b/react/components/FilterOptionTemplate.js
@@ -18,6 +18,7 @@ import { useCssHandles } from 'vtex.css-handles'
 import styles from '../searchResult.css'
 import { SearchFilterBar } from './SearchFilterBar'
 import SettingsContext from './SettingsContext'
+import useOutsideClick from './../hooks/useOutsideClick'
 
 import { useRenderOnView } from '../hooks/useRenderOnView'
 import { FACETS_RENDER_THRESHOLD } from '../constants/filterConstants'
@@ -79,10 +80,12 @@ const FilterOptionTemplate = ({
   openFiltersMode,
   truncatedFacetsFetched,
   setTruncatedFacetsFetched,
+  closeOnOutsideClick = false,
 }) => {
   const [open, setOpen] = useState(!initiallyCollapsed)
   const { getSettings } = useRuntime()
   const scrollable = useRef()
+  const filterRef = useRef()
   const handles = useCssHandles(CSS_HANDLES)
   const { thresholdForFacetSearch } = useSettings()
   const [searchTerm, setSearchTerm] = useState('')
@@ -179,6 +182,8 @@ const FilterOptionTemplate = ({
     }
   }, [lastOpenFilter, open, openFiltersMode, setLastOpenFilter, title])
 
+  closeOnOutsideClick && useOutsideClick(filterRef, handleCollapse, isOpen)
+
   const handleKeyDown = useCallback(
     e => {
       if (e.key === ' ' && collapsable) {
@@ -210,7 +215,7 @@ const FilterOptionTemplate = ({
   )
 
   return (
-    <div className={containerClassName}>
+    <div className={containerClassName} ref={filterRef}>
       <div className={titleContainerClassName}>
         <div
           role="button"
@@ -256,14 +261,14 @@ const FilterOptionTemplate = ({
             theme={{ content: handles.filterContent }}
           >
             {thresholdForFacetSearch !== undefined &&
-            thresholdForFacetSearch < filters.length ? (
-              <SearchFilterBar name={title} handleChange={setSearchTerm} />
-            ) : null}
+              thresholdForFacetSearch < filters.length ? (
+                <SearchFilterBar name={title} handleChange={setSearchTerm} />
+              ) : null}
             {renderChildren()}
           </Collapse>
         ) : (
-          renderChildren()
-        )}
+              renderChildren()
+            )}
       </div>
     </div>
   )
@@ -299,6 +304,7 @@ FilterOptionTemplate.propTypes = {
   setTruncatedFacetsFetched: PropTypes.func,
   /** Quantity of facets of the current filter */
   quantity: PropTypes.number,
+  closeOnOutsideClick: PropTypes.bool,
 }
 
 export default FilterOptionTemplate

--- a/react/components/FilterOptionTemplate.js
+++ b/react/components/FilterOptionTemplate.js
@@ -182,10 +182,16 @@ const FilterOptionTemplate = ({
     }
   }, [lastOpenFilter, open, openFiltersMode, setLastOpenFilter, title])
 
-  // closeOnOutsideClick only works with openFiltersMode == 'one'
-  if (closeOnOutsideClick && openFiltersMode === 'one') {
-    useOutsideClick(filterRef, handleCollapse, isOpen)
-  }
+  useOutsideClick(
+    filterRef,
+    () => {
+      // closeOnOutsideClick only works with openFiltersMode == 'one'
+      if (closeOnOutsideClick && openFiltersMode === 'one') {
+        handleCollapse()
+      }
+    },
+    isOpen
+  )
 
   const handleKeyDown = useCallback(
     e => {
@@ -264,14 +270,14 @@ const FilterOptionTemplate = ({
             theme={{ content: handles.filterContent }}
           >
             {thresholdForFacetSearch !== undefined &&
-              thresholdForFacetSearch < filters.length ? (
-                <SearchFilterBar name={title} handleChange={setSearchTerm} />
-              ) : null}
+            thresholdForFacetSearch < filters.length ? (
+              <SearchFilterBar name={title} handleChange={setSearchTerm} />
+            ) : null}
             {renderChildren()}
           </Collapse>
         ) : (
-              renderChildren()
-            )}
+          renderChildren()
+        )}
       </div>
     </div>
   )

--- a/react/components/SearchFilter.js
+++ b/react/components/SearchFilter.js
@@ -25,6 +25,7 @@ const SearchFilter = ({
   openFiltersMode,
   truncatedFacetsFetched,
   setTruncatedFacetsFetched,
+  closeOnOutsideClick,
 }) => {
   const sampleFacet = facets && facets.length > 0 ? facets[0] : null
   const facetTitle = getFilterTitle(title, intl)
@@ -43,6 +44,7 @@ const SearchFilter = ({
       openFiltersMode={openFiltersMode}
       truncatedFacetsFetched={truncatedFacetsFetched}
       setTruncatedFacetsFetched={setTruncatedFacetsFetched}
+      closeOnOutsideClick={closeOnOutsideClick}
     >
       {facet => (
         <FacetItem
@@ -83,6 +85,7 @@ SearchFilter.propTypes = {
   setTruncatedFacetsFetched: PropTypes.func,
   /** Quantity of facets of the current filter */
   quantity: PropTypes.number,
+  closeOnOutsideClick: PropTypes.bool,
 }
 
 export default injectIntl(SearchFilter)


### PR DESCRIPTION
#### What problem is this solving?

This PR add a new prop `closeOnOutsideClick` on `filter-navigator.v3` component that allow close opened filters with outside click.

#### How to test it?

To test it you only need to open a filter and click outside it.

[Workspace](https://outsideclick--dzarm.myvtex.com/novidades)

#### Screenshots or example usage:

![outsideclick-filter](https://user-images.githubusercontent.com/47363947/94953921-b2809280-04be-11eb-8376-e107b3325d9c.gif)

#### Describe alternatives you've considered, if any.

#### Related to / Depends on

This behavior will only works when `openFiltersMode === 'one'`

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://gph.is/g/E368BRY)
