### PR TITLE
Fix search title with percentage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Search title with percentage.
 
 ## [3.81.1] - 2020-11-05
 ### Changed

--- a/react/SearchTitle.js
+++ b/react/SearchTitle.js
@@ -58,14 +58,21 @@ const SearchTitle = props => {
 
   const title =
     index >= 0 ? breadcrumbName(index, breadcrumb) : getLastName(breadcrumb)
+
+  const decodedTitle = useMemo(() => {
+    try {
+      return decodeURI(title)
+    } catch {
+      return title
+    }
+  }, [title])
+
   if (!title) {
     return null
   }
 
   return (
-    <h1 className={classNames(wrapperClass, 't-heading-1')}>
-      {decodeURI(title)}
-    </h1>
+    <h1 className={classNames(wrapperClass, 't-heading-1')}>{decodedTitle}</h1>
   )
 }
 


### PR DESCRIPTION
#### What problem is this solving?

When the search title had a percentage symbol (`%`) the SearchTitle component was not displayed due to an error when trying to run `decodeURI(title)`

[Issue](https://github.com/vtex-apps/store-discussion/issues/442)

<!--- What is the motivation and context for this change? -->

#### How to test it?

[Before](https://acctglobal.myvtex.com/141?map=productClusterIds)

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://raissateste--acctglobal.myvtex.com/141?map=productClusterIds)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
