### PR TITLE
Update README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Update the app documentation (README.md file)
+
 ## [3.87.1] - 2020-12-03
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -124,6 +124,8 @@ or
 }
 ```
 
+> ⚠️ *When set as `skip`, the `simulationBehavior` prop defines that the search data should only be fetched using the store's Cache. Caution: In practice, **this may impact the content displayed on store pages, since the cache storage changes according to user interaction in each page**. In order to understand this prop behavior, take a look at the table below!
+
 :warning: **You must define the query for the following search pages: brand, department, category and subcategory**. This will allow you to define custom behaviors for each of your store's possible search pages. For example:
 
 ```json
@@ -175,6 +177,8 @@ or
   }
 }
 ```
+
+> ⚠️ *When set as `skip`, the `simulationBehavior` prop defines that the search data should only be fetched using the store's Cache. Caution: In practice, **this may impact the content displayed on store pages, since the cache storage changes according to user interaction in each page**. In order to understand this prop behavior, take a look at the table below!
 
 Below you may find all available props to configure your search data (be it by using a context or a custom query through the `querySchema` block):
 


### PR DESCRIPTION
Add the following disclaimer to the docs:

> ⚠️ *When set as `skip`, the `simulationBehavior` prop defines that the search data should only be fetched using the store's Cache. Caution: In practice, **this may impact the content displayed on store pages, since the cache storage changes according to user interaction in each page**. In order to understand this prop behavior, take a look at the table below!