### PR TITLE
Fix/orderby behaviour on custom query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fix
+- Fixed the orderBy behaviour when using SearchResultLayoutCustomQuery block
+
 ## [3.110.6] - 2021-12-08
 ### Fixed
 - Safely URI decoding `query` to prevent errors when the search query contains breaking characters such as "%"

--- a/react/SearchResultLayoutCustomQuery.js
+++ b/react/SearchResultLayoutCustomQuery.js
@@ -67,7 +67,7 @@ const SearchResultLayoutCustomQuery = props => {
             queryField: props.querySchema.queryField,
             mapField: props.querySchema.mapField,
           })}
-      orderByField={props.querySchema.orderByField}
+      orderByField={query.order ?? props.querySchema.orderByField}
       hideUnavailableItems={props.querySchema.hideUnavailableItems}
       facetsBehavior={props.querySchema.facetsBehavior}
       skusFilter={props.querySchema.skusFilter}


### PR DESCRIPTION
#### What problem is this solving?

When we use the SearchResultLayoutCustomQuery block, changing the orderby select does not change the order of the products shown. This PR seeks to correct that, by adding a check if the order key exists in the querystring of the URL. 

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

You can use this [Workspace](https://affiliates--gabrielhosinoio.myvtex.com/affiliates/lojasa) with the new solution working. That link will take you to a new custom page the FPA BR team is working on. There, we use the SearchResultLayoutCustomQuery 

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

https://user-images.githubusercontent.com/8519076/145996367-b97260c3-95ba-4f92-8a4d-daf8b425efe9.mp4

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/8UF0EXzsc0Ckg/giphy.gif)
