### PR TITLE
Adjust OrderBy when OrderByScoreDESC is selected

### DIFF
--- a/react/OrderBy.js
+++ b/react/OrderBy.js
@@ -10,6 +10,10 @@ export const SORT_OPTIONS = [
     label: 'store/ordenation.relevance',
   },
   {
+    value: 'OrderByScoreDESC',
+    label: 'store/ordenation.relevance',
+  },
+  {
     value: 'OrderByTopSaleDESC',
     label: 'store/ordenation.sales',
   },


### PR DESCRIPTION
#### What problem is this solving?
I've noticed when I deliberated choose option OrderByScoreDESC there's no effect on store search, then I added this option again and kept the default option as relevance when no option is provided.

When I select orderByField with OrderByScoreDESC nothing happens.

```json
"context": {
      "orderByField": "OrderByScoreDESC",
      "hideUnavailableItems": true,
      "maxItemsPerPage": 24
}
```

![image](https://user-images.githubusercontent.com/77166595/108839236-92f41e80-75b3-11eb-96f5-683bc6f90554.png)

<!--- What is the motivation and context for this change? -->

#### How to test it?

Add option OrderByScoreDESC into context props and check text inside store search result

![image](https://user-images.githubusercontent.com/77166595/108839203-87a0f300-75b3-11eb-8a42-58b04fa2fdeb.png)

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://task234--tackoftheday.myvtex.com/rider)

#### Screenshots or example usage:

Search JSON example:

```json
"context": {
        "orderByField": "OrderByScoreDESC",
        "hideUnavailableItems": true,
        "maxItemsPerPage": 24
      }
```

Before:

![image](https://user-images.githubusercontent.com/77166595/108839267-9d161d00-75b3-11eb-8176-6d44d282738b.png)

After:

![image](https://user-images.githubusercontent.com/77166595/108839203-87a0f300-75b3-11eb-8a42-58b04fa2fdeb.png)

<!--- Add some images or gifs to showcase changes in behavior or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

Maybe we can keep how it is by know, but needs to update on docs to developers know how to use or select items by `OrderByScoreDESC` and remove `OrderByScoreDESC ` from possible values.

How we can avoid duplicated options "Relevance" and allow developer to use by default or by selecting `OrderByScoreDESC `?