### PR TITLE
Fix lazy rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Issue where paginated results would not render properly when lazy rendering is enabled.
 
 ## [3.98.3] - 2021-04-15
 ### Fixed

--- a/react/hooks/useOnView.ts
+++ b/react/hooks/useOnView.ts
@@ -91,6 +91,13 @@ const useOnView = ({
         unobserve = initializeObserver()
       }
 
+      // Checks if the user has scrolled the page before JS is loaded
+      const scrollPosition = window.pageYOffset
+
+      if (scrollPosition > 0) {
+        handleInteraction()
+      }
+
       window?.document?.addEventListener('scroll', handleInteraction)
       window?.document?.addEventListener('mouseover', handleInteraction)
 


### PR DESCRIPTION
#### What problem is this solving?
Checks for scroll to see if the user has interacted before the JS has been loaded.

This fixes an issue where the user would click on "Show more", mainly on mobile, but the new items would only appear after the user scrolls.


<!--- What is the motivation and context for this change? -->

#### How to test it?
Open this on mobile https://storetheme.vtex.com/apparel---accessories/

Then scroll down to "Show more" and press on it, without scrolling the page further.

The new items will "appear" empty, until the user scrolls again.


https://user-images.githubusercontent.com/5691711/118146065-9e056080-b3e4-11eb-8366-3bedc0dad6a7.mov



Doing the same on https://storetheme.vtex.com/apparel---accessories/?workspace=lbebbersearch1&v=eita should not cause the same issue


https://user-images.githubusercontent.com/5691711/118146392-f177ae80-b3e4-11eb-8152-73ea85a98e8a.mov



