### PR TITLE
Adding schemas to allow enabling SEO improvements via site-editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Schemas for customizing Fetch More and Fetch Previous buttons behaviors through site-editor
 
 ## [3.100.0] - 2021-06-10
 ### Fixed

--- a/messages/context.json
+++ b/messages/context.json
@@ -96,10 +96,10 @@
   "admin/editor.search-result-layout.title": "Title of Search Result Layout",
   "admin/editor.search-result-mobile.title": "Title of Search Result Layout for Mobile",
   "admin/editor.search-result-desktop.title": "Title of Search Result Layout for Deskptop",
-  "store/search-result.price-ranges.submit": "Price Range submit button",
-  "admin/editor.search-result.fetch-more": "Fetch more",
-  "admin/editor.search-result.fetch-previous": "Fetch previous",
+  "store/search-result.price-ranges.submit": "Go",
+  "admin/editor.search-result.fetch-more": "Show more",
+  "admin/editor.search-result.fetch-previous": "Show previous",
   "admin/editor.search-result.fetch-button.button-behavior": "Button behavior",
   "admin/editor.search-result.fetch-button.button-behavior.button": "Button",
-  "admin/editor.search-result.fetch-button.button-behavior.link-to-page": "Link to page - improves SEO, may change how the button looks"
+  "admin/editor.search-result.fetch-button.button-behavior.link-to-page": "Link to page - Improves SEO, may change how the button looks"
 }

--- a/messages/context.json
+++ b/messages/context.json
@@ -97,8 +97,8 @@
   "admin/editor.search-result-mobile.title": "Title of Search Result Layout for Mobile",
   "admin/editor.search-result-desktop.title": "Title of Search Result Layout for Deskptop",
   "store/search-result.price-ranges.submit": "Go",
-  "admin/editor.search-result.fetch-more": "Show more",
-  "admin/editor.search-result.fetch-previous": "Show previous",
+  "admin/editor.search-result.fetch-more": "Fetch more",
+  "admin/editor.search-result.fetch-previous": "Fetch previous",
   "admin/editor.search-result.fetch-button.button-behavior": "Button behavior",
   "admin/editor.search-result.fetch-button.button-behavior.button": "Button",
   "admin/editor.search-result.fetch-button.button-behavior.link-to-page": "Link to page - Improves SEO, may change how the button looks"

--- a/messages/context.json
+++ b/messages/context.json
@@ -96,5 +96,10 @@
   "admin/editor.search-result-layout.title": "Title of Search Result Layout",
   "admin/editor.search-result-mobile.title": "Title of Search Result Layout for Mobile",
   "admin/editor.search-result-desktop.title": "Title of Search Result Layout for Deskptop",
-  "store/search-result.price-ranges.submit": "Price Range submit button"
+  "store/search-result.price-ranges.submit": "Price Range submit button",
+  "admin/editor.search-result.fetch-more": "Fetch more",
+  "admin/editor.search-result.fetch-previous": "Fetch previous",
+  "admin/editor.search-result.fetch-button.button-behavior": "Button behavior",
+  "admin/editor.search-result.fetch-button.button-behavior.button": "Button",
+  "admin/editor.search-result.fetch-button.button-behavior.link-to-page": "Link to page - improves SEO, may change how the button looks"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -97,5 +97,10 @@
   "admin/editor.search-result-layout.title": "Search Result Flexible Layout",
   "admin/editor.search-result-mobile.title": "Search Result Flexible Layout Mobile",
   "admin/editor.search-result-desktop.title": "Search Result Flexible Layout Desktop",
-  "store/search-result.price-ranges.submit": "Go"
+  "store/search-result.price-ranges.submit": "Go",
+  "admin/editor.search-result.fetch-more": "Fetch more",
+  "admin/editor.search-result.fetch-previous": "Fetch previous",
+  "admin/editor.search-result.fetch-button.button-behavior": "Button behavior",
+  "admin/editor.search-result.fetch-button.button-behavior.button": "Button",
+  "admin/editor.search-result.fetch-button.button-behavior.link-to-page": "Link to page - improves SEO, may change how the button looks"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -98,9 +98,9 @@
   "admin/editor.search-result-mobile.title": "Search Result Flexible Layout Mobile",
   "admin/editor.search-result-desktop.title": "Search Result Flexible Layout Desktop",
   "store/search-result.price-ranges.submit": "Go",
