### PR TITLE
Fix/fetch filters partially

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Added `key` to `filter-less-items` & `filter-more-items` preventing button focus to fix unwanted auto-scroll behavior on chromium-based browsers.
 
 ## [3.79.0] - 2020-10-14
 ### Added

--- a/react/components/FilterOptionTemplate.js
+++ b/react/components/FilterOptionTemplate.js
@@ -147,6 +147,9 @@ const FilterOptionTemplate = ({
           <button
             onClick={() => openTruncated(truncated => !truncated)}
             className={`${handles.seeMoreButton} mt2 pv2 bn pointer c-link`}
+            key={
+              truncated ? 'store/filter.more-items' : 'store/filter.less-items'
+            }
           >
             <FormattedMessage
               id={


### PR DESCRIPTION
#### What problem is this solving?

Chromium based browsers auto-scroll behavior to keep showing a button on-screen after clicking it

![Peek 2020-10-20 11-43](https://user-images.githubusercontent.com/51974587/96602560-87bd7900-12c9-11eb-8d8a-2456c56a746a.gif)

#### How to test it?

Click on see-more button after loading the page

![feature](https://user-images.githubusercontent.com/51974587/96602105-0bc33100-12c9-11eb-8525-6323e4d34577.gif)

[Workspace](https://ecom8452--carrefourbr.myvtex.com/Celulares-Smartphones-e-Smartwatches/Smartphones?crfimt=hm-tlink|carrefour|menu|campanha|smartphones|1|120820)

#### Screenshots or example usage:

![feature](https://user-images.githubusercontent.com/51974587/96602105-0bc33100-12c9-11eb-8525-6323e4d34577.gif)

#### Describe alternatives you've considered, if any.
n.a.
#### Related to / Depends on
n.a.
#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/O7b01gFko9Ohy/giphy.gif)
