### PR TITLE
fix redirects with https://www

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Redirect URLs that follows the format `https://www.example.com`.
+
 ## [3.98.0] - 2021-03-25
 
 ### Added

--- a/react/hooks/useRedirect.js
+++ b/react/hooks/useRedirect.js
@@ -1,10 +1,9 @@
 import { useRuntime } from 'vtex.render-runtime'
-import { useState, useEffect } from 'react'
 
 const useRedirect = () => {
   const { navigate } = useRuntime()
 
-  const setRedirect = redirect => {
+  const setRedirect = (redirect) => {
     if (!redirect) {
       return
     }
@@ -27,7 +26,7 @@ const useRedirect = () => {
         to: originRedirect.replace(origin, ''),
       })
     } else {
-      window.location.replace(redirect.replace(/www\./, 'http://'))
+      window.location.replace(redirect.replace(/^www/, 'https://www'))
     }
   }
 


### PR DESCRIPTION
#### What problem is this solving?

URLs with the format 'https://www.example.com' were becoming `https://http://example.com` during the redirect flow.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://hiago--biggy.myvtex.com/)

Search for `hiagotest`
