### PR TITLE
Bring back order by "Relevance" as the default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Default `orderBy` value is now to order items by "Relevance", which now means products will follow the same ordering logic defined by the Search API.
 
 ## [3.82.0] - 2020-11-10
 ### Added

--- a/messages/context.json
+++ b/messages/context.json
@@ -85,7 +85,6 @@
   "store/ordenation.price.ascending": "Price: Low to High",
   "store/ordenation.name.ascending": "Name, ascending",
   "store/ordenation.name.descending": "Name, descending",
-  "store/ordenation.default": "Default",
   "store/layoutModeSwitcher.inline": "Line",
   "store/layoutModeSwitcher.small": "Small",
   "store/layoutModeSwitcher.normal": "Normal",

--- a/messages/en.json
+++ b/messages/en.json
@@ -85,7 +85,6 @@
   "store/ordenation.price.ascending": "Price: Low to High",
   "store/ordenation.name.ascending": "Name, ascending",
   "store/ordenation.name.descending": "Name, descending",
-  "store/ordenation.default": "Default",
   "store/layoutModeSwitcher.inline": "Line",
   "store/layoutModeSwitcher.small": "Small",
   "store/layoutModeSwitcher.normal": "Normal",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -85,7 +85,6 @@
   "store/ordenation.price.ascending": "Menor preço",
   "store/ordenation.name.ascending": "De A a Z",
   "store/ordenation.name.descending": "De Z a A",
-  "store/ordenation.default": "Padrão",
   "store/layoutModeSwitcher.inline": "Na linha",
   "store/layoutModeSwitcher.small": "Pequeno",
   "store/layoutModeSwitcher.normal": "Normal",

--- a/react/OrderBy.js
+++ b/react/OrderBy.js
@@ -7,10 +7,6 @@ import SelectionListOrderBy from './components/SelectionListOrderBy'
 export const SORT_OPTIONS = [
   {
     value: '',
-    label: 'store/ordenation.default',
-  },
-  {
-    value: 'OrderByScoreDESC',
     label: 'store/ordenation.relevance',
   },
   {

--- a/react/__tests__/__snapshots__/OrderBy.test.js.snap
+++ b/react/__tests__/__snapshots__/OrderBy.test.js.snap
@@ -32,11 +32,6 @@ exports[`<OrderBy /> should match snapshot in mobile 1`] = `
       <button
         class="hover-bg-muted-5 bg-base orderByOptionItem orderByOptionItem--  c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 w-100 right-0-ns"
       >
-        Default
-      </button>
-      <button
-        class="hover-bg-muted-5 bg-base orderByOptionItem orderByOptionItem--  c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 w-100 right-0-ns"
-      >
         Relevance
       </button>
       <button
@@ -108,11 +103,6 @@ exports[`<OrderBy /> should match snapshot in web mod 1`] = `
     <div
       class="orderByOptionsContainer z-1 absolute bg-base shadow-5 w-100 f5 b--muted-4 br2 ba bw1 br--bottom top-0 right-0-ns dn"
     >
-      <button
-        class="hover-bg-muted-5 bg-base orderByOptionItem orderByOptionItem--  c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 w-100 right-0-ns"
-      >
-        Default
-      </button>
       <button
         class="hover-bg-muted-5 bg-base orderByOptionItem orderByOptionItem--  c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 w-100 right-0-ns"
       >


### PR DESCRIPTION
#### What problem is this solving?

We're removing the `Default` sorting option introduced by #442  in favor of changing the way the `Relevance` ordering works. It will now follow the same behavior defined by the Search API.

#### How to test it?

Go to [Workspace](https://victormiranda--cosmetics1.myvtex.com/6008?map=productClusterIds) and check that the orderBy is set to `Relevance`, and the products are ordered the same way they are [here](https://cosmetics1.vtexcommercestable.com.br/6008?map=productClusterIds).

#### Related to / Depends on

Related to: https://github.com/vtex-apps/store/pull/499.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/9Dtye59YLYQpIwQWpv/giphy.gif)
