### PR TITLE
SEO improvements on FetchPrevious and FetchMore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `FetchPrevious` and `FetchMore` links now consider the page number to improve SEO
 
 ## [3.99.0] - 2021-05-24
 ### Added

--- a/react/FetchMore.js
+++ b/react/FetchMore.js
@@ -1,23 +1,24 @@
 import React from 'react'
+// eslint-disable-next-line no-restricted-imports
 import { path } from 'ramda'
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
+import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
+
 import FetchMoreButton from './components/loaders/FetchMoreButton'
 import LoadingSpinner from './components/loaders/LoadingSpinner'
 import { PAGINATION_TYPE } from './constants/paginationType'
 import { useFetchMore } from './hooks/useFetchMore'
-
-import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
-
 import styles from './searchResult.css'
 
-const FetchMore = ({ htmlElementForButton = 'button '}) => {
+const FetchMore = ({ htmlElementForButton = 'button' }) => {
   const { pagination, searchQuery, maxItemsPerPage, page } = useSearchPage()
   const products = path(['data', 'productSearch', 'products'], searchQuery)
   const recordsFiltered = path(
     ['data', 'productSearch', 'recordsFiltered'],
     searchQuery
   )
+
   const fetchMore = path(['fetchMore'], searchQuery)
   const queryData = {
     query: path(['variables', 'query'], searchQuery),
@@ -26,7 +27,7 @@ const FetchMore = ({ htmlElementForButton = 'button '}) => {
     priceRange: path(['variables', 'priceRange'], searchQuery),
   }
 
-  const { handleFetchMoreNext, loading, to } = useFetchMore({
+  const { handleFetchMoreNext, loading, to, nextPage } = useFetchMore({
     page,
     recordsFiltered,
     maxItemsPerPage,
@@ -53,6 +54,7 @@ const FetchMore = ({ htmlElementForButton = 'button '}) => {
           loading={loading}
           showProductsCount={false}
           htmlElementForButton={htmlElementForButton}
+          nextPage={nextPage}
         />
       </div>
     )

--- a/react/FetchPrevious.js
+++ b/react/FetchPrevious.js
@@ -1,11 +1,12 @@
 import React from 'react'
+// eslint-disable-next-line no-restricted-imports
 import { path } from 'ramda'
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import FetchPreviousButton from './components/loaders/FetchPreviousButton'
-import { useFetchMore } from './hooks/useFetchMore'
 import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
 
+import FetchPreviousButton from './components/loaders/FetchPreviousButton'
+import { useFetchMore } from './hooks/useFetchMore'
 import styles from './searchResult.css'
 
 const FetchPrevious = ({ htmlElementForButton = 'button' }) => {
@@ -24,14 +25,16 @@ const FetchPrevious = ({ htmlElementForButton = 'button' }) => {
     priceRange: path(['variables', 'priceRange'], searchQuery),
   }
 
-  const { handleFetchMorePrevious, loading, from } = useFetchMore({
-    page,
-    recordsFiltered,
-    maxItemsPerPage,
-    fetchMore,
-    products,
-    queryData,
-  })
+  const { handleFetchMorePrevious, loading, from, previousPage } = useFetchMore(
+    {
+      page,
+      recordsFiltered,
+      maxItemsPerPage,
+      fetchMore,
+      products,
+      queryData,
+    }
+  )
 
   return (
     <div
@@ -47,6 +50,7 @@ const FetchPrevious = ({ htmlElementForButton = 'button' }) => {
         onFetchPrevious={handleFetchMorePrevious}
         loading={loading}
         htmlElementForButton={htmlElementForButton}
+        previousPage={previousPage}
       />
     </div>
   )

--- a/react/components/loaders/FetchMoreButton.js
+++ b/react/components/loaders/FetchMoreButton.js
@@ -13,6 +13,7 @@ const useShowButton = (to, products, loading, recordsFiltered) => {
   const [showButton, setShowButton] = useState(
     !!products && to + 1 < recordsFiltered
   )
+
   useEffect(() => {
     if (!loading) {
       setShowButton(!!products && to + 1 < recordsFiltered)
@@ -22,7 +23,7 @@ const useShowButton = (to, products, loading, recordsFiltered) => {
   return showButton
 }
 
-const FetchMoreButton = props => {
+const FetchMoreButton = (props) => {
   const {
     products,
     to,
@@ -30,6 +31,7 @@ const FetchMoreButton = props => {
     onFetchMore,
     loading,
     showProductsCount,
+    nextPage,
     htmlElementForButton,
   } = props
 
@@ -37,7 +39,7 @@ const FetchMoreButton = props => {
   const showButton = useShowButton(to, products, loading, recordsFiltered)
   const handles = useCssHandles(CSS_HANDLES)
 
-  const handleFetchMoreClick = ev => {
+  const handleFetchMoreClick = (ev) => {
     isAnchor && ev.preventDefault()
     onFetchMore()
   }
@@ -47,8 +49,8 @@ const FetchMoreButton = props => {
       <div className={`${handles.buttonShowMore} w-100 flex justify-center`}>
         {showButton && (
           <Button
-            onClick={ev => handleFetchMoreClick(ev)}
-            href={isAnchor && '#'}
+            onClick={(ev) => handleFetchMoreClick(ev)}
+            href={isAnchor && `?page=${nextPage}`}
             rel={isAnchor && 'next'}
             isLoading={loading}
             size="small"

--- a/react/components/loaders/FetchPreviousButton.js
+++ b/react/components/loaders/FetchPreviousButton.js
@@ -9,6 +9,7 @@ const useShowButton = (from, products, loading) => {
   const [showButton, setShowButton] = useState(
     !!products && from > 0 && products.length > 0
   )
+
   useEffect(() => {
     if (!loading) {
       setShowButton(!!products && from > 0 && products.length > 0)
@@ -18,20 +19,21 @@ const useShowButton = (from, products, loading) => {
   return showButton
 }
 
-const FetchPreviousButton = props => {
+const FetchPreviousButton = (props) => {
   const {
     products,
     from,
     onFetchPrevious,
     loading,
     htmlElementForButton,
+    previousPage,
   } = props
 
   const isAnchor = htmlElementForButton === 'a'
   const showButton = useShowButton(from, products, loading)
   const handles = useCssHandles(CSS_HANDLES)
 
-  const handleFetchMoreClick = ev => {
+  const handleFetchMoreClick = (ev) => {
     isAnchor && ev.preventDefault()
     onFetchPrevious()
   }
@@ -40,8 +42,8 @@ const FetchPreviousButton = props => {
     <div className={`${handles.buttonShowMore} w-100 flex justify-center`}>
       {showButton && (
         <Button
-          onClick={ev => handleFetchMoreClick(ev)}
-          href={isAnchor && '#'}
+          onClick={(ev) => handleFetchMoreClick(ev)}
+          href={isAnchor && `?page=${previousPage}`}
           rel={isAnchor && 'prev'}
           isLoading={loading}
           size="small"

--- a/react/hooks/useFetchMore.js
+++ b/react/hooks/useFetchMore.js
@@ -1,10 +1,12 @@
 import { useState, useRef, useCallback, useEffect, useReducer } from 'react'
+// eslint-disable-next-line no-restricted-imports
 import { max } from 'ramda'
 import { useRuntime } from 'vtex.render-runtime'
 import {
   useSearchPageStateDispatch,
   useSearchPageState,
 } from 'vtex.search-page-context/SearchPageContext'
+
 import useSearchState from './useSearchState'
 
 export const FETCH_TYPE = {
@@ -14,6 +16,7 @@ export const FETCH_TYPE = {
 
 function reducer(state, action) {
   const { maxItemsPerPage, to, from, rollbackState } = action.args
+
   switch (action.type) {
     case 'RESET':
       return {
@@ -23,6 +26,7 @@ function reducer(state, action) {
         from: 0,
         to: maxItemsPerPage - 1,
       }
+
     case 'NEXT_PAGE':
       return {
         ...state,
@@ -30,6 +34,7 @@ function reducer(state, action) {
         nextPage: state.nextPage + 1,
         to,
       }
+
     case 'PREVIOUS_PAGE':
       return {
         ...state,
@@ -40,6 +45,8 @@ function reducer(state, action) {
 
     case 'ROLLBACK':
       return rollbackState
+
+    default:
   }
 }
 
@@ -55,6 +62,7 @@ const handleFetchMore = async (
   fuzzy,
   operator,
   searchState
+  // eslint-disable-next-line max-params
 ) => {
   if (fetchMoreLocked.current || products.length === 0) {
     return
@@ -80,6 +88,7 @@ const handleFetchMore = async (
 
       if (!products || !fetchMoreResult) {
         updateQueryError.current = true
+
         return
       }
 
@@ -111,11 +120,12 @@ const handleFetchMore = async (
         },
       }
     },
-  }).catch(error => {
+  }).catch((error) => {
     setLoading(false)
     fetchMoreLocked.current = false
     updateQueryError.current = true
-    return { error: error }
+
+    return { error }
   })
 }
 
@@ -124,25 +134,27 @@ const useFetchingMore = () => {
   const { isFetchingMore } = useSearchPageState()
   const dispatch = useSearchPageStateDispatch()
   const setFetchMore = useCallback(
-    value => {
+    (value) => {
       dispatch({ type: 'SET_FETCHING_MORE', args: { isFetchingMore: value } })
       localSetMore(value)
     },
     [dispatch]
   )
+
   const stateValue = isFetchingMore == null ? loading : isFetchingMore
+
   return [stateValue, setFetchMore]
 }
 
-export const useFetchMore = props => {
+export const useFetchMore = (props) => {
   const {
     page,
-    recordsFiltered,
     maxItemsPerPage,
     fetchMore,
     products,
     queryData: { query, map, orderBy, priceRange },
   } = props
+
   const { setQuery, query: runtimeQuery } = useRuntime()
   const { fuzzy, operator, searchState } = useSearchState()
   const currentPage = (runtimeQuery.page && Number(runtimeQuery.page)) || page
@@ -154,6 +166,7 @@ export const useFetchMore = props => {
     from: (page - 1) * maxItemsPerPage,
     to: currentPage * maxItemsPerPage - 1,
   }
+
   const [pageState, pageDispatch] = useReducer(reducer, initialState)
   const [loading, setLoading] = useFetchingMore()
   const isFirstRender = useRef(true)
@@ -162,12 +175,13 @@ export const useFetchMore = props => {
   errors when the search result uses infinite scroll. 
   This should be removed once infinite scrolling is removed */
   const [infiniteScrollError, setInfiniteScrollError] = useState(false)
-  const updateQueryError = useRef(false) //TODO: refactor this ref
+  const updateQueryError = useRef(false) // TODO: refactor this ref
 
   useEffect(() => {
     if (!isFirstRender.current) {
       pageDispatch({ type: 'RESET', args: { maxItemsPerPage } })
     }
+
     isFirstRender.current = false
   }, [maxItemsPerPage, query, map, orderBy, priceRange])
 
@@ -175,6 +189,7 @@ export const useFetchMore = props => {
     const rollbackState = pageState
     const from = pageState.to + 1
     const to = from + maxItemsPerPage - 1
+
     setInfiniteScrollError(false)
     pageDispatch({ type: 'NEXT_PAGE', args: { to } })
 
@@ -198,19 +213,24 @@ export const useFetchMore = props => {
       operator,
       sessionStorage.getItem('searchState') ?? searchState
     )
-    //if error, rollback
-    if (promiseResult && updateQueryError.current) {
-      pageDispatch({ type: 'ROLLBACK', args: { rollbackState } })
-      setQuery({ page: pageState.page }, { replace: true })
-      setInfiniteScrollError(true)
-      updateQueryError.current = false
+
+    // success
+    if (!promiseResult || !updateQueryError.current) {
+      return
     }
+
+    // if error, rollback
+    pageDispatch({ type: 'ROLLBACK', args: { rollbackState } })
+    setQuery({ page: pageState.page }, { replace: true })
+    setInfiniteScrollError(true)
+    updateQueryError.current = false
   }
 
   const handleFetchMorePrevious = async () => {
     const rollbackState = pageState
     const to = pageState.from - 1
     const from = max(0, to - maxItemsPerPage + 1)
+
     setInfiniteScrollError(false)
     pageDispatch({ type: 'PREVIOUS_PAGE', args: { from } })
 
@@ -234,13 +254,17 @@ export const useFetchMore = props => {
       operator,
       sessionStorage.getItem('searchState') ?? searchState
     )
-    //if error, rollback
-    if (promiseResult && updateQueryError.current) {
-      pageDispatch({ type: 'ROLLBACK', args: { rollbackState } })
-      setQuery({ page: pageState.page }, { replace: true, merge: true })
-      setInfiniteScrollError(true)
-      updateQueryError.current = false
+
+    // success
+    if (!promiseResult || !updateQueryError.current) {
+      return
     }
+
+    // if error, rollback
+    pageDispatch({ type: 'ROLLBACK', args: { rollbackState } })
+    setQuery({ page: pageState.page }, { replace: true, merge: true })
+    setInfiniteScrollError(true)
+    updateQueryError.current = false
   }
 
   return {
@@ -249,6 +273,8 @@ export const useFetchMore = props => {
     loading,
     from: pageState.from,
     to: pageState.to,
+    nextPage: pageState.nextPage,
+    previousPage: pageState.previousPage,
     infiniteScrollError,
   }
 }


### PR DESCRIPTION
#### What problem is this solving?

This PR fixes the links provided by FetchPrevious and FetchMore components. They now consider the page number to improve SEO performance.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://icarosearchseo--storecomponents.myvtex.com/apparel---accessories/)

#### Screenshots or example usage:
Notice it now points to `?page=3`

![Screen Shot 2021-05-25 at 18 15 34](https://user-images.githubusercontent.com/8127610/119569518-37d5f180-bd85-11eb-8434-a8f927df64f5.png)

#### Related to / Depends on

Related to [https://github.com/vtex-apps/store/pull/524](https://github.com/vtex-apps/store/pull/524)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/0qiwSa0SwH8DTNjQyR/giphy-downsized.gif)
