### PR TITLE
Delete page querystring in navigateToFacet function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Selecting a new filter doesn't reset the page count.
+
 ## [3.88.1] - 2020-12-09
 
 ### Fixed

--- a/react/hooks/useFacetNavigation.js
+++ b/react/hooks/useFacetNavigation.js
@@ -88,6 +88,7 @@ const getCleanUrlParams = currentMap => {
   if (!currentMap) {
     urlParams.delete(MAP_QUERY_KEY)
   }
+  urlParams.delete('page')
   return urlParams
 }
 


### PR DESCRIPTION
#### What problem is this solving?

When you select a new filter, the page is not reset.

To reproduce the bug:

1. Go to [this page](https://storecomponents.myvtex.com/apparel---accessories)
2. Click on show more once
3. Select any brand; let's say "Kawasaki."
4. It will return a not found page because it is rendering the second page.


#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://hiago--storecomponents.myvtex.com/apparel---accessories)

