### PR TITLE
change from productId to cacheId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Use `cacheId` instead of `productId` as `Gallery` key.
+
 ## [3.106.0] - 2021-07-28
 
 ### Changed

--- a/react/Gallery.tsx
+++ b/react/Gallery.tsx
@@ -44,6 +44,8 @@ const Gallery: React.FC<GalleryLegacyProps | GalleryLayoutPropsWithSlots> = (
 export interface Product {
   /** Product's id. */
   productId: string
+  /** Product's cache id. */
+  cacheId: string
   /** Product's name. */
   productName: string
   /** Product's description. */

--- a/react/components/GalleryLayoutRow.tsx
+++ b/react/components/GalleryLayoutRow.tsx
@@ -52,10 +52,9 @@ const GalleryLayoutRow: React.FC<GalleryLayoutRowProps> = ({
     <>
       {products.map((product, index) => {
         const absoluteProductIndex = rowIndex * itemsPerRow + index + 1
-
         return (
           <div
-            key={product.productId}
+            key={product.cacheId}
             style={style}
             className={classNames(
               applyModifiers(handles.galleryItem, [

--- a/react/components/GalleryRow.tsx
+++ b/react/components/GalleryRow.tsx
@@ -66,7 +66,7 @@ function GalleryRow({
 
         return (
           <div
-            key={product.productId}
+            key={product.cacheId}
             style={style}
             className={classNames(
               applyModifiers(handles.galleryItem, [


### PR DESCRIPTION
#### What problem is this solving?

The intelligent search has a feature called `split by sku`. This is used to show multiple skus on the search-result. Like this

![image](https://user-images.githubusercontent.com/40380674/126231198-2ca04f3f-92f8-45e0-a8a0-bedae7724af7.png)


Those five products are actually the same product, but different SKUs

![2nb427w5d5](https://user-images.githubusercontent.com/40380674/126231415-b8ce6633-b6aa-418d-9b07-e74de11eeceb.gif)


Since they are the same product, they have the same `productId`. For this reason, we can't use the `productId` as the component key anymore


#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://hiago--paylessus.myvtex.com/)