-  "admin/editor.search-result.fetch-more": "Fetch more",
-  "admin/editor.search-result.fetch-previous": "Fetch previous",
+  "admin/editor.search-result.fetch-more": "Show more",
+  "admin/editor.search-result.fetch-previous": "Show previous",
   "admin/editor.search-result.fetch-button.button-behavior": "Button behavior",
   "admin/editor.search-result.fetch-button.button-behavior.button": "Button",
-  "admin/editor.search-result.fetch-button.button-behavior.link-to-page": "Link to page - improves SEO, may change how the button looks"
+  "admin/editor.search-result.fetch-button.button-behavior.link-to-page": "Link to page - Improves SEO, may change how the button looks"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -98,8 +98,8 @@
   "admin/editor.search-result-mobile.title": "Search Result Flexible Layout Mobile",
   "admin/editor.search-result-desktop.title": "Search Result Flexible Layout Desktop",
   "store/search-result.price-ranges.submit": "Go",
-  "admin/editor.search-result.fetch-more": "Show more",
-  "admin/editor.search-result.fetch-previous": "Show previous",
+  "admin/editor.search-result.fetch-more": "Fetch more",
+  "admin/editor.search-result.fetch-previous": "Fetch previous",
   "admin/editor.search-result.fetch-button.button-behavior": "Button behavior",
   "admin/editor.search-result.fetch-button.button-behavior.button": "Button",
   "admin/editor.search-result.fetch-button.button-behavior.link-to-page": "Link to page - Improves SEO, may change how the button looks"

--- a/messages/es.json
+++ b/messages/es.json
@@ -97,5 +97,10 @@
   "admin/editor.search-result-layout.title": "Resultado de búsqueda flexible",
   "admin/editor.search-result-mobile.title": "Resultado de búsqueda móvil flexible",
   "admin/editor.search-result-desktop.title": "Resultado de búsqueda de desktop flexible",
-  "store/search-result.price-ranges.submit": "Ir"
+  "store/search-result.price-ranges.submit": "Buscar",
+  "admin/editor.search-result.fetch-more": "Mostrar más",
+  "admin/editor.search-result.fetch-previous": "Mostrar anterior",
+  "admin/editor.search-result.fetch-button.button-behavior": "Comportamiento del botón",
+  "admin/editor.search-result.fetch-button.button-behavior.button": "Botón",
+  "admin/editor.search-result.fetch-button.button-behavior.link-to-page": "Link a la página - Mejora el SEO, puede cambiar el aspecto del botón"
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -94,5 +94,11 @@
   "admin/editor.search-result-layout-custom.title": "Mise en page flexible et personnalisée du résultat de recherche",
   "admin/editor.search-result-layout.title": "Mise en page flexible du résultat de recherche",
   "admin/editor.search-result-mobile.title": "Mise en page flexible du résultat de recherche sur mobile",
-  "admin/editor.search-result-desktop.title": "Mise en page flexible du résultat de recherche sur ordinateur"
+  "admin/editor.search-result-desktop.title": "Mise en page flexible du résultat de recherche sur ordinateur",
+  "store/search-result.price-ranges.submit": "Aller",
+  "admin/editor.search-result.fetch-more": "Récupérer plus",
+  "admin/editor.search-result.fetch-previous": "Récupérer le précédent",
+  "admin/editor.search-result.fetch-button.button-behavior": "Comportement du bouton",
+  "admin/editor.search-result.fetch-button.button-behavior.button": "Bouton",
+  "admin/editor.search-result.fetch-button.button-behavior.link-to-page": "Lien vers la page - Améliore le référencement SEO, peut changer l’apparence du bouton"
 }

--- a/messages/it.json
+++ b/messages/it.json
@@ -1,0 +1,8 @@
+{
+  "store/search-result.price-ranges.submit": "Vai",
+  "admin/editor.search-result.fetch-more": "Recupera altro",
+  "admin/editor.search-result.fetch-previous": "Recupera precedente",
+  "admin/editor.search-result.fetch-button.button-behavior": "Comportamento pulsante",
+  "admin/editor.search-result.fetch-button.button-behavior.button": "Pulsante",
+  "admin/editor.search-result.fetch-button.button-behavior.link-to-page": "Link alla pagina - Migliora il SEO, può cambiare l'aspetto del pulsante"
+}

