### PR TITLE
reactivate search cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Reactivate search cache.
+
 ## [3.93.0] - 2021-01-28
 
 ### Changed

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -152,7 +152,6 @@ const useQueries = (variables, facetsArgs) => {
 
   const productSearchResult = useQuery(productSearchQuery, {
     variables,
-    fetchPolicy: 'network-only',
   })
 
   const {


### PR DESCRIPTION
#### What problem is this solving?

Apparently, the cache was hiding a layout problem on search-result pages. This PR is a rollback of [this one](https://github.com/vtex-apps/search-result/pull/484).

We will solve this definitely after [this card](https://vtex-dev.atlassian.net/browse/PER-1915). For while [this issue](https://github.com/vtex-apps/search-result/issues/483) will still open

#### How to test it?

refresh the following page and check if the bug still happening.

[workspace](https://hiago--uvline.myvtex.com/roupas)

#### Screenshots or example usage:

Bug:
![image](https://user-images.githubusercontent.com/40380674/107400717-db560b80-6ae0-11eb-9a31-3aae705dcf11.png)

