### PR TITLE
Fix/price range max value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- `PriceRange` trauncating max value.
+
 ## [3.84.3] - 2020-11-11
 
 ### Fixed

--- a/react/components/PriceRange.js
+++ b/react/components/PriceRange.js
@@ -51,7 +51,7 @@ const PriceRange = ({ title, facets, intl, priceRange }) => {
     const [_, minSlug, maxSlug] = slug.match(slugRegex)
 
     const min = parseInt(minSlug)
-    const max = parseInt(maxSlug)
+    const max = parseInt(Math.ceil(maxSlug))
 
     if (min < minValue) {
       minValue = min


### PR DESCRIPTION
#### What problem is this solving?

Actually, our price range truncate the max value, and this behavior is wrong, because if we have some product that costs 197,90, ou pricerange will display the max value to 197. Following this, if we adjust the pricerange to the max value (197), the product with 197,90 will disappear. So, this PR is just simple ceiling the max value in price range, to got in this example, 198

#### How to test it?

Go to the workspace, search for something or go to category page and see if the higher price is being ceiled 

[Workspace](https://iespinoza--storecomponents.myvtex.com/home---decor/)

#### Screenshots or example usage:

older ![image](https://user-images.githubusercontent.com/13649073/98965195-85c19100-24e8-11eb-8889-5affc61ecbd2.png)

fresher 
![image](https://user-images.githubusercontent.com/13649073/98965638-097b7d80-24e9-11eb-898a-33fe2709aa60.png)

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/RO5JLFmiHnN6g/giphy.gif)
