### PR TITLE
Add search-engagement-team as CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @vtex-apps/store-framework-devs
+* @vtex-apps/store-framework-devs @vtex-apps/search-engagement-team
 docs/ @vtex-apps/technical-writers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `@vtex-apps/search-engagement-team` as CODEOWNER.
+
 ## [3.86.0] - 2020-11-17
 
 ### Changed


### PR DESCRIPTION
#### What problem is this solving?

Since @vtex-apps/search-engagement-team is becoming one of the main contributors, I think it is reasonable to add it to the CODEOWNER.