### PR TITLE
Add specificationOptions to OrderBy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `specificationOptions` to `OrderBy`.
+
 ## [3.109.1] - 2021-10-12
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -471,6 +471,7 @@ Renders a dropdown button with sorting options to display the fetched results (t
 
 | Prop name       | Type            | Description                 | Default value |
 | --------------- | --------------- | --------------------------- | ------------- |
+| `specificationOptions` | `[object]` | Indicates which sorting options by specification will be displayed. This only works for stores using `vtex.search-resolver@1.x` | `undefined` |
 | `hiddenOptions` | `[string]` | Indicates which sorting options will be hidden. (e.g. `["OrderByNameASC", "OrderByNameDESC"]`) | `undefined`      |
 | `showOrderTitle` | `boolean` | Whether the selected order value (e.g. `Relevance`) will be displayed (`true`) or not (`false`).  | `true`           |
 
@@ -487,6 +488,12 @@ The sorting options are:
 | Name Ascending           | `"OrderByNameASC"`          |
 | Name Descending          | `"OrderByNameDESC"`         |
 | Collection          | `"OrderByCollection"`         |
+
+- **`specificationOptions` Object:**
+| Prop name | Type    | Description    | Default value |
+| --------- | ------- | -------------- | ------------- |
+| value     | string  | Value that will be sent for ordering in the API. Must be in the format `{specification key}:{asc|desc}`. For example: `"size:desc"` or `"priceByUnit:asc"`. | `undefined` |
+| label     | string  | Label that will be displayed in the sorting options. E.g.: `"Price by unit, ascending"` | `undefined` |
 
 #### `search-fetch-more` block
 

--- a/react/OrderBy.js
+++ b/react/OrderBy.js
@@ -42,21 +42,22 @@ export const SORT_OPTIONS = [
 const OrderBy = ({
   orderBy,
   message,
+  specificationOptions = [],
   hiddenOptions = [],
   showOrderTitle = true,
 }) => {
   const intl = useIntl()
 
   const sortingOptions = useMemo(() => {
-    return SORT_OPTIONS.filter(
-      (option) => !hiddenOptions.includes(option.value)
+    return SORT_OPTIONS.concat(specificationOptions).filter(
+      (option) => !hiddenOptions.includes(option.value) && option.label
     ).map(({ value, label }) => {
       return {
         value,
         label: intl.formatMessage({ id: label }),
       }
     })
-  }, [intl, hiddenOptions])
+  }, [intl, hiddenOptions, specificationOptions])
 
   return (
     <SelectionListOrderBy
@@ -71,6 +72,8 @@ const OrderBy = ({
 OrderBy.propTypes = {
   /** Which sorting option is selected. */
   orderBy: PropTypes.string,
+  /** Specification sorting options to be displayed in the list */
+  specificationOptions: PropTypes.arrayOf(PropTypes.object),
   /** Options to be hidden. (e.g. `["OrderByNameASC", "OrderByNameDESC"]`) */
   hiddenOptions: PropTypes.arrayOf(PropTypes.string),
   /** Message to be displayed */


### PR DESCRIPTION
#### What problem is this solving?

Allows the store to add sorting options (ascending or descending) by product specifications

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://thalyta2--storecomponents.myvtex.com/shirt?_q=shirt&map=ft&order=color:asc)

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/20840671/138948813-aa0f4001-02ef-434d-a8c5-e72d5620950b.png)


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
