### PR TITLE
Hide facet quantity when search result is sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Hide the facet quantity when search result is sampling.
+
 ## [3.105.1] - 2021-07-26
 
 ### Fixed

--- a/react/components/FacetCheckboxList.js
+++ b/react/components/FacetCheckboxList.js
@@ -35,6 +35,7 @@ const FacetCheckboxList = ({
   const [truncated, setTruncated] = useState(true)
   const isLazyFacetsFetchEnabled = getSettings('vtex.store')
     ?.enableFiltersFetchOptimization
+  const sampling = searchQuery?.facets?.sampling
 
   const filteredFacets = useMemo(() => {
     if (thresholdForFacetSearch === undefined || searchTerm === '') {
@@ -92,7 +93,7 @@ const FacetCheckboxList = ({
               checked={facet.selected}
               id={name}
               label={
-                showFacetQuantity
+                (showFacetQuantity && !sampling)
                   ? `${facet.name} (${facet.quantity})`
                   : facet.name
               }

--- a/react/components/FacetItem.js
+++ b/react/components/FacetItem.js
@@ -41,6 +41,7 @@ const FacetItem = ({
   )
 
   const { searchQuery } = useSearchPage()
+  const sampling = searchQuery?.facets?.sampling
 
   const checkBoxId = reservedVariableNames.includes(facet.value)
     ? `filterItem--${facet.key}-${facet.value}`
@@ -60,7 +61,7 @@ const FacetItem = ({
 
   const shouldDisable = useShouldDisableFacet(facet)
 
-  const facetLabel = showFacetQuantity ? (
+  const facetLabel = (showFacetQuantity && !sampling) ? (
     <>
       {facet.name}{' '}
       <span

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -230,6 +230,7 @@ const useQueries = (variables, facetsArgs) => {
         queryArgs,
         breadcrumb: facets && facets.breadcrumb,
         facetsFetchMore,
+        sampling: facets?.sampling,
       },
       searchMetadata,
     },


### PR DESCRIPTION
#### What problem is this solving?

Now the Intelligent Search has a feature to improve search performance that only takes a sampling of the results to get a faster `facets` query response.
With this feature enabled for a store, if there is a query that has more results than the limit set by the store, we will only return a sample of that result.
In these scenarios, it's possible that the amount of products for a facet is returned with a lower value than the actual amount of products for that facet:

![sampling](https://user-images.githubusercontent.com/20840671/125115216-656ec400-e0c1-11eb-9c0c-77a205421301.gif)


To avoid an inconsistency in what is displayed to the user, it's necessary for the component to know when only a sample of the data was taken and, in this case, we should not display the amount of products for the facet in the filter navigator.

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[using sampling](https://thalyta--carrefourbr.myvtex.com/eletrodomesticos?crfint=hm|header-menu-departamentos|eletrodomesticos|2)
[without using sampling](https://thalyta--carrefourbr.myvtex.com/eletrodomesticos/geladeira?crfint=hm-tlink|geladeira|1|geladeira|1)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
