### PR TITLE
Add category to SearchQuery: variables on SearchQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `category` to `SearchQuery: variables` on `SearchQuery`
 
 ## [3.79.1] - 2020-10-20
 ### Fixed

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -228,6 +228,7 @@ const useQueries = (variables, facetsArgs) => {
 }
 
 const SearchQuery = ({
+  category,
   maxItemsPerPage,
   query,
   map,
@@ -295,6 +296,7 @@ const SearchQuery = ({
 
   const variables = useMemo(() => {
     return {
+      category,
       map,
       query,
       orderBy,
@@ -318,6 +320,7 @@ const SearchQuery = ({
         installmentCriteria || DEFAULT_QUERY_VALUES.installmentCriteria,
     }
   }, [
+    category,
     map,
     query,
     orderBy,


### PR DESCRIPTION
#### What problem is this solving?

Add `category` to `SearchQuery: variables` on `SearchQuery`

#### How to test it?

`category` field is returning empty on `search-resolver` response. 

[Workspace]https://ricardofreitas--iocea.myvtex.com/moda-masculina/bermudas

#### Screenshots or example usage:

screenshot of productSearch args return on search-resolver app without PR changes
![image](https://user-images.githubusercontent.com/26003016/98120915-59c16280-1e8d-11eb-80cd-e1d6b0616d2e.png)

screenshot of productSearch args return on search-resolver app with PR changes
![image](https://user-images.githubusercontent.com/26003016/98121054-8aa19780-1e8d-11eb-8425-053a4a0b92b8.png)

#### Related to / Depends on

https://github.com/vtex-apps/store-resources/pull/139

https://github.com/vtex-apps/search-result/pull/446


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
