### PR TITLE
fix: urls on fetch more/fetch previous buttons now includes the map query string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Urls on Fetch more/Fetch previous buttons now includes the map query string
 
 ## [3.108.0] - 2021-08-24
 

--- a/react/components/loaders/FetchMoreButton.js
+++ b/react/components/loaders/FetchMoreButton.js
@@ -2,6 +2,7 @@ import React, { Fragment, useState, useEffect } from 'react'
 import { Button } from 'vtex.styleguide'
 import { useCssHandles } from 'vtex.css-handles'
 import { FormattedMessage } from 'react-intl'
+import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
 
 const CSS_HANDLES = [
   'buttonShowMore',
@@ -23,6 +24,28 @@ const useShowButton = (to, products, loading, recordsFiltered) => {
   return showButton
 }
 
+function shouldNotIncludeMap(map) {
+  if (!map || map === 'b' || map === 'brand') {
+    return true
+  }
+
+  const mapTree = map.split(',')
+
+  if (mapTree.length > 3) {
+    return false
+  }
+
+  return mapTree.every((mapItem) => mapItem === 'c')
+}
+
+export function getMapQueryString(searchQuery) {
+  if (shouldNotIncludeMap(searchQuery?.variables?.map)) {
+    return ''
+  }
+
+  return `&map=${searchQuery?.variables?.map}`
+}
+
 const FetchMoreButton = (props) => {
   const {
     products,
@@ -38,6 +61,7 @@ const FetchMoreButton = (props) => {
   const isAnchor = htmlElementForButton === 'a'
   const showButton = useShowButton(to, products, loading, recordsFiltered)
   const handles = useCssHandles(CSS_HANDLES)
+  const { searchQuery } = useSearchPage()
 
   const handleFetchMoreClick = (ev) => {
     isAnchor && ev.preventDefault()
@@ -50,7 +74,9 @@ const FetchMoreButton = (props) => {
         {showButton && (
           <Button
             onClick={(ev) => handleFetchMoreClick(ev)}
-            href={isAnchor && `?page=${nextPage}`}
+            href={
+              isAnchor && `?page=${nextPage}${getMapQueryString(searchQuery)}`
+            }
             rel={isAnchor && 'next'}
             isLoading={loading}
             size="small"

--- a/react/components/loaders/FetchPreviousButton.js
+++ b/react/components/loaders/FetchPreviousButton.js
@@ -2,6 +2,9 @@ import React, { useState, useEffect } from 'react'
 import { Button } from 'vtex.styleguide'
 import { useCssHandles } from 'vtex.css-handles'
 import { FormattedMessage } from 'react-intl'
+import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
+
+import { getMapQueryString } from './FetchMoreButton'
 
 const CSS_HANDLES = ['buttonShowMore']
 
@@ -32,6 +35,7 @@ const FetchPreviousButton = (props) => {
   const isAnchor = htmlElementForButton === 'a'
   const showButton = useShowButton(from, products, loading)
   const handles = useCssHandles(CSS_HANDLES)
+  const { searchQuery } = useSearchPage()
 
   const handleFetchMoreClick = (ev) => {
     isAnchor && ev.preventDefault()
@@ -43,7 +47,9 @@ const FetchPreviousButton = (props) => {
       {showButton && (
         <Button
           onClick={(ev) => handleFetchMoreClick(ev)}
-          href={isAnchor && `?page=${previousPage}`}
+          href={
+            isAnchor && `?page=${previousPage}${getMapQueryString(searchQuery)}`
+          }
           rel={isAnchor && 'prev'}
           isLoading={loading}
           size="small"


### PR DESCRIPTION
#### What problem is this solving?

This PR fixes URLs that were not including the `map` query string when referencing next or previous pages. This is a problem specially on collection pages, since these pages need the `map` property to work. Before, crawlers would be redirected to a 404 page.

#### How to test it?

Look at the Fetch More/Fetch Previous buttons present on the page. This is not the exact same scenario but reflects that the `map` is now being included on the URL when needed. If you remove the `map` from the URL, it doesn't work.

[Workspace](https://icarocnc--storecomponents.myvtex.com/apparel---accessories/home---decor?map=category-1%2Ccategory-1)

#### Screenshots or example usage:

![Screen Shot 2021-07-27 at 12 24 16](https://user-images.githubusercontent.com/8127610/127181623-3b4af17d-94af-4dd5-bf8f-5935b1292358.png)


#### Related to / Depends on

Related to https://github.com/vtex-apps/store/pull/529

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/Kx7HO28xRu1cG8S3GB/giphy-downsized.gif)
