### PR TITLE
Add fetch optimization for collapsible filters on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- `enableFiltersFetchOptimization` now working on mobile.
+
 ## [3.85.4] - 2020-11-13
 
 ### Fixed

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -97,7 +97,7 @@ const FilterNavigator = ({
     )
 
     // The mobileLayout is part of this condition while we do not have a showMoreFacets button on mobile
-    if ((mobileLayout || truncatedFacetsFetched) && needsFetching && !loading) {
+    if (truncatedFacetsFetched && needsFetching && !loading) {
       filtersFetchMore({
         variables: {
           from: FACETS_RENDER_THRESHOLD,
@@ -200,6 +200,8 @@ const FilterNavigator = ({
               navigationType={navigationTypeOnMobile}
               initiallyCollapsed={initiallyCollapsed}
               truncateFilters={truncateFilters}
+              truncatedFacetsFetched={truncatedFacetsFetched}
+              setTruncatedFacetsFetched={setTruncatedFacetsFetched}
             />
           </div>
         </div>

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -96,7 +96,6 @@ const FilterNavigator = ({
       filter => filter.quantity > filter.facets.length
     )
 
-    // The mobileLayout is part of this condition while we do not have a showMoreFacets button on mobile
     if (truncatedFacetsFetched && needsFetching && !loading) {
       filtersFetchMore({
         variables: {

--- a/react/__tests__/AccordionFilterContainer.test.js
+++ b/react/__tests__/AccordionFilterContainer.test.js
@@ -1,6 +1,17 @@
 import React from 'react'
 import { render } from '@vtex/test-tools/react'
 import AccordionFilterContainer from '../components/AccordionFilterContainer'
+import { useRuntime } from '../__mocks__/vtex.render-runtime'
+
+const mockUseRuntime = useRuntime
+
+beforeEach(() => {
+  jest.clearAllMocks()
+
+  mockUseRuntime.mockImplementation(() => ({
+    getSettings: () => ({}),
+  }))
+})
 
 describe('<AccordionFilterContainer />', () => {
   const renderComponent = () => {

--- a/react/components/AccordionFilterContainer.js
+++ b/react/components/AccordionFilterContainer.js
@@ -32,6 +32,8 @@ const AccordionFilterContainer = ({
   navigationType,
   initiallyCollapsed,
   truncateFilters,
+  truncatedFacetsFetched,
+  setTruncatedFacetsFetched,
 }) => {
   const [openItem, setOpenItem] = useState(null)
   const handles = useCssHandles(CSS_HANDLES)
@@ -158,6 +160,7 @@ const AccordionFilterContainer = ({
               <AccordionFilterGroup
                 title={filter.title}
                 facets={filter.facets}
+                quantity={filter.quantity}
                 key={title}
                 className={itemClassName}
                 open={isOpen}
@@ -168,6 +171,8 @@ const AccordionFilterContainer = ({
                 navigationType={navigationType}
                 initiallyCollapsed={initiallyCollapsed}
                 truncateFilters={truncateFilters}
+                truncatedFacetsFetched={truncatedFacetsFetched}
+                setTruncatedFacetsFetched={setTruncatedFacetsFetched}
               />
             )
         }
@@ -197,6 +202,10 @@ AccordionFilterContainer.propTypes = {
   initiallyCollapsed: PropTypes.bool,
   /** If filters start truncated */
   truncateFilters: PropTypes.bool,
+  /** If the truncated facets were fetched */
+  truncatedFacetsFetched: PropTypes.bool,
+  /** Sets if the truncated facets were fetched */
+  setTruncatedFacetsFetched: PropTypes.func,
 }
 
 export default injectIntl(AccordionFilterContainer)

--- a/react/components/AccordionFilterContainer.js
+++ b/react/components/AccordionFilterContainer.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { injectIntl, intlShape } from 'react-intl'
 import classNames from 'classnames'
 import { IconCaret } from 'vtex.store-icons'
+import { useRuntime } from 'vtex.render-runtime'
 
 import AccordionFilterItem from './AccordionFilterItem'
 import DepartmentFilters from './DepartmentFilters'
@@ -35,14 +36,21 @@ const AccordionFilterContainer = ({
   truncatedFacetsFetched,
   setTruncatedFacetsFetched,
 }) => {
+  const { getSettings } = useRuntime()
   const [openItem, setOpenItem] = useState(null)
   const handles = useCssHandles(CSS_HANDLES)
+  const isLazyFacetsFetchEnabled = getSettings('vtex.store')
+    ?.enableFiltersFetchOptimization
 
   const handleOpen = id => e => {
     e.preventDefault()
 
     if (navigationType === 'collapsible') {
       return
+    }
+
+    if (isLazyFacetsFetchEnabled && !truncatedFacetsFetched) {
+      setTruncatedFacetsFetched(true)
     }
 
     if (openItem === id) {

--- a/react/components/AccordionFilterGroup.js
+++ b/react/components/AccordionFilterGroup.js
@@ -16,6 +16,7 @@ const AccordionFilterGroup = ({
   className,
   title,
   facets,
+  quantity,
   show,
   open,
   onOpen,
@@ -24,6 +25,8 @@ const AccordionFilterGroup = ({
   navigationType,
   initiallyCollapsed,
   truncateFilters,
+  truncatedFacetsFetched,
+  setTruncatedFacetsFetched,
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
   const filters = useSelectedFilters(facets)
@@ -52,9 +55,12 @@ const AccordionFilterGroup = ({
         <FacetCheckboxList
           onFilterCheck={onFilterCheck}
           facets={filters}
+          quantity={quantity}
           facetTitle={facetTitle}
           truncateFilters={truncateFilters}
           navigationType={navigationType}
+          truncatedFacetsFetched={truncatedFacetsFetched}
+          setTruncatedFacetsFetched={setTruncatedFacetsFetched}
         />
       </div>
     </AccordionFilterItem>

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -46,6 +46,8 @@ const FilterSidebar = ({
   navigationType,
   initiallyCollapsed,
   truncateFilters,
+  truncatedFacetsFetched,
+  setTruncatedFacetsFetched,
 }) => {
   const { searchQuery } = useSearchPage()
   const filterContext = useFilterNavigator()
@@ -188,6 +190,8 @@ const FilterSidebar = ({
             navigationType={navigationType}
             initiallyCollapsed={initiallyCollapsed}
             truncateFilters={truncateFilters}
+            truncatedFacetsFetched={truncatedFacetsFetched}
+            setTruncatedFacetsFetched={setTruncatedFacetsFetched}
           />
           <ExtensionPoint id="sidebar-close-button" onClose={handleClose} />
         </FilterNavigatorContext.Provider>


### PR DESCRIPTION
#### What problem is this solving?

Make `enableFiltersFetchOptimization` work on mobile.

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Collapsible](https://thalyta--storecomponents.myvtex.com/apparel---accessories/clothing)

[Page](https://thalyta1--storecomponents.myvtex.com/apparel---accessories/clothing)

there are two different behaviors:
1 - when using filters in `collapsible` mode, filters must display a maximum of 10 items and fetch by clicking on `see more`.
2 - when using filters in `page` mode, fetching must be done when clicking on the filter, showing all facets when opening.

#### Screenshots or example usage:

Collapsible:

![collapsiblefetch](https://user-images.githubusercontent.com/20840671/98242195-d8300a00-1f4a-11eb-83f5-63c730efe7f6.gif)

Page:

![pagefetch](https://user-images.githubusercontent.com/20840671/98242202-db2afa80-1f4a-11eb-95fc-dd073e2acefd.gif)

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->
Depends on: https://github.com/vtex-apps/search-result/pull/410

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
