### PR TITLE
Remove fuzzy and operator for searches that are not full text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+- Query strings `fuzzy` and `operator` for searches that are not full text.
+
 ## [3.93.1] - 2021-02-09
 
 ### Fixed


### PR DESCRIPTION
#### What problem is this solving?
the `fuzzy` and `operator` query strings are only used for full text searches, so we don't need to keep them in the url in cases where the search is not full text

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

Department:
- [Workspace](https://thalyta--applesaddlery.myvtex.com/clothing?map=department)
- select a facet (ex: the `pants` category)
- check if the url doesn't have the `fuzzy` and` operator` parameters

Full text:
- [Workspace](https://thalyta--applesaddlery.myvtex.com/pants?_q=pants&map=ft)
- select a facet (ex: the `pants` category)
- in this case, the url must have `fuzzy` and `operator`

#### Screenshots or example usage:

Before:
![before](https://user-images.githubusercontent.com/20840671/107424769-d1da9c80-6afc-11eb-8eb5-7f1b85b9ca46.gif)

After:
![after](https://user-images.githubusercontent.com/20840671/107425566-e0758380-6afd-11eb-822f-3cddd5cd56ca.gif)

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
