### PR TITLE
Fixed enableFiltersFetchOptimization on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `enableFiltersFetchOptimization` also affecting the mobile environment, always showing the maximum of 10 facets on mobile.
 
 ## [3.78.0] - 2020-10-13
 ### Added

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -81,12 +81,18 @@ const FilterNavigator = ({
   const handles = useCssHandles(CSS_HANDLES)
   const [truncatedFacetsFetched, setTruncatedFacetsFetched] = useState(false)
 
+  const mobileLayout =
+    (isMobile && layout === LAYOUT_TYPES.responsive) ||
+    layout === LAYOUT_TYPES.mobile
+
   useEffect(() => {
     // This condition confirms if there are facets that still need fetching
     const needsFetching = !!filters.find(
       filter => filter.quantity > filter.facets.length
     )
-    if (truncatedFacetsFetched && needsFetching && !loading) {
+
+    // The mobileLayout is part of this condition while we do not have a showMoreFacets button on mobile
+    if ((mobileLayout || truncatedFacetsFetched) && needsFetching && !loading) {
       filtersFetchMore({
         variables: {
           from: FACETS_RENDER_THRESHOLD,
@@ -119,9 +125,6 @@ const FilterNavigator = ({
       })
     }
   }, [filters, filtersFetchMore, truncatedFacetsFetched, loading])
-  const mobileLayout =
-    (isMobile && layout === LAYOUT_TYPES.responsive) ||
-    layout === LAYOUT_TYPES.mobile
 
   const selectedFilters = useMemo(() => {
     const options = [


### PR DESCRIPTION
#### What problem is this solving?

When enableFiltersFetchOptimization was enabled, only a maximum of 10 facets was shown on mobile. This PR disables this feature for mobile environments while we design the appropriate solution for this to work on mobile.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://iaronaraujo--storecomponents.myvtex.com/apparel---accessories/clothing/)
Go on mobile and check that the `Color` filter has more than 10 facets!

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/xT9NvBB5LKshAIWOPK/giphy.gif)
