### PR TITLE
remove maxHeight from selected facets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Remove `maxHeight` from the selected facets section.
+
 ## [3.88.0] - 2020-12-07
 ### Added
 - `gallery` block: added support for multiple gallery layouts

--- a/react/components/FilterOptionTemplate.js
+++ b/react/components/FilterOptionTemplate.js
@@ -253,7 +253,9 @@ const FilterOptionTemplate = ({
         })}
         ref={scrollable}
         style={
-          !(truncateFilters || isLazyFacetsFetchEnabled) || isLazyRenderEnabled
+          !selected &&
+          (!(truncateFilters || isLazyFacetsFetchEnabled) ||
+            isLazyRenderEnabled)
             ? { maxHeight: '200px' }
             : {}
         }


### PR DESCRIPTION
#### What problem is this solving?

There is a maxHeight in the selected facets section. It's causing problems where there are many facets selected

Before:
![image](https://user-images.githubusercontent.com/40380674/101213103-9e8d1480-3658-11eb-830c-d976b306cee3.png)

Afiter

![image](https://user-images.githubusercontent.com/40380674/101213123-a51b8c00-3658-11eb-801c-4f4294a842e9.png)


#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://hiago--eriksbikeshop.myvtex.com/cycling?fuzzy=0&map=category-3,category-1,category-3,category-3,category-3,category-3,category-3,sell-online&operator=and&query=/accessories/cycling/jerseys/shoes/shorts/tires/wheels/yes)

