### PR TITLE
Fixing Show More button appearing on the last page the second time an user performs the same search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Show More button now no longer appears on the last page when users leave a search page and access it again
 
 ## [3.110.6] - 2021-12-08
 ### Fixed

--- a/react/components/loaders/FetchMoreButton.js
+++ b/react/components/loaders/FetchMoreButton.js
@@ -12,12 +12,14 @@ const CSS_HANDLES = [
 
 const useShowButton = (to, products, loading, recordsFiltered) => {
   const [showButton, setShowButton] = useState(
-    !!products && to + 1 < recordsFiltered
+    !!products && Math.max(to + 1, products.length) < recordsFiltered
   )
 
   useEffect(() => {
     if (!loading) {
-      setShowButton(!!products && to + 1 < recordsFiltered)
+      setShowButton(
+        !!products && Math.max(to + 1, products.length) < recordsFiltered
+      )
     }
   }, [to, products, loading, recordsFiltered])
 
@@ -39,11 +41,15 @@ function shouldNotIncludeMap(map) {
 }
 
 export function getMapQueryString(searchQuery) {
-  if (shouldNotIncludeMap(searchQuery?.variables?.map)) {
+  if (
+    !searchQuery ||
+    !searchQuery.variables ||
+    shouldNotIncludeMap(searchQuery.variables.map)
+  ) {
     return ''
   }
 
-  return `&map=${searchQuery?.variables?.map}`
+  return `&map=${searchQuery.variables.map}`
 }
 
 const FetchMoreButton = (props) => {


### PR DESCRIPTION
#### What problem is this solving?

This PR solves an issue where users who navigated to a search page, browsed it to the last page, then navigated to another page, and then back to the same first search page would be presented with the show more button after all of the items. This shouldn't happen since all the results are already being shown.

#### How to test it?

Follow the steps on the video in the section below.
[Workspace](https://icarovtex--tackoftheday.myvtex.com/)

#### Screenshots or example usage:

[https://watch.screencastify.com/v/tiBgjEJ4DzQntsCGWhcK](https://watch.screencastify.com/v/tiBgjEJ4DzQntsCGWhcK)

#### Related to / Depends on

Related to https://github.com/vtex-apps/search-result/pull/553

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/3o752gZdDHjObx309W/giphy.gif)
