### PR TITLE
Update orderByOptionsContainter z-index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Badge z-index with priority over the orderBy filter.
+
 ## [3.88.2] - 2021-01-04
 
 ### Fixed

--- a/react/__tests__/__snapshots__/OrderBy.test.js.snap
+++ b/react/__tests__/__snapshots__/OrderBy.test.js.snap
@@ -27,7 +27,7 @@ exports[`<OrderBy /> should match snapshot in mobile 1`] = `
       </span>
     </button>
     <div
-      class="orderByOptionsContainer z-1 absolute bg-base shadow-5 w-100 f5 b--muted-4 br2 ba bw1 br--bottom top-0 right-0-ns dn"
+      class="orderByOptionsContainer z-3 absolute bg-base shadow-5 w-100 f5 b--muted-4 br2 ba bw1 br--bottom top-0 right-0-ns dn"
     >
       <button
         class="hover-bg-muted-5 bg-base orderByOptionItem orderByOptionItem--  c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 w-100 right-0-ns"
@@ -101,7 +101,7 @@ exports[`<OrderBy /> should match snapshot in web mod 1`] = `
       </span>
     </button>
     <div
-      class="orderByOptionsContainer z-1 absolute bg-base shadow-5 w-100 f5 b--muted-4 br2 ba bw1 br--bottom top-0 right-0-ns dn"
+      class="orderByOptionsContainer z-3 absolute bg-base shadow-5 w-100 f5 b--muted-4 br2 ba bw1 br--bottom top-0 right-0-ns dn"
     >
       <button
         class="hover-bg-muted-5 bg-base orderByOptionItem orderByOptionItem--  c-on-base f5 ml-auto db no-underline pointer tl bn pv4 ph5 w-100 right-0-ns"

--- a/react/components/SelectionListOrderBy.js
+++ b/react/components/SelectionListOrderBy.js
@@ -78,7 +78,7 @@ const SelectionListOrderBy = ({
 
   const contentClass = classNames(
     styles.orderByOptionsContainer,
-    'z-1 absolute bg-base shadow-5 w-100 f5 b--muted-4 br2 ba bw1 br--bottom top-0 right-0-ns',
+    'z-3 absolute bg-base shadow-5 w-100 f5 b--muted-4 br2 ba bw1 br--bottom top-0 right-0-ns',
     {
       db: showDropdown,
       dn: !showDropdown,


### PR DESCRIPTION
#### What problem is this solving?

Badge z-index with priority over the orderBy filter.

#### How to test it?

![Screen Shot 2021-01-07 at 12 28 55 PM](https://user-images.githubusercontent.com/13058968/103910780-fe595e00-50e3-11eb-94d5-4e5c9a30bff2.png) ![Screen Shot 2021-01-07 at 12 29 16 PM](https://user-images.githubusercontent.com/13058968/103910774-fbf70400-50e3-11eb-8812-1c56bd1656ef.png)


https://vitorflg--storecomponents.myvtex.com/apparel---accessories/?order=OrderByPriceDESC

#### Screenshots or example usage:

Above.

#### Describe alternatives you've considered, if any.

X

#### Related to / Depends on

X
