### PR TITLE
Fix clear button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Clear filters on mobile.
 
 ## [3.84.0] - 2020-11-11
 ### Added

--- a/react/SearchResultFlexible.js
+++ b/react/SearchResultFlexible.js
@@ -62,6 +62,12 @@ const SearchResultFlexible = ({
   thresholdForFacetSearch,
   lazyItemsRemaining,
 }) => {
+  const facetsFromPathname = pathname =>
+    pathname
+      .toLowerCase()
+      .split('/')
+      .filter(facet => facet)
+
   useEffect(() => {
     const pathname = window.location.pathname
     const initialSearch = window.initialSearchFacets
@@ -72,8 +78,8 @@ const SearchResultFlexible = ({
     }
 
     if (!preventRouteChange) {
-      const initialFacets = initialSearch.pathname.toLowerCase().split('/')
-      const newFacets = pathname.toLowerCase().split('/')
+      const initialFacets = facetsFromPathname(initialSearch.pathname)
+      const newFacets = facetsFromPathname(pathname)
       const totalEqualFacets = newFacets.filter(facet =>
         initialFacets.includes(facet)
       ).length

--- a/react/SearchResultFlexible.js
+++ b/react/SearchResultFlexible.js
@@ -62,6 +62,44 @@ const SearchResultFlexible = ({
   thresholdForFacetSearch,
   lazyItemsRemaining,
 }) => {
+  useEffect(() => {
+    const pathname = window.location.pathname
+    const initialSearch = window.initialSearchFacets
+
+    if (!initialSearch && searchQuery.facets) {
+      window.initialSearchFacets = { ...searchQuery.facets, pathname }
+      return
+    }
+
+    if (!preventRouteChange) {
+      const initialFacets = initialSearch.pathname.toLowerCase().split('/')
+      const newFacets = pathname.toLowerCase().split('/')
+      const totalEqualFacets = newFacets.filter(facet =>
+        initialFacets.includes(facet)
+      ).length
+
+      if (
+        (newFacets.length < initialFacets.length &&
+          totalEqualFacets === newFacets.length) ||
+        (newFacets.length > initialFacets.length &&
+          totalEqualFacets === initialFacets.length)
+      ) {
+        return
+      }
+
+      window.initialSearchFacets = { ...searchQuery.facets, pathname }
+      return
+    }
+
+    if (
+      searchQuery.facets &&
+      initialSearch.pathname !== pathname &&
+      searchQuery.facets.queryArgs.query !== initialSearch.queryArgs.query
+    ) {
+      window.initialSearchFacets = { ...searchQuery.facets, pathname }
+    }
+  }, [preventRouteChange, searchQuery.facets])
+
   //This makes infinite scroll unavailable.
   //Infinite scroll was deprecated and we have
   //removed it since the flexible search release

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -19,9 +19,9 @@ import { buildNewQueryMap } from '../hooks/useFacetNavigation'
 import styles from '../searchResult.css'
 import { getMainSearches } from '../utils/compatibilityLayer'
 import {
-  isCategoryDepartmentCollectionOrFT,
-  filterCategoryDepartmentCollectionAndFT,
-} from '../utils/queryAndMapUtils'
+  filterInitialSelected,
+  isInitialFacet,
+} from '../utils/initialSearchUtils'
 
 const CSS_HANDLES = [
   'filterPopupButton',
@@ -53,6 +53,7 @@ const FilterSidebar = ({
     searchQuery.data &&
     searchQuery.data.productSearch &&
     searchQuery.data.productSearch.recordsFiltered
+  const initialSearch = window.initialSearchFacets
 
   const [filterOperations, setFilterOperations] = useState([])
   const [categoryTreeOperations, setCategoryTreeOperations] = useState([])
@@ -94,12 +95,12 @@ const FilterSidebar = ({
     shouldClear.current = true
     // Gets the previously selected facets that should be cleared
     const selectedFacets = selectedFilters.filter(
-      facet => !isCategoryDepartmentCollectionOrFT(facet.key) && facet.selected
+      facet => facet.selected && !isInitialFacet(facet, initialSearch)
     )
 
-    // Should not clear categories, departments and clusterIds
+    // Should not clear initial search facets
     const selectedRest = filterOperations.filter(facet =>
-      isCategoryDepartmentCollectionOrFT(facet.key)
+      isInitialFacet(facet, initialSearch)
     )
 
     setFilterOperations([...selectedFacets, ...selectedRest])
@@ -133,11 +134,10 @@ const FilterSidebar = ({
     const fullTextAndCollection = getMainSearches(query, map)
 
     /* This removes the previously selected stuff from the context when you click on 'clear'.
-    It is important to notice that it keeps categories, departments and clusterIds since they
-    are important to show the correct facets. */
+    It is important to notice that it keeps the initial search facets. */
     if (shouldClear.current) {
       shouldClear.current = false
-      return filterCategoryDepartmentCollectionAndFT(filterContext)
+      return filterInitialSelected(filterContext, initialSearch)
     }
 
     /* The spread on selectedFilters was necessary because buildNewQueryMap
@@ -148,7 +148,7 @@ const FilterSidebar = ({
         ...selectedFilters,
       ]),
     }
-  }, [filterOperations, filterContext, selectedFilters])
+  }, [filterContext, filterOperations, initialSearch, selectedFilters])
 
   return (
     <Fragment>

--- a/react/utils/initialSearchUtils.js
+++ b/react/utils/initialSearchUtils.js
@@ -1,0 +1,33 @@
+import { PATH_SEPARATOR, MAP_VALUES_SEP } from '../constants'
+
+export const isInitialFacet = (facet, initialSearch) => {
+  if (!initialSearch) {
+    return false
+  }
+
+  const initialFacets = initialSearch.specificationFilters.flatMap(filter =>
+    filter.facets.filter(facet => facet.selected)
+  )
+
+  return initialFacets.some(
+    initialFacet =>
+      initialFacet.key === facet.key && initialFacet.value === facet.value
+  )
+}
+
+export const filterInitialSelected = (context, initialSearch) => {
+  const query = context.query.split(PATH_SEPARATOR)
+  const map = context.map.split(MAP_VALUES_SEP)
+  const newQuery = []
+  const newMap = []
+  for (let i = 0; i < map.length; i++) {
+    if (isInitialFacet({ key: map[i], value: query[i] }, initialSearch)) {
+      newQuery.push(query[i])
+      newMap.push(map[i])
+    }
+  }
+  return {
+    query: newQuery.join(PATH_SEPARATOR),
+    map: newMap.join(MAP_VALUES_SEP),
+  }
+}

--- a/react/utils/queryAndMapUtils.ts
+++ b/react/utils/queryAndMapUtils.ts
@@ -2,19 +2,8 @@ import {
   MAP_CATEGORY_CHAR,
   DEPARTMENT,
   CATEGORY,
-  PATH_SEPARATOR,
-  MAP_VALUES_SEP,
-  PRODUCT_CLUSTER_IDS,
   FULLTEXT_QUERY_KEY,
 } from '../constants'
-
-const CATEGORY_DEPARTMENTS_CLUSTER_ID_FT = [
-  MAP_CATEGORY_CHAR,
-  PRODUCT_CLUSTER_IDS,
-  CATEGORY,
-  DEPARTMENT,
-  FULLTEXT_QUERY_KEY,
-]
 
 const CATEGORY_DEPARTMENTS_FT = [
   MAP_CATEGORY_CHAR,
@@ -30,25 +19,4 @@ export const isSameMap = (map1: string, map2: string) => {
     return CATEGORY_DEPARTMENTS_FT.includes(map2)
   }
   return map1 === map2
-}
-
-export const isCategoryDepartmentCollectionOrFT = (term: string) => {
-  return CATEGORY_DEPARTMENTS_CLUSTER_ID_FT.includes(term)
-}
-
-export const filterCategoryDepartmentCollectionAndFT = (context: any) => {
-  const query = context.query.split(PATH_SEPARATOR)
-  const map = context.map.split(MAP_VALUES_SEP)
-  const newQuery = []
-  const newMap = []
-  for (let i = 0; i < map.length; i++) {
-    if (isCategoryDepartmentCollectionOrFT(map[i])) {
-      newQuery.push(query[i])
-      newMap.push(map[i])
-    }
-  }
-  return {
-    query: newQuery.join(PATH_SEPARATOR),
-    map: newMap.join(MAP_VALUES_SEP),
-  }
 }


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
there are two problems with the current clear filters button:

- if the initial search includes a filter that is not a category, department or collection, that filter will be removed if you clear the filters.
- if `preventRouteChange` is `false`, the button clears all filters, regardless of type, and consequently leaves the search page.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->
[Before](https://alssports.myvtex.com/clothing/jackets/Mens?map=c,c,specificationFilter_7721)
[After](https://mobileclear--alssports.myvtex.com/clothing/jackets/Mens?map=c,c,specificationFilter_7721&__device=phone)
[After - without `preventRouteChange`](https://mobilewithoutprevent--alssports.myvtex.com/clothing/jackets/Mens?map=c,c,specificationFilter_7721)

- on mobile, select a filter and apply.
- open the filter sidebar, and click the clear button
- only the applied filter must be cleaned, and the search must return to the initial state

#### Screenshots or example usage:

Before:
![beforeprevent](https://user-images.githubusercontent.com/20840671/95628446-71572800-0a54-11eb-9eb5-97aea05a9d46.gif)

After:
![afterprevent](https://user-images.githubusercontent.com/20840671/95628466-7b792680-0a54-11eb-9f75-3f1394b35fd8.gif)


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->
- initially i tried to save the initial state in a context within the search-result, however this does not work without `preventRouteChange` since the initial state was lost whenever the route changed. for this reason, and because it would be strange to put this search info in a context outside the search, the option that made most sense was to put it in the `window` object. however, if you have an alternative that seems more appropriate, we can change this. :)

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
