### PR TITLE
Fix decoded search title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Search title with `/`.
 
 ## [3.95.0] - 2021-02-11
 ### Added

--- a/react/SearchTitle.js
+++ b/react/SearchTitle.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames'
 import React, { useContext, useMemo } from 'react'
+// eslint-disable-next-line no-restricted-imports
 import {
   compose,
   equals,
@@ -12,7 +13,6 @@ import {
 } from 'ramda'
 
 import QueryContext from './components/QueryContext'
-
 import styles from './searchResult.css'
 
 const findFT = findIndex(equals('ft'))
@@ -22,23 +22,29 @@ const isBrandPage = compose(equals('b'), head)
 const getLastName = compose(prop('name'), last)
 const breadcrumbName = (index, breadcrumb) => path([index, 'name'], breadcrumb)
 
-const getQueryNameIndex = mapArray => {
+const getQueryNameIndex = (mapArray) => {
   if (isBrandPage(mapArray)) {
     return 0
   }
+
   const ftIndex = findFT(mapArray)
+
   if (ftIndex >= 0) {
     return ftIndex
   }
+
   const clusterIndex = findProductCluster(mapArray)
+
   if (clusterIndex >= 0) {
     return clusterIndex
   }
+
   const lastCategoryIndex = findLastCategory(mapArray)
+
   return lastCategoryIndex
 }
 
-const SearchTitle = props => {
+const SearchTitle = (props) => {
   const {
     breadcrumb: breadcrumbProp,
     wrapperClass = styles.galleryTitle,
@@ -52,7 +58,9 @@ const SearchTitle = props => {
     if (!map) {
       return -1
     }
+
     const mapArray = map.split(',')
+
     return getQueryNameIndex(mapArray)
   }, [map])
 
@@ -61,7 +69,7 @@ const SearchTitle = props => {
 
   const decodedTitle = useMemo(() => {
     try {
-      return decodeURI(title)
+      return decodeURIComponent(title)
     } catch {
       return title
     }


### PR DESCRIPTION
#### What problem is this solving?

the `decodeURI` function does not work for cases where the encoded character is a slash:
![image](https://user-images.githubusercontent.com/20840671/107697698-51e63b00-6c92-11eb-9423-9f2c84308f69.png)

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://encodeurl--biscoind.myvtex.com/3-48m%2fs?_q=3-48m/s&map=ft)

#### Screenshots or example usage:

Before:
![image](https://user-images.githubusercontent.com/20840671/107697347-e2704b80-6c91-11eb-85ea-e59f36b49924.png)

After:
![image](https://user-images.githubusercontent.com/20840671/107697461-02a00a80-6c92-11eb-8fc1-1e832f66c513.png)

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
