### PR TITLE
Feature/category links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `"categoryFiltersMode"` prop to Filter Navigation Flexible
+- `categoryFiltersMode` prop to Filter Navigator Flexible.
 
 ## [3.86.4] - 2020-12-02
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `"categoryFiltersMode"` prop to Filter Navigation Flexible
 
 ## [3.86.4] - 2020-12-02
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -282,12 +282,11 @@ Check out the [**Product Summary documentation**](https://vtex.io/docs/component
 
 - **`filter-navigator.v3` block**
 
+
 | Prop name | Type                      | Description                                                                                       | Default value |
 | --------- | ------------------------- | ------------------------------------------------------------------------------------------------- | ------------- |
-
 | `categoryFiltersMode`  | `Enum` | Whether the Category Filter should add href (`href`) or not (`default`). By default the filter uses divs with role="link" you may change to href to improve store Link building. | `default`  |
 | `layout`  | `Enum` | Whether the Filter Navigator layout should be responsive (`responsive`) or not (`desktop`). You may use `desktop` when the Filter Navigator was configured to be displayed in a [drawer](https://vtex.io/docs/components/content-blocks/vtex.store-drawer@0.9.0). | `responsive`  |
-
 | `maxItemsDepartment` | `number`                 | Maximum number of departments to be displayed before the See More button is triggered.          | `8`             |
 | `maxItemsCategory`   | `number`                 | Maximum number of category items to be displayed before the See More button is triggered.     | `8`             |
 | `initiallyCollapsed` | `Boolean` | Makes the search filters start out collapsed (`true`) or open (`false`). | `false` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -284,7 +284,10 @@ Check out the [**Product Summary documentation**](https://vtex.io/docs/component
 
 | Prop name | Type                      | Description                                                                                       | Default value |
 | --------- | ------------------------- | ------------------------------------------------------------------------------------------------- | ------------- |
+
+| `categoryFiltersMode`  | `Enum` | Whether the Category Filter should add href (`href`) or not (`default`). By default the filter uses divs with role="link" you may change to href to improve store Link building. | `default`  |
 | `layout`  | `Enum` | Whether the Filter Navigator layout should be responsive (`responsive`) or not (`desktop`). You may use `desktop` when the Filter Navigator was configured to be displayed in a [drawer](https://vtex.io/docs/components/content-blocks/vtex.store-drawer@0.9.0). | `responsive`  |
+
 | `maxItemsDepartment` | `number`                 | Maximum number of departments to be displayed before the See More button is triggered.          | `8`             |
 | `maxItemsCategory`   | `number`                 | Maximum number of category items to be displayed before the See More button is triggered.     | `8`             |
 | `initiallyCollapsed` | `Boolean` | Makes the search filters start out collapsed (`true`) or open (`false`). | `false` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -284,7 +284,7 @@ Check out the [**Product Summary documentation**](https://vtex.io/docs/component
 
 | Prop name | Type                      | Description                                                                                       | Default value |
 | --------- | ------------------------- | ------------------------------------------------------------------------------------------------- | ------------- |
-| `categoryFiltersMode`  | `Enum` | Whether the Category Filters should use href (`href`) or not (`default`). By default the filter uses divs with role="link" you may change to href to improve store Link Building. | `default`  |
+| `categoryFiltersMode`  | `enum` | Whether the category filters should use the `href` attribute with the category pages' URLs (`href`) or not (`default`). By default, the filters use HTML divs with `role="link"`. You may change this behavior by setting this prop's value to `href`, thereby creating a link building to improve the SEO ranking of your category pages. | `default`  |
 | `layout`  | `Enum` | Whether the Filter Navigator layout should be responsive (`responsive`) or not (`desktop`). You may use `desktop` when the Filter Navigator was configured to be displayed in a [drawer](https://vtex.io/docs/components/content-blocks/vtex.store-drawer@0.9.0). | `responsive`  |
 | `maxItemsDepartment` | `number`                 | Maximum number of departments to be displayed before the See More button is triggered.          | `8`             |
 | `maxItemsCategory`   | `number`                 | Maximum number of category items to be displayed before the See More button is triggered.     | `8`             |

--- a/docs/README.md
+++ b/docs/README.md
@@ -282,10 +282,9 @@ Check out the [**Product Summary documentation**](https://vtex.io/docs/component
 
 - **`filter-navigator.v3` block**
 
-
 | Prop name | Type                      | Description                                                                                       | Default value |
 | --------- | ------------------------- | ------------------------------------------------------------------------------------------------- | ------------- |
-| `categoryFiltersMode`  | `Enum` | Whether the Category Filter should add href (`href`) or not (`default`). By default the filter uses divs with role="link" you may change to href to improve store Link building. | `default`  |
+| `categoryFiltersMode`  | `Enum` | Whether the Category Filters should use href (`href`) or not (`default`). By default the filter uses divs with role="link" you may change to href to improve store Link Building. | `default`  |
 | `layout`  | `Enum` | Whether the Filter Navigator layout should be responsive (`responsive`) or not (`desktop`). You may use `desktop` when the Filter Navigator was configured to be displayed in a [drawer](https://vtex.io/docs/components/content-blocks/vtex.store-drawer@0.9.0). | `responsive`  |
 | `maxItemsDepartment` | `number`                 | Maximum number of departments to be displayed before the See More button is triggered.          | `8`             |
 | `maxItemsCategory`   | `number`                 | Maximum number of category items to be displayed before the See More button is triggered.     | `8`             |

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -202,6 +202,7 @@ const FilterNavigator = ({
               truncateFilters={truncateFilters}
               truncatedFacetsFetched={truncatedFacetsFetched}
               setTruncatedFacetsFetched={setTruncatedFacetsFetched}
+              categoryFiltersMode={categoryFiltersMode}
             />
           </div>
         </div>

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -72,6 +72,7 @@ const FilterNavigator = ({
   layout = LAYOUT_TYPES.responsive,
   maxItemsDepartment = 8,
   maxItemsCategory = 8,
+  categoryFiltersMode = 'default',
   filtersTitleHtmlTag = 'h5',
   scrollToTop = 'none',
   openFiltersMode = 'many',
@@ -82,6 +83,7 @@ const FilterNavigator = ({
   fullWidthOnMobile = false,
   navigationTypeOnMobile = 'page',
 }) => {
+  console.log('>>>>categoryFiltersMode', categoryFiltersMode);
   const { isMobile } = useDevice()
   const handles = useCssHandles(CSS_HANDLES)
   const [truncatedFacetsFetched, setTruncatedFacetsFetched] = useState(false)
@@ -230,6 +232,7 @@ const FilterNavigator = ({
               preventRouteChange={preventRouteChange}
               maxItemsDepartment={maxItemsDepartment}
               maxItemsCategory={maxItemsCategory}
+              categoryFiltersMode={categoryFiltersMode}
             />
             <AvailableFilters
               filters={filters}

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -83,7 +83,6 @@ const FilterNavigator = ({
   fullWidthOnMobile = false,
   navigationTypeOnMobile = 'page',
 }) => {
-  console.log('>>>>categoryFiltersMode', categoryFiltersMode);
   const { isMobile } = useDevice()
   const handles = useCssHandles(CSS_HANDLES)
   const [truncatedFacetsFetched, setTruncatedFacetsFetched] = useState(false)

--- a/react/FilterNavigatorFlexible.js
+++ b/react/FilterNavigatorFlexible.js
@@ -13,6 +13,7 @@ const withSearchPageContextProps = Component => ({
   scrollToTop,
   maxItemsDepartment,
   maxItemsCategory,
+  categoryFiltersMode,
   filtersTitleHtmlTag,
   truncateFilters,
   openFiltersMode,
@@ -81,6 +82,7 @@ const withSearchPageContextProps = Component => ({
           scrollToTop={scrollToTop}
           maxItemsDepartment={maxItemsDepartment}
           maxItemsCategory={maxItemsCategory}
+          categoryFiltersMode={categoryFiltersMode}
           filtersTitleHtmlTag={filtersTitleHtmlTag}
           truncateFilters={truncateFilters}
           openFiltersMode={openFiltersMode}

--- a/react/components/AccordionFilterContainer.js
+++ b/react/components/AccordionFilterContainer.js
@@ -139,7 +139,6 @@ const AccordionFilterContainer = ({
               onCategorySelect={onCategorySelect}
               categoryFiltersMode={categoryFiltersMode}
               hideBorder
-              categoryFiltersMode={categoryFiltersMode}
             />
           </div>
         </AccordionFilterItem>

--- a/react/components/AccordionFilterContainer.js
+++ b/react/components/AccordionFilterContainer.js
@@ -137,6 +137,7 @@ const AccordionFilterContainer = ({
               tree={tree}
               isVisible={tree.length > 0}
               onCategorySelect={onCategorySelect}
+              categoryFiltersMode={categoryFiltersMode}
               hideBorder
               categoryFiltersMode={categoryFiltersMode}
             />

--- a/react/components/AccordionFilterContainer.js
+++ b/react/components/AccordionFilterContainer.js
@@ -35,6 +35,7 @@ const AccordionFilterContainer = ({
   truncateFilters,
   truncatedFacetsFetched,
   setTruncatedFacetsFetched,
+  categoryFiltersMode
 }) => {
   const { getSettings } = useRuntime()
   const [openItem, setOpenItem] = useState(null)
@@ -137,6 +138,7 @@ const AccordionFilterContainer = ({
               isVisible={tree.length > 0}
               onCategorySelect={onCategorySelect}
               hideBorder
+              categoryFiltersMode={categoryFiltersMode}
             />
           </div>
         </AccordionFilterItem>

--- a/react/components/CategoryFilter.js
+++ b/react/components/CategoryFilter.js
@@ -152,6 +152,7 @@ const CategoryFilter = ({
                 render={(childCategory, index) => (
                   <CategoryItem
                     key={childCategory.id}
+                    href={childCategory.href}
                     className={classNames({
                       mt2: index === 0 && !shallow,
                     })}

--- a/react/components/CategoryFilter.js
+++ b/react/components/CategoryFilter.js
@@ -43,6 +43,7 @@ const CategoryFilter = ({
   onCategorySelect,
   preventRouteChange,
   maxItemsCategory,
+  categoryFiltersMode
 }) => {
   const { map } = useFilterNavigator()
   const handles = useCssHandles(CSS_HANDLES)
@@ -153,6 +154,7 @@ const CategoryFilter = ({
                   <CategoryItem
                     key={childCategory.id}
                     href={childCategory.href}
+                    categoryFiltersMode={categoryFiltersMode}
                     className={classNames({
                       mt2: index === 0 && !shallow,
                     })}

--- a/react/components/CategoryItem.js
+++ b/react/components/CategoryItem.js
@@ -10,7 +10,6 @@ const CategoryItem = ({ label, onClick, className, href }) => {
   return (
     <a
       tabIndex={0}
-      role="link"
       className={classNames(
         handles.categoryItemChildren,
         'ph5 ph3-ns pv5 pv1-ns lh-copy pointer hover-bg-muted-5 c-muted-1 db no-underline',

--- a/react/components/CategoryItem.js
+++ b/react/components/CategoryItem.js
@@ -4,22 +4,27 @@ import { useCssHandles } from 'vtex.css-handles'
 
 const CSS_HANDLES = ['categoryItemChildren']
 
-const CategoryItem = ({ label, onClick, className }) => {
+const CategoryItem = ({ label, onClick, className, href }) => {
   const handles = useCssHandles(CSS_HANDLES)
   return (
-    <div
+    <a
       tabIndex={0}
       role="link"
       className={classNames(
         handles.categoryItemChildren,
-        'ph5 ph3-ns pv5 pv1-ns lh-copy pointer hover-bg-muted-5 c-muted-1',
+        'ph5 ph3-ns pv5 pv1-ns lh-copy pointer hover-bg-muted-5 c-muted-1 db no-underline',
         className
       )}
-      onClick={onClick}
+      onClick={e => {
+        e.preventDefault()
+        onClick()
+      }}
+      href={href}
+      title={label}
       onKeyDown={e => e.key === 'Enter' && onClick(e)}
     >
       {label}
-    </div>
+    </a>
   )
 }
 

--- a/react/components/CategoryItem.js
+++ b/react/components/CategoryItem.js
@@ -20,7 +20,7 @@ const CategoryItem = ({ label, onClick, className, href }) => {
         e.preventDefault()
         onClick()
       }}
-      href={href ? href.toLowerCase() : href}
+      href={href && href.toLowerCase()}
       title={label}
       onKeyDown={e => e.key === 'Enter' && onClick(e)}
     >

--- a/react/components/CategoryItem.js
+++ b/react/components/CategoryItem.js
@@ -4,27 +4,45 @@ import { useCssHandles } from 'vtex.css-handles'
 
 const CSS_HANDLES = ['categoryItemChildren']
 
-const CategoryItem = ({ label, onClick, className, href }) => {
+const CategoryItem = ({ label, onClick, className, href, categoryFiltersMode }) => {
   const handles = useCssHandles(CSS_HANDLES)
 
+  if (categoryFiltersMode === 'href') {
+    return (
+      <a
+        tabIndex={0}
+        className={classNames(
+          handles.categoryItemChildren,
+          'ph5 ph3-ns pv5 pv1-ns lh-copy pointer hover-bg-muted-5 c-muted-1 db no-underline',
+          className
+        )}
+        onClick={e => {
+          e.preventDefault()
+          onClick()
+        }}
+        href={href && href.toLowerCase()}
+        title={label}
+        onKeyDown={e => e.key === 'Enter' && onClick(e)}
+      >
+        {label}
+      </a>
+    )
+  }
+
   return (
-    <a
+    <div
       tabIndex={0}
+      role="link"
       className={classNames(
         handles.categoryItemChildren,
-        'ph5 ph3-ns pv5 pv1-ns lh-copy pointer hover-bg-muted-5 c-muted-1 db no-underline',
+        'ph5 ph3-ns pv5 pv1-ns lh-copy pointer hover-bg-muted-5 c-muted-1',
         className
       )}
-      onClick={e => {
-        e.preventDefault()
-        onClick()
-      }}
-      href={href && href.toLowerCase()}
-      title={label}
+      onClick={onClick}
       onKeyDown={e => e.key === 'Enter' && onClick(e)}
     >
       {label}
-    </a>
+    </div>
   )
 }
 

--- a/react/components/CategoryItem.js
+++ b/react/components/CategoryItem.js
@@ -6,6 +6,7 @@ const CSS_HANDLES = ['categoryItemChildren']
 
 const CategoryItem = ({ label, onClick, className, href }) => {
   const handles = useCssHandles(CSS_HANDLES)
+
   return (
     <a
       tabIndex={0}
@@ -19,7 +20,7 @@ const CategoryItem = ({ label, onClick, className, href }) => {
         e.preventDefault()
         onClick()
       }}
-      href={href}
+      href={href ? href.toLowerCase() : href}
       title={label}
       onKeyDown={e => e.key === 'Enter' && onClick(e)}
     >

--- a/react/components/DepartmentFilters.js
+++ b/react/components/DepartmentFilters.js
@@ -22,6 +22,7 @@ const DepartmentFilters = ({
   preventRouteChange,
   maxItemsDepartment,
   maxItemsCategory,
+  categoryFiltersMode
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
   if (!isVisible || tree.length === 0) {
@@ -69,6 +70,7 @@ const DepartmentFilters = ({
                 onCategorySelect={onCategorySelect}
                 preventRouteChange={preventRouteChange}
                 maxItemsCategory={maxItemsCategory}
+                categoryFiltersMode={categoryFiltersMode}
               />
             )}
           />
@@ -78,6 +80,7 @@ const DepartmentFilters = ({
             onCategorySelect={onCategorySelect}
             preventRouteChange={preventRouteChange}
             maxItemsCategory={maxItemsCategory}
+            categoryFiltersMode={categoryFiltersMode}
           />
         )}
       </div>

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -48,6 +48,7 @@ const FilterSidebar = ({
   truncateFilters,
   truncatedFacetsFetched,
   setTruncatedFacetsFetched,
+  categoryFiltersMode
 }) => {
   const { searchQuery } = useSearchPage()
   const filterContext = useFilterNavigator()
@@ -192,6 +193,7 @@ const FilterSidebar = ({
             truncateFilters={truncateFilters}
             truncatedFacetsFetched={truncatedFacetsFetched}
             setTruncatedFacetsFetched={setTruncatedFacetsFetched}
+            categoryFiltersMode={categoryFiltersMode}
           />
           <ExtensionPoint id="sidebar-close-button" onClose={handleClose} />
         </FilterNavigatorContext.Provider>


### PR DESCRIPTION
#### What problem is this solving?
This pull request is related to this issue: https://github.com/vtex-apps/store-discussion/issues/371

Today the category links are divs with role="link". It works fine but I think that would be best to use just `<a>` tags as suggested in Mozilla docs: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_link_role and by a SEO team of one of my clients.

With tags we also will improve the experience because the user will can open link in a new tab

#### How to test it?
You can test in this workspace: 

[Workspace](https://mathias1--compracerta.myvtex.com/eletrodomesticos)

#### Screenshots or example usage:
There is no visual changes
![image](https://user-images.githubusercontent.com/16908590/96489996-9860e700-1216-11eb-8528-d8fa24810314.png)


#### Describe alternatives you've considered, if any.

I think that this change may affect some stores because I changed a `<div>` tag to a `<a>` tag. To mantain the compatibility I add the "db no-underline" classes and did not change the css handle. One alternative that I think is to enable this change by prop, but I really do not think that is a prop that makes sense since the  `<a>` is clearly the recommended option.


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/9PgvV8ale90lQwfQTZ/giphy.gif)