--- a/messages/jp.json
+++ b/messages/jp.json
@@ -1,0 +1,8 @@
+{
+  "store/search-result.price-ranges.submit": "進む",
+  "admin/editor.search-result.fetch-more": "さらに取得",
+  "admin/editor.search-result.fetch-previous": "前のを取得",
+  "admin/editor.search-result.fetch-button.button-behavior": "ボタンの動作",
+  "admin/editor.search-result.fetch-button.button-behavior.button": "ボタン",
+  "admin/editor.search-result.fetch-button.button-behavior.link-to-page": "ページへのリンク - SEO を改善します。ボタンの見た目が変わることがあります。"
+}

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -94,5 +94,11 @@
   "admin/editor.search-result-layout-custom.title": "검색 결과 사용자 정의 플렉시블 레이아웃",
   "admin/editor.search-result-layout.title": "검색 결과 플렉시블 레이아웃",
   "admin/editor.search-result-mobile.title": "검색 결과 플렉시블 레이아웃 모바일",
-  "admin/editor.search-result-desktop.title": "검색 결과 플렉시블 레이아웃 데스크탑"
+  "admin/editor.search-result-desktop.title": "검색 결과 플렉시블 레이아웃 데스크탑",
+  "store/search-result.price-ranges.submit": "이동",
+  "admin/editor.search-result.fetch-more": "추가 가져오기",
+  "admin/editor.search-result.fetch-previous": "이전 가져오기",
+  "admin/editor.search-result.fetch-button.button-behavior": "단추 동작",
+  "admin/editor.search-result.fetch-button.button-behavior.button": "단추",
+  "admin/editor.search-result.fetch-button.button-behavior.link-to-page": "페이지 링크 - SEO 개선, 버튼 모양 변경 가능"
 }

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -94,5 +94,11 @@
   "admin/editor.search-result-layout-custom.title": "Zoekresultaat Aangepaste Flexibele Lay-out",
   "admin/editor.search-result-layout.title": "Zoekresultaat Flexibele Layout",
   "admin/editor.search-result-mobile.title": "Zoekresultaat Flexibele Layout Mobiel",
-  "admin/editor.search-result-desktop.title": "Zoekresultaat Flexibele Layout Desktop"
+  "admin/editor.search-result-desktop.title": "Zoekresultaat Flexibele Layout Desktop",
+  "store/search-result.price-ranges.submit": "Ga",
+  "admin/editor.search-result.fetch-more": "Meer halen",
+  "admin/editor.search-result.fetch-previous": "Vorige halen",
+  "admin/editor.search-result.fetch-button.button-behavior": "Knopgedrag",
+  "admin/editor.search-result.fetch-button.button-behavior.button": "Knop",
+  "admin/editor.search-result.fetch-button.button-behavior.link-to-page": "Link naar pagina - Verbetert SEO, kan veranderen hoe de knop eruit ziet"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -97,5 +97,10 @@
   "admin/editor.search-result-layout.title": "Resultado de busca flexível",
   "admin/editor.search-result-mobile.title": "Resultado de busca flexível para dispositivo móvel",
   "admin/editor.search-result-desktop.title": "Resultado de busca flexível para Desktop",
-  "store/search-result.price-ranges.submit": "Ir"
+  "store/search-result.price-ranges.submit": "Pesquisar",
+  "admin/editor.search-result.fetch-more": "Mostrar mais",
+  "admin/editor.search-result.fetch-previous": "Mostrar anteriores",
+  "admin/editor.search-result.fetch-button.button-behavior": "Comportamento do botão",
+  "admin/editor.search-result.fetch-button.button-behavior.button": "Botão",
+  "admin/editor.search-result.fetch-button.button-behavior.link-to-page": "Link para a página – Melhora o SEO, pode mudar a aparência do botão"
 }

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -94,5 +94,11 @@
   "admin/editor.search-result-layout-custom.title": "Mod de afișare rezultat personalizat flexibil",
   "admin/editor.search-result-layout.title": "Mod de afișare rezultat flexibil",
   "admin/editor.search-result-mobile.title": "Mod de afișare rezultat flexibil pentru mobil",
