### PR TITLE
Add position prop to GalleryItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `position` prop to `GalleryItem`.
+- send `postion` prop in the `productClick` event.
+
 ## [3.90.0] - 2021-01-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - `position` prop to `GalleryItem`.
-- send `postion` prop in the `productClick` event.
+- send `position` prop in the `productClick` event.
 
 ## [3.90.0] - 2021-01-11
 

--- a/react/GalleryLayout.tsx
+++ b/react/GalleryLayout.tsx
@@ -144,6 +144,7 @@ const GalleryLayout: React.FC<GalleryLayoutProps> = ({
             displayMode="normal"
             itemsPerRow={itemsPerRow}
             currentLayoutName={currentLayoutOption.name}
+            rowIndex={index}
             GalleryItemComponent={slots[currentLayoutOption.component]}
           />
         ))}

--- a/react/components/GalleryItem.js
+++ b/react/components/GalleryItem.js
@@ -11,7 +11,7 @@ import { PropTypes } from 'prop-types'
 /**
  * Normalizes the item received in the props to adapt to the extension point prop.
  */
-const GalleryItem = ({ item, displayMode, summary }) => {
+const GalleryItem = ({ item, displayMode, summary, position }) => {
   const { push } = usePixel()
   const { searchQuery } = useSearchPage()
 
@@ -31,7 +31,7 @@ const GalleryItem = ({ item, displayMode, summary }) => {
   ])
 
   const handleClick = useCallback(() => {
-    push({ event: 'productClick', product, query, map })
+    push({ event: 'productClick', product, query, map, position })
   }, [product, query, push])
 
   return (
@@ -52,6 +52,8 @@ GalleryItem.propTypes = {
   summary: PropTypes.any,
   /** Display mode of the product summary */
   displayMode: PropTypes.string,
+  /** Item position in the gallery */
+  position: PropTypes.number,
 }
 
 export default memo(GalleryItem)

--- a/react/components/GalleryLayoutItem.tsx
+++ b/react/components/GalleryLayoutItem.tsx
@@ -10,6 +10,7 @@ interface GalleryLayoutItemProps {
   item: Product
   displayMode: string
   summary: unknown
+  position: number
 }
 
 const GalleryLayoutItem: React.FC<GalleryLayoutItemProps> = ({
@@ -17,6 +18,7 @@ const GalleryLayoutItem: React.FC<GalleryLayoutItemProps> = ({
   item,
   displayMode,
   summary,
+  position,
 }) => {
   const { push } = usePixel()
   const { searchQuery } = useSearchPage()
@@ -37,7 +39,7 @@ const GalleryLayoutItem: React.FC<GalleryLayoutItemProps> = ({
   ])
 
   const handleClick = useCallback(() => {
-    push({ event: 'productClick', product, query, map })
+    push({ event: 'productClick', product, query, map, position })
   }, [product, query, push])
 
   return (

--- a/react/components/GalleryLayoutRow.tsx
+++ b/react/components/GalleryLayoutRow.tsx
@@ -16,6 +16,7 @@ interface GalleryLayoutRowProps {
   lazyRender: boolean
   products: Product[]
   summary: unknown
+  rowIndex: number
 }
 
 const GalleryLayoutRow: React.FC<GalleryLayoutRowProps> = ({
@@ -26,6 +27,7 @@ const GalleryLayoutRow: React.FC<GalleryLayoutRowProps> = ({
   products,
   summary,
   currentLayoutName,
+  rowIndex,
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
 
@@ -45,7 +47,7 @@ const GalleryLayoutRow: React.FC<GalleryLayoutRowProps> = ({
 
   return (
     <>
-      {products.map((product) => {
+      {products.map((product, index) => {
         return (
           <div
             key={product.productId}
@@ -63,6 +65,7 @@ const GalleryLayoutRow: React.FC<GalleryLayoutRowProps> = ({
               item={product}
               summary={summary}
               displayMode={displayMode}
+              position={(rowIndex * itemsPerRow) + index}
             />
           </div>
         )

--- a/react/components/GalleryRow.js
+++ b/react/components/GalleryRow.js
@@ -13,6 +13,7 @@ const GalleryRow = ({
   displayMode,
   itemsPerRow,
   lazyRender,
+  rowIndex,
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
 
@@ -30,7 +31,7 @@ const GalleryRow = ({
     return dummyElement
   }
 
-  return products.map(product => {
+  return products.map((product, index) => {
     return (
       <div
         key={product.productId}
@@ -44,6 +45,7 @@ const GalleryRow = ({
           item={product}
           summary={summary}
           displayMode={displayMode}
+          position={(rowIndex * itemsPerRow) + index}
         />
       </div>
     )


### PR DESCRIPTION
#### What problem is this solving?
Add the position prop in the `GalleryItem` to send the item position in the gallery to the `productClick` event.

#### How to test it?

Go to the search result page and click on a product (just for an easy test, I added an alert to show the position clicked).

[Workspace](https://waza2--storecomponents.myvtex.com/apparel---accessories/)

#### Screenshots or example usage:

https://user-images.githubusercontent.com/12852518/104027183-c9154480-51a5-11eb-8445-3c3e9e479818.mov

#### Related to / Depends on

New metrics for new Search and Personalization dashboards.

