### PR TITLE
Pass initialMap to facets query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Pass `initialMap` to facets query.
+
 ## [3.103.0] - 2021-07-01
 ### Added
 - Schemas for customizing Fetch More and Fetch Previous buttons behaviors through site-editor

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -146,7 +146,7 @@ const useCorrectSearchStateVariables = (
 }
 
 const useQueries = (variables, facetsArgs) => {
-  const { getSettings } = useRuntime()
+  const { getSettings, query: runtimeQuery } = useRuntime()
   const isLazyFacetsFetchEnabled = getSettings('vtex.store')
     ?.enableFiltersFetchOptimization
 
@@ -187,6 +187,7 @@ const useQueries = (variables, facetsArgs) => {
       operator: variables.operator,
       fuzzy: variables.fuzzy,
       searchState: variables.searchState,
+      initialAttributes: runtimeQuery?.initialMap,
     },
     skip: !facetsArgs.withFacets,
   })


### PR DESCRIPTION
#### What problem is this solving?

Pass `initialMap` to facets query. This way, we can optimize the facets query made in the API if the store has the optimization setting enabled.
For stores that don't enable the setting, this parameter will be ignored by the API, so it's ok to send it to all stores :)

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://thalyta--carrefourbr.myvtex.com/eletrodomesticos/geladeira/vonder?crfint=hm-tlink|geladeira|1|geladeira|1&initialMap=c,c&initialQuery=eletrodomesticos/geladeira&map=b)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on
https://github.com/vtex-apps/store-resources/pull/156

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
