### PR TITLE
Fix search not found layout

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "3.104.0",
+  "version": "3.104.1",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/SearchResultLayout.js
+++ b/react/SearchResultLayout.js
@@ -11,13 +11,11 @@ const noProducts = compose(
   pathOr([], ['data', 'productSearch', 'products'])
 )
 
-const isFtOnly = compose(equals('ft'), path(['variables', 'map']))
-
 const noRedirect = compose(isNil, path(['data', 'productSearch', 'redirect']))
 
 const foundNothing = searchQuery => {
   const { loading } = searchQuery || {}
-  return isFtOnly(searchQuery) && !loading && noProducts(searchQuery)
+  return !loading && noProducts(searchQuery)
 }
 
 const SearchResultLayout = props => {

--- a/react/SearchResultLayoutCustomQuery.js
+++ b/react/SearchResultLayoutCustomQuery.js
@@ -13,13 +13,11 @@ const noProducts = compose(
   pathOr([], ['data', 'productSearch', 'products'])
 )
 
-const isFtOnly = compose(equals('ft'), path(['variables', 'map']))
-
 const trimStartingSlash = value => value && value.replace(/^\//, '')
 
 const foundNothing = searchQuery => {
   const { loading } = searchQuery || {}
-  return isFtOnly(searchQuery) && !loading && noProducts(searchQuery)
+  return !loading && noProducts(searchQuery)
 }
 
 const ExtensionPointWithProps = ({ id, parentProps, localSearchQueryData }) => {


### PR DESCRIPTION
…search does not return results or when a category or department path does not return results

#### What problem is this solving?

is set so that the search-not-found-layout block is displayed when a search does not return results or when a category or department path does not return results

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

https://jomarr--aquamaxxpe.myvtex.com/hola%20coom%20estas?_q=hola%20coom%20estas&map=ft

https://jomarr--aquamaxxpe.myvtex.com/Parrillas/Empotrables

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

![image](https://user-images.githubusercontent.com/17678382/125028636-002dbb00-e04e-11eb-935e-820d029dfd95.png)
![image](https://user-images.githubusercontent.com/17678382/125028647-06bc3280-e04e-11eb-938b-8641121869f9.png)


#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

This helps us to better customize the basic search message since the default block will always be shown in the type /department /category path

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
