### PR TITLE
Fix/search title category compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add new category mapping compatibility to `SearchTitle`
 
 ## [3.98.2] - 2021-04-06
 ### Added

--- a/react/SearchTitle.js
+++ b/react/SearchTitle.js
@@ -10,6 +10,8 @@ import {
   findIndex,
   prop,
   path,
+  either,
+  startsWith,
 } from 'ramda'
 
 import QueryContext from './components/QueryContext'
@@ -17,7 +19,11 @@ import styles from './searchResult.css'
 
 const findFT = findIndex(equals('ft'))
 const findProductCluster = findIndex(equals('productClusterIds'))
-const findLastCategory = findLastIndex(equals('c'))
+const isCategoryMap = either(
+  equals('c'), // traditional mapping for category
+  startsWith('category-') // compatibility with VTEX IS approach
+  )
+const findLastCategory = findLastIndex(isCategoryMap)
 const isBrandPage = compose(equals('b'), head)
 const getLastName = compose(prop('name'), last)
 const breadcrumbName = (index, breadcrumb) => path([index, 'name'], breadcrumb)


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
`SearchTitle` tries to get the last category on breadcrumb to use as a title looking for `map` values equals to `c`, but values like `category-1` and `category-2` are also used to this nowadays, then in scenarios like this, the title is being always the fallback approach (last term in breadcrumb that is usually a specification filter).

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Fixed](https://brunomoreira--shoulderio.myvtex.com/colecao/blusas/decote-v?initialMap=c,c&initialQuery=colecao/blusas&map=category-1,category-2,decote)

[Currently](https://shoulderio.myvtex.com/colecao/blusas/decote-v?initialMap=c,c&initialQuery=colecao/blusas&map=category-1,category-2,decote)


#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->
![Fixed](https://user-images.githubusercontent.com/27451066/114116856-d1237400-98bb-11eb-97be-537538fdb05c.png)

![Currently](https://user-images.githubusercontent.com/27451066/114116894-e9938e80-98bb-11eb-8faf-6d625aef856f.png)




#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/sRHVFZVZlHsOBwYTFn/giphy.gif)
