### PR TITLE
Feature/gallery layout query params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Query param identifying chosen gallery layout
+- `css-handles` modifiers for chosen gallery layout
 
 ## [3.88.2] - 2021-01-04
 

--- a/react/GalleryLayout.tsx
+++ b/react/GalleryLayout.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames'
 
 import { ProductListContext } from 'vtex.product-list-context'
 import { Spinner } from 'vtex.styleguide'
-import { useCssHandles } from 'vtex.css-handles'
+import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 import { useResponsiveValue } from 'vtex.responsive-values'
 import type { MaybeResponsiveInput } from 'vtex.responsive-values'
 import { useRuntime } from 'vtex.render-runtime'
@@ -121,7 +121,7 @@ const GalleryLayout: React.FC<GalleryLayoutProps> = ({
   }
 
   const galleryClasses = classNames(
-    handles.gallery,
+    applyModifiers(handles.gallery, currentLayoutOption.name),
     'flex flex-row flex-wrap items-stretch bn ph1 na4',
     {
       'justify-center': !showingFacets,
@@ -143,6 +143,7 @@ const GalleryLayout: React.FC<GalleryLayoutProps> = ({
             summary={summary}
             displayMode="normal"
             itemsPerRow={itemsPerRow}
+            currentLayoutName={currentLayoutOption.name}
             GalleryItemComponent={slots[currentLayoutOption.component]}
           />
         ))}

--- a/react/GalleryLayoutOption.tsx
+++ b/react/GalleryLayoutOption.tsx
@@ -1,6 +1,7 @@
 import React, { PropsWithChildren, useEffect } from 'react'
 
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
+import { RenderContext, useRuntime } from 'vtex.render-runtime'
 import { SearchPageContext } from 'vtex.search-page-context'
 import { SWITCH_GALLERY_LAYOUT_TYPE } from './constants'
 
@@ -19,6 +20,7 @@ function GalleryLayoutOption({
 }: PropsWithChildren<GalleryLayoutOptionProps>) {
   const handles = useCssHandles(CSS_HANDLES)
   const optionButtonRef = React.useRef<HTMLButtonElement>(null)
+  const { setQuery } = useRuntime() as RenderContext.RenderContext
   const { selectedGalleryLayout, focusedGalleryLayout } = useSearchPageState()
   const dispatch = useSearchPageStateDispatch()
 
@@ -35,6 +37,8 @@ function GalleryLayoutOption({
       type: SWITCH_GALLERY_LAYOUT_TYPE,
       args: { selectedGalleryLayout: name },
     })
+
+    setQuery({ layout: name })
   }
 
   return (

--- a/react/SearchResultFlexible.js
+++ b/react/SearchResultFlexible.js
@@ -8,6 +8,7 @@ import {
   useSearchPageStateReducer,
 } from 'vtex.search-page-context/SearchPageContext'
 import { useCssHandles } from 'vtex.css-handles'
+import { useRuntime } from 'vtex.render-runtime'
 
 import { generateBlockClass } from '@vtex/css-handles'
 import { pathOr, isEmpty } from 'ramda'
@@ -102,10 +103,11 @@ const SearchResultFlexible = ({
     categoriesTrees &&
     categoriesTrees.length > 0
   const showFacets = showCategories || (!hideFacets && !isEmpty(filters))
+  const { query: runtimeQuery } = useRuntime()
   const [state, dispatch] = useSearchPageStateReducer({
     mobileLayout: mobileLayout.mode1,
     showContentLoader: searchQuery.loading,
-    selectedGalleryLayout: defaultGalleryLayout,
+    selectedGalleryLayout: runtimeQuery.layout || defaultGalleryLayout,
   })
 
   useShowContentLoader(searchQuery, dispatch)

--- a/react/components/GalleryLayoutRow.tsx
+++ b/react/components/GalleryLayoutRow.tsx
@@ -9,6 +9,7 @@ import type { Product } from '../Gallery'
 const CSS_HANDLES = ['galleryItem'] as const
 
 interface GalleryLayoutRowProps {
+  currentLayoutName: string
   displayMode: string
   GalleryItemComponent: ComponentType
   itemsPerRow: number
@@ -24,6 +25,7 @@ const GalleryLayoutRow: React.FC<GalleryLayoutRowProps> = ({
   lazyRender,
   products,
   summary,
+  currentLayoutName,
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
 
@@ -49,7 +51,10 @@ const GalleryLayoutRow: React.FC<GalleryLayoutRowProps> = ({
             key={product.productId}
             style={style}
             className={classNames(
-              applyModifiers(handles.galleryItem, displayMode),
+              applyModifiers(handles.galleryItem, [
+                displayMode,
+                currentLayoutName,
+              ]),
               'pa4'
             )}
           >


### PR DESCRIPTION
#### What problem is this solving?

This PR adds new modifiers to the gallery to allow custom CSS rules per layout. It also adds the current layout to the query params, so users resizing the browser window or sharing the link can see the items the same way.

#### How to test it?

The default layout is Grid, but by using the link below you will start with the List layout.
[Workspace](https://icarosearch--storecomponents.myvtex.com/apparel---accessories/?layout=list)

#### Screenshots or example usage:

<img width="146" alt="Screen Shot 2021-01-06 at 20 11 30" src="https://user-images.githubusercontent.com/8127610/103831689-5f891f00-505b-11eb-96f5-878bdef77b42.png">

#### Related to / Depends on

Related to [store-theme#240](https://github.com/vtex-apps/store-theme/pull/240)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/QYSgo7te5uhhZjz155/source.gif)
