### PR TITLE
Insert add new classes to responsive filter navigator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- New classes to responsive filter navigator
+
 ## [3.110.6] - 2021-12-08
 ### Fixed
 - Safely URI decoding `query` to prevent errors when the search query contains breaking characters such as "%"

--- a/docs/README.md
+++ b/docs/README.md
@@ -573,6 +573,9 @@ To apply CSS customization in this and other blocks, follow the instructions giv
 | `accordionFilterItem`                 |
 | `accordionFilterOpen`                 |
 | `accordionSelectedFilters`            |
+| `accordionCollapseOpen`               |
+| `accordionCollapseClose`              |
+| `accordionCollapseContent`            |
 | `border`                              |
 | `breadcrumb`                          |
 | `buttonShowMore`                      |
@@ -679,6 +682,7 @@ Thanks goes out to these wonderful people ([emoji key](https://allcontributors.o
     <td align="center"><a href="https://github.com/felipeireslan"><img src="https://avatars3.githubusercontent.com/u/47363947?v=4?s=100" width="100px;" alt=""/><br /><sub><b>felipeireslan</b></sub></a><br /><a href="https://github.com/vtex-apps/search-result/commits?author=felipeireslan" title="Code">💻</a></td>
     <td align="center"><a href="https://juliomoreira.pro"><img src="https://avatars2.githubusercontent.com/u/1207017?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Julio Moreira</b></sub></a><br /><a href="https://github.com/vtex-apps/search-result/commits?author=juliomoreira" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/anto90fg"><img src="https://avatars.githubusercontent.com/u/73878310?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Antonio Cervelione</b></sub></a><br /><a href="https://github.com/vtex-apps/search-result/commits?author=anto90fg" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/lucas-castro-developer"><img src="https://avatars.githubusercontent.com/lucas-castro-developer" width="100px;" alt=""/><br /><sub><b>Lucas Castro Developer</b></sub></a><br /><a href="#" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -573,9 +573,12 @@ To apply CSS customization in this and other blocks, follow the instructions giv
 | `accordionFilterItem`                 |
 | `accordionFilterOpen`                 |
 | `accordionSelectedFilters`            |
-| `accordionCollapseOpen`               |
-| `accordionCollapseClose`              |
-| `accordionCollapseContent`            |
+| `accordionCollapseContainerOpen`      |
+| `accordionCollapseContainerClose`     |
+| `accordionCollapseButtonOpen`         |
+| `accordionCollapseButtonClose`        |
+| `accordionCollapseContentOpen`        |
+| `accordionCollapseContentClose`       |
 | `border`                              |
 | `breadcrumb`                          |
 | `buttonShowMore`                      |

--- a/docs/README.md
+++ b/docs/README.md
@@ -579,6 +579,7 @@ To apply CSS customization in this and other blocks, follow the instructions giv
 | `accordionCollapseButtonClose`        |
 | `accordionCollapseContentOpen`        |
 | `accordionCollapseContentClose`       |
+| `accordionCollapseContentChildren`    |
 | `border`                              |
 | `breadcrumb`                          |
 | `buttonShowMore`                      |

--- a/react/components/AccordionFilterItem.js
+++ b/react/components/AccordionFilterItem.js
@@ -21,6 +21,9 @@ const CSS_HANDLES = [
   'accordionFilterItemTag',
   'accordionFilterItemIcon',
   'accordionSelectedFilters',
+  'accordionCollapseOpen',
+  'accordionCollapseClose',
+  'accordionCollapseContent'
 ]
 
 const AccordionFilterItem = ({
@@ -41,7 +44,7 @@ const AccordionFilterItem = ({
   const handles = useCssHandles(CSS_HANDLES)
   const isNavigationCollapsible = navigationType === 'collapsible'
   const [isCollapsed, setIsCollapsed] = useState(initiallyCollapsed)
-
+  
   const handleOnOpen = (e) => {
     if (isNavigationCollapsible) {
       setIsCollapsed((prevIsCollapsed) => !prevIsCollapsed)
@@ -56,6 +59,10 @@ const AccordionFilterItem = ({
     }
   }
 
+  const applyAccordionCollapseClasses = () => {
+    return !isCollapsed ? `${handles.accordionCollapseOpen}` : `${handles.accordionCollapseClose}`
+  }
+
   const quantitySelected = selectedFilters.length
 
   const titleSlug = generateSlug(getFilterTitle(title, intl))
@@ -67,13 +74,14 @@ const AccordionFilterItem = ({
           className={`${applyModifiers(
             handles.accordionFilterContainer,
             titleSlug
-          )} pl7`}
+          )} ${applyAccordionCollapseClasses()} pl7`}
         >
           <div
             role="button"
             tabIndex={0}
             className={classNames(
               handles.accordionFilterItem,
+              applyAccordionCollapseClasses(),
               applyModifiers(handles.filterAccordionItemBox, titleSlug),
               't-body pr5 pv3 pointer bb b--muted-5 outline-0',
               {
@@ -150,7 +158,7 @@ const AccordionFilterItem = ({
       {!isNavigationCollapsible ? (
         open && children
       ) : (
-        <Collapse isOpened={!isCollapsed && isNavigationCollapsible}>
+        <Collapse className={applyAccordionCollapseClasses()} isOpened={!isCollapsed && isNavigationCollapsible}>
           <div className="pl8">{children}</div>
         </Collapse>
       )}

--- a/react/components/AccordionFilterItem.js
+++ b/react/components/AccordionFilterItem.js
@@ -21,9 +21,12 @@ const CSS_HANDLES = [
   'accordionFilterItemTag',
   'accordionFilterItemIcon',
   'accordionSelectedFilters',
-  'accordionCollapseOpen',
-  'accordionCollapseClose',
-  'accordionCollapseContent'
+  'accordionCollapseContainerOpen',
+  'accordionCollapseContainerClose',
+  'accordionCollapseButtonOpen',
+  'accordionCollapseButtonClose',
+  'accordionCollapseContentOpen',
+  'accordionCollapseContentClose'
 ]
 
 const AccordionFilterItem = ({
@@ -59,8 +62,17 @@ const AccordionFilterItem = ({
     }
   }
 
-  const applyAccordionCollapseClasses = () => {
-    return !isCollapsed ? `${handles.accordionCollapseOpen}` : `${handles.accordionCollapseClose}`
+  const applyAccordionCollapseClasses = (param) => {
+    switch(param) {
+      case "Button":
+        return !isCollapsed ? `${handles.accordionCollapseButtonOpen}` : `${handles.accordionCollapseButtonClose}`
+      case "Content":
+        return !isCollapsed ? `${handles.accordionCollapseContentOpen}` : `${handles.accordionCollapseContentClose}`
+      case "Container":
+        return !isCollapsed ? `${handles.accordionCollapseContainerOpen}` : `${handles.accordionCollapseContainerClose}`
+      default:
+        return null
+    }
   }
 
   const quantitySelected = selectedFilters.length
@@ -74,14 +86,14 @@ const AccordionFilterItem = ({
           className={`${applyModifiers(
             handles.accordionFilterContainer,
             titleSlug
-          )} ${applyAccordionCollapseClasses()} pl7`}
+          )} ${applyAccordionCollapseClasses("Container")} pl7`}
         >
           <div
             role="button"
             tabIndex={0}
             className={classNames(
               handles.accordionFilterItem,
-              applyAccordionCollapseClasses(),
+              applyAccordionCollapseClasses("Button"),
               applyModifiers(handles.filterAccordionItemBox, titleSlug),
               't-body pr5 pv3 pointer bb b--muted-5 outline-0',
               {
@@ -158,7 +170,7 @@ const AccordionFilterItem = ({
       {!isNavigationCollapsible ? (
         open && children
       ) : (
-        <Collapse className={applyAccordionCollapseClasses()} isOpened={!isCollapsed && isNavigationCollapsible}>
+        <Collapse className={applyAccordionCollapseClasses("Content")} isOpened={!isCollapsed && isNavigationCollapsible}>
           <div className="pl8">{children}</div>
         </Collapse>
       )}

--- a/react/components/AccordionFilterItem.js
+++ b/react/components/AccordionFilterItem.js
@@ -26,7 +26,8 @@ const CSS_HANDLES = [
   'accordionCollapseButtonOpen',
   'accordionCollapseButtonClose',
   'accordionCollapseContentOpen',
-  'accordionCollapseContentClose'
+  'accordionCollapseContentClose',
+  'accordionCollapseContentChildren'
 ]
 
 const AccordionFilterItem = ({
@@ -62,17 +63,10 @@ const AccordionFilterItem = ({
     }
   }
 
-  const applyAccordionCollapseClasses = (param) => {
-    switch(param) {
-      case "Button":
-        return !isCollapsed ? `${handles.accordionCollapseButtonOpen}` : `${handles.accordionCollapseButtonClose}`
-      case "Content":
-        return !isCollapsed ? `${handles.accordionCollapseContentOpen}` : `${handles.accordionCollapseContentClose}`
-      case "Container":
-        return !isCollapsed ? `${handles.accordionCollapseContainerOpen}` : `${handles.accordionCollapseContainerClose}`
-      default:
-        return null
-    }
+  const accordionCollapseClasses = {
+    button: !isCollapsed ? `${handles.accordionCollapseButtonOpen}` : `${handles.accordionCollapseButtonClose}`,
+    content: !isCollapsed ? `${handles.accordionCollapseContentOpen}` : `${handles.accordionCollapseContentClose}`,
+    container: !isCollapsed ? `${handles.accordionCollapseContainerOpen}` : `${handles.accordionCollapseContainerClose}`
   }
 
   const quantitySelected = selectedFilters.length
@@ -86,14 +80,14 @@ const AccordionFilterItem = ({
           className={`${applyModifiers(
             handles.accordionFilterContainer,
             titleSlug
-          )} ${applyAccordionCollapseClasses("Container")} pl7`}
+          )} ${accordionCollapseClasses.container} pl7`}
         >
           <div
             role="button"
             tabIndex={0}
             className={classNames(
               handles.accordionFilterItem,
-              applyAccordionCollapseClasses("Button"),
+              accordionCollapseClasses.button,
               applyModifiers(handles.filterAccordionItemBox, titleSlug),
               't-body pr5 pv3 pointer bb b--muted-5 outline-0',
               {
@@ -170,8 +164,8 @@ const AccordionFilterItem = ({
       {!isNavigationCollapsible ? (
         open && children
       ) : (
-        <Collapse className={applyAccordionCollapseClasses("Content")} isOpened={!isCollapsed && isNavigationCollapsible}>
-          <div className="pl8">{children}</div>
+        <Collapse className={accordionCollapseClasses.content} isOpened={!isCollapsed && isNavigationCollapsible}>
+          <div className={` ${handles.accordionCollapseContentChildren} pl8`}>{children}</div>
         </Collapse>
       )}
     </Fragment>


### PR DESCRIPTION
#### What problem is this solving?

The filter-navigator component, in its responsive option, has no dynamic classes when the Collapse effect is open or closed, blocking many possibilities for customization via CSS

#### How to test it?

1. Login to WS: [Workspace](https://class16259--casadopapel1.myvtex.com/)
2. Enter a department or category page;
3. Open the App in a mobile dimension;
4. Click on the filter button;
5. Inspect the filter options, and see that when we open and close the collapsed contents, the classes change reflecting their respective status.

#### Screenshots or example usage:

![example-1-filter-navigator](https://user-images.githubusercontent.com/8903852/145875377-dbd5423e-8c17-40b6-9660-260f65e6bea4.png)

![example-2-filter-navigator](https://user-images.githubusercontent.com/8903852/145875381-e6d7c319-9aae-43d4-b68d-b95895b77f43.png)
