### PR TITLE
Pass the map prop to productClick event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Pass the `map` prop to the `productClick` event.
+
 ## [3.89.0] - 2021-01-11
 ### Added
 - Query param identifying chosen gallery layout

--- a/react/components/GalleryItem.js
+++ b/react/components/GalleryItem.js
@@ -26,7 +26,9 @@ const GalleryItem = ({ item, displayMode, summary }) => {
     }
   }, [searchQuery])
 
-  const map = useMemo(() => searchQuery?.variables?.map, [searchQuery?.variables?.map])
+  const map = useMemo(() => searchQuery?.variables?.map, [
+    searchQuery?.variables?.map,
+  ])
 
   const handleClick = useCallback(() => {
     push({ event: 'productClick', product, query, map })

--- a/react/components/GalleryItem.js
+++ b/react/components/GalleryItem.js
@@ -21,13 +21,19 @@ const GalleryItem = ({ item, displayMode, summary }) => {
   )
 
   const query = useMemo(() => {
-    if (searchQuery && searchQuery.variables) {
+    if (searchQuery?.variables) {
       return searchQuery.variables.query
     }
   }, [searchQuery])
 
+  const map = useMemo(() => {
+    if (searchQuery?.variables) {
+      return searchQuery.variables.map
+    }
+  }, [searchQuery])
+
   const handleClick = useCallback(() => {
-    push({ event: 'productClick', product, query })
+    push({ event: 'productClick', product, query, map })
   }, [product, query, push])
 
   return (

--- a/react/components/GalleryItem.js
+++ b/react/components/GalleryItem.js
@@ -26,7 +26,7 @@ const GalleryItem = ({ item, displayMode, summary }) => {
     }
   }, [searchQuery])
 
-  const map = useMemo(() => searchQuery?.variables.map, [searchQuery])
+  const map = useMemo(() => searchQuery?.variables?.map, [searchQuery?.variables?.map])
 
   const handleClick = useCallback(() => {
     push({ event: 'productClick', product, query, map })

--- a/react/components/GalleryItem.js
+++ b/react/components/GalleryItem.js
@@ -26,11 +26,7 @@ const GalleryItem = ({ item, displayMode, summary }) => {
     }
   }, [searchQuery])
 
-  const map = useMemo(() => {
-    if (searchQuery?.variables) {
-      return searchQuery.variables.map
-    }
-  }, [searchQuery])
+  const map = useMemo(() => searchQuery?.variables.map, [searchQuery])
 
   const handleClick = useCallback(() => {
     push({ event: 'productClick', product, query, map })

--- a/react/components/GalleryLayoutItem.tsx
+++ b/react/components/GalleryLayoutItem.tsx
@@ -32,11 +32,7 @@ const GalleryLayoutItem: React.FC<GalleryLayoutItemProps> = ({
     }
   }, [searchQuery])
 
-  const map = useMemo(() => {
-    if (searchQuery?.variables) {
-      return searchQuery.variables.map
-    }
-  }, [searchQuery])
+  const map = useMemo(() => searchQuery?.variables.map, [searchQuery])
 
   const handleClick = useCallback(() => {
     push({ event: 'productClick', product, query, map })

--- a/react/components/GalleryLayoutItem.tsx
+++ b/react/components/GalleryLayoutItem.tsx
@@ -32,7 +32,7 @@ const GalleryLayoutItem: React.FC<GalleryLayoutItemProps> = ({
     }
   }, [searchQuery])
 
-  const map = useMemo(() => searchQuery?.variables.map, [searchQuery])
+  const map = useMemo(() => searchQuery?.variables?.map, [searchQuery?.variables?.map])
 
   const handleClick = useCallback(() => {
     push({ event: 'productClick', product, query, map })

--- a/react/components/GalleryLayoutItem.tsx
+++ b/react/components/GalleryLayoutItem.tsx
@@ -32,7 +32,9 @@ const GalleryLayoutItem: React.FC<GalleryLayoutItemProps> = ({
     }
   }, [searchQuery])
 
-  const map = useMemo(() => searchQuery?.variables?.map, [searchQuery?.variables?.map])
+  const map = useMemo(() => searchQuery?.variables?.map, [
+    searchQuery?.variables?.map,
+  ])
 
   const handleClick = useCallback(() => {
     push({ event: 'productClick', product, query, map })

--- a/react/components/GalleryLayoutItem.tsx
+++ b/react/components/GalleryLayoutItem.tsx
@@ -32,8 +32,14 @@ const GalleryLayoutItem: React.FC<GalleryLayoutItemProps> = ({
     }
   }, [searchQuery])
 
+  const map = useMemo(() => {
+    if (searchQuery?.variables) {
+      return searchQuery.variables.map
+    }
+  }, [searchQuery])
+
   const handleClick = useCallback(() => {
-    push({ event: 'productClick', product, query })
+    push({ event: 'productClick', product, query, map })
   }, [product, query, push])
 
   return (


### PR DESCRIPTION
#### What problem is this solving?
I need to know if the `productClick` event was triggered after a full-text search or just by applying filters.

#### How to test it?

Go to the search result page and click on a product, the `productClick` event body should contain the `map` property.

[Workspace](https://waza--storecomponents.myvtex.com/)

#### Describe alternatives you've considered, if any.
Another alternative is to pass different fields for the search terms and for filters, but it could be a breaking change. 😟 

<!--- Optional -->

#### Related to / Depends on
New metrics for navigation events in Search and Personalization dashboards.
