### PR TITLE
add: usability enhance using alt and title on facet's div

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `alt` and `title` into facet's div at `FacetItem.js`
+
 ## [3.107.0] - 2021-08-19
 
 ### Added

--- a/react/components/FacetItem.js
+++ b/react/components/FacetItem.js
@@ -80,6 +80,8 @@ const FacetItem = ({
     <div
       className={classes}
       style={{ hyphens: 'auto', wordBreak: 'break-word' }}
+      alt={facet.name}
+      title={facet.name}
     >
       <Checkbox
         id={checkBoxId}

--- a/react/test.logs
+++ b/react/test.logs
@@ -1,0 +1,7 @@
+13:14:25.051 - [32minfo[39m: Connecting to logs stream for segurosexito  
+13:14:25.052 - [32minfo[39m: Press CTRL+C to abort  
+13:15:10.981 - [32minfo[39m: Listening to segurosexito's logs  
+13:41:30.979 - [31merror[39m: Error reading logs: SSE error on endpoint http://infra.io.vtex.com/skidder/v1/segurosexito/iespinoza/logs/stream - [ErrorID: 4f5a408feac2e08a1adb15990ff26abd]  
+13:42:17.655 - [32minfo[39m: Listening to segurosexito's logs  
+14:13:11.360 - [31merror[39m: Error reading logs: SSE error on endpoint http://infra.io.vtex.com/skidder/v1/segurosexito/iespinoza/logs/stream - [ErrorID: 7d57df21c604817ca851b5abe0ffa2d4]  
+14:14:38.413 - [32minfo[39m: Listening to segurosexito's logs  


### PR DESCRIPTION
#### What problem is this solving?

Usability improvement allowing to see the facets name on mouse hover and also for screen readers

#### How to test it?

Mouse hover on some facet spec in the search result page


[After](https://iespinoza--miniprix.myvtex.com/femei)
[Before](https://master--miniprix.myvtex.com/femei)

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/13649073/130660852-ed1c72ca-6650-41ad-80da-8cb1dca214ae.png)

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/l4EoQgyMUXw0TM9Pi/giphy.gif?cid=ecf05e47eddbd17kwifx6wxhus280euj5f4bd27jfcqk9bpy&rid=giphy.gif&ct=g)
