### PR TITLE
Corretion in scroll to top in price range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Fixed
+- add scroll to top in `PriceRange`
+
 ## [3.98.1] - 2021-03-26
 
 ### Fixed

--- a/react/components/PriceRange/index.js
+++ b/react/components/PriceRange/index.js
@@ -42,6 +42,7 @@ const PriceRange = ({ title, facets, priceRange, priceRangeLayout }) => {
       })
 
       setRange([left, right])
+      window.scroll({ top: 0, left: 0, behavior: 'auto' })
     }, DEBOUNCE_TIME)
   }
 


### PR DESCRIPTION
#### What problem is this solving?

When using the price range in the filters of the department and search pages, there was no scrolling function to the top of the page

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace]https://oh950--outletespacohering.myvtex.com/blusas/

### Screenshots or example usage:

Before:
![oh950-2](https://user-images.githubusercontent.com/40704545/113331024-ceda7c00-92f5-11eb-8d03-7aa666e4a2be.gif)

After:
![oh950](https://user-images.githubusercontent.com/40704545/113330523-347a3880-92f5-11eb-824f-121feabd8d25.gif)

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

http://giphy.com/

![](put .gif link here - can be found under "advanced" on giphy)
