### PR TITLE
Add 'filterCollapsable' CSS handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `filterCollapsable` CSS handle.
 
 ## [3.86.0] - 2020-11-17
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -390,6 +390,7 @@ In order to apply CSS customization in this and other blocks, follow the instruc
 | `filterContainer--{selectedFilters}`  |
 | `filterContainer--{title}`            |
 | `filterContainer`                     |
+| `filterCollapsable`                     |
 | `filterIcon`                          |
 | `filterItem--{facetValue}`            |
 | `filterItem--selected`                |

--- a/react/components/FilterOptionTemplate.js
+++ b/react/components/FilterOptionTemplate.js
@@ -56,6 +56,7 @@ const CSS_HANDLES = [
   'filterTitle',
   'filterIcon',
   'filterContent',
+  'filterCollapsable',
   'filterTemplateOverflow',
   'seeMoreButton',
   'filterSelectedFilters',
@@ -218,7 +219,9 @@ const FilterOptionTemplate = ({
         <div
           role="button"
           tabIndex={collapsable ? 0 : undefined}
-          className={collapsable ? 'pointer' : ''}
+          className={`${handles.filterCollapsable} ${
+            collapsable ? 'pointer' : ''
+          }`}
           onClick={() => collapsable && handleCollapse()}
           onKeyDown={handleKeyDown}
           aria-disabled={!collapsable}


### PR DESCRIPTION
#### What problem is this solving?

There was a missing CSS handle in a `<div>`.

#### How to test it?

[Workspace](https://victormirandavtex--alssports.myvtex.com/clothing/jackets/Mens?map=c,c,specificationFilter_7721)

#### Screenshots or example usage:

**Before**

![Screen Shot 2020-11-18 at 14 25 30](https://user-images.githubusercontent.com/27777263/99565816-df273580-29aa-11eb-9260-a0817b2207bd.png)

**After**

![Screen Shot 2020-11-18 at 14 31 58](https://user-images.githubusercontent.com/27777263/99565813-ddf60880-29aa-11eb-9093-0f162059cbbf.png)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/Rl9Yqavfj2Ula/giphy.gif)
