### PR TITLE
fix shouldDisable when category tree is selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- `shouldDisable` when category tree is selected.
+
 ## [3.87.1] - 2020-12-03
 
 ### Fixed

--- a/react/hooks/useShouldDisableFacet.js
+++ b/react/hooks/useShouldDisableFacet.js
@@ -2,22 +2,20 @@ import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
 import { MAP_VALUES_SEP } from '../constants'
 
 export default function useShouldDisableFacet(facet) {
-  const { selectedFacets, map } = useSearchPage()
+  const { map } = useSearchPage()
 
-  if (!facet.selected) {
+  if (!facet.selected || !map) {
     return false
   }
 
-  if (map && map.split(MAP_VALUES_SEP).includes('ft')) {
+  const mapArray = map.split(MAP_VALUES_SEP)
+
+  if (mapArray.includes('ft')) {
     return false
   }
 
-  if (selectedFacets && selectedFacets.length === 1) {
-    const [selectedFacet] = selectedFacets
-
-    return (
-      selectedFacet.key === facet.key && selectedFacet.value === facet.value
-    )
+  if (mapArray.length === 1) {
+    return true
   }
 
   return false


### PR DESCRIPTION
#### What problem is this solving?

`shouldDisable` is returning true even when there is a category tree selected.
It turns out the selectedFacets variable doesn't have the info about the category tree. Now, I'm using the map instead.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://hiago--storecomponents.myvtex.com/apparel---accessories/bwe?initialMap=c&initialQuery=apparel---accessories&map=b)

#### Screenshots or example usage:

Before
![image](https://user-images.githubusercontent.com/40380674/101167748-29e6b580-3619-11eb-975f-a3d37ab3f82f.png)

After

![image](https://user-images.githubusercontent.com/40380674/101167702-19363f80-3619-11eb-9475-6977c24c34b4.png)