-  "admin/editor.search-result-desktop.title": "Mod de afișare rezultat pentru desktop"
+  "admin/editor.search-result-desktop.title": "Mod de afișare rezultat pentru desktop",
+  "store/search-result.price-ranges.submit": "Caută",
+  "admin/editor.search-result.fetch-more": "Preia mai multe",
+  "admin/editor.search-result.fetch-previous": "Preia anterioarele",
+  "admin/editor.search-result.fetch-button.button-behavior": "Comportament buton",
+  "admin/editor.search-result.fetch-button.button-behavior.button": "Buton",
+  "admin/editor.search-result.fetch-button.button-behavior.link-to-page": "Link către pagină - Îmbunătățește SEO, poate schimba modul în care arată butonul"
 }

--- a/react/FetchMore.js
+++ b/react/FetchMore.js
@@ -68,4 +68,8 @@ FetchMore.propTypes = {
   htmlElementForButton: PropTypes.string,
 }
 
+FetchMore.schema = {
+  title: 'admin/editor.search-result.fetch-more',
+}
+
 export default FetchMore

--- a/react/FetchPrevious.js
+++ b/react/FetchPrevious.js
@@ -61,4 +61,8 @@ FetchPrevious.propTypes = {
   htmlElementForButton: PropTypes.string,
 }
 
+FetchPrevious.schema = {
+  title: 'admin/editor.search-result.fetch-previous',
+}
+
 export default FetchPrevious

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -19,6 +19,42 @@
           "title": "admin/editor.search-result.total-products"
         }
       }
+    },
+    "FetchPrevious": {
+      "title": "admin/editor.search-result.fetch-previous",
+      "type": "object",
+      "properties": {
+        "htmlElementForButton": {
+          "title": "admin/editor.search-result.fetch-button.button-behavior",
+          "enum": ["button", "a"],
+          "enumNames": [
+            "admin/editor.search-result.fetch-button.button-behavior.button",
+            "admin/editor.search-result.fetch-button.button-behavior.link-to-page"
+          ],
+          "widget": {
+            "ui:widget": "radio"
+          },
+          "default": "button"
+        }
+      }
+    },
+    "FetchMore": {
+      "title": "admin/editor.search-result.fetch-more",
+      "type": "object",
+      "properties": {
+        "htmlElementForButton": {
+          "title": "admin/editor.search-result.fetch-button.button-behavior",
+          "enum": ["button", "a"],
+          "enumNames": [
+            "admin/editor.search-result.fetch-button.button-behavior.button",
+            "admin/editor.search-result.fetch-button.button-behavior.link-to-page"
+          ],
+          "widget": {
+            "ui:widget": "radio"
+          },
+          "default": "button"
+        }
+      }
     }
   }
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -72,10 +72,16 @@
     "component": "SearchContent"
   },
   "search-fetch-more": {
-    "component": "FetchMore"
+    "component": "FetchMore",
+    "content": {
+      "$ref": "app:vtex.search-result#/definitions/FetchMore"
+    }
   },
   "search-fetch-previous": {
-    "component": "FetchPrevious"
+    "component": "FetchPrevious",
+    "content": {
+      "$ref": "app:vtex.search-result#/definitions/FetchPrevious"
+    }
   },
   "search-result-layout.desktop": {
     "allowed": [


### PR DESCRIPTION
#### What problem is this solving?
This PR adds schemas to fetch more/previous components to allow clients to enable SEO improvements via site-editor.

#### How to test it?

Go to a search page on the site-editor. Hover Fetch More button on the page. You should see nothing happening.  Edit the fetch more block inside the Search Result Flexible Layout block. Choose the "Link to page" option. Now hover over the Fetch More button on the page. You should see the little browser popup showing this button is a link to another page.

Clicking the button should not redirect the user, only load more items. The link is only there for SEO purposes.

[Workspace](https://icarovtex--alssports.myvtex.com/admin/cms/site-editor/patagonia?map=ft)
[Workspace 2](https://icarofetch--storecomponents.myvtex.com/admin/cms/site-editor/apparel---accessories)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

<img width="280" alt="Screen Shot 2021-06-16 at 19 47 03" src="https://user-images.githubusercontent.com/8127610/122304458-a701ba00-cedb-11eb-9419-281dc78e7b94.png">

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/kD4pknHevDUQNOTSbl/giphy.gif)
