### PR TITLE
Feature/add quantity badge on mobile filters button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `showQuantityBadgeOnMobile` prop to the `FilterNavigator`.
 
 ## [3.115.0] - 2022-03-11
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -454,6 +454,7 @@ This block renders a filter selector for the fetched results.
 | `showClearAllFiltersOnDesktop`       | `boolean` |  Whether a clear button should be displayed (`true`) or not (`false`). This button will reset all selected filters.   | `false`       |
 | `priceRangeLayout` | `enum` | Whether a text field enters the desired price range should be displayed  (`inputAndSlider`) or not (`slider`). | `slider` |
 | `facetOrdering` | `array` | Array of objects (see below) that applies custom sorting rules for filters. The default behavior sorts descending the items by quantity. | `undefined` |
+| `showQuantityBadgeOnMobile` | `boolean` | Displays a badge for mobile users indicating how many active filters there are. | `false` |
 
 - **`facetOrdering` object:** 
   

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -178,7 +178,7 @@ const FilterNavigator = ({
   )
 
   const { searchQuery } = useSearchPage()
-  const hasFiltersApplied = searchQuery.variables?.selectedFacets?.length > 1
+  const hasFiltersApplied = searchQuery?.variables?.selectedFacets?.length > 1
 
   const handleResetFilters = () => {
     navigateToFacet(selectedFilters, preventRouteChange)

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -99,6 +99,7 @@ const FilterNavigator = ({
   showClearByFilter = false,
   showClearAllFiltersOnDesktop = false,
   priceRangeLayout = 'slider',
+  showQuantityBadgeOnMobile = false
 }) => {
   const { isMobile } = useDevice()
   const handles = useCssHandles(CSS_HANDLES)
@@ -242,6 +243,7 @@ const FilterNavigator = ({
               showClearByFilter={showClearByFilter}
               priceRangeLayout={priceRangeLayout}
               filtersDrawerDirectionMobile={filtersDrawerDirectionMobile}
+              showQuantityBadgeOnMobile={showQuantityBadgeOnMobile}
             />
           </div>
         </div>

--- a/react/FilterNavigatorFlexible.js
+++ b/react/FilterNavigatorFlexible.js
@@ -28,6 +28,7 @@ const withSearchPageContextProps = (Component) => ({
   showClearAllFiltersOnDesktop,
   priceRangeLayout,
   facetOrdering = [],
+  showQuantityBadgeOnMobile = false,
 }) => {
   const {
     searchQuery,
@@ -107,7 +108,11 @@ const withSearchPageContextProps = (Component) => ({
           showClearByFilter={showClearByFilter}
           showClearAllFiltersOnDesktop={showClearAllFiltersOnDesktop}
           priceRangeLayout={priceRangeLayout}
+<<<<<<< HEAD
           drawerDirectionMobile={drawerDirectionMobile}
+=======
+          showQuantityBadgeOnMobile={showQuantityBadgeOnMobile}
+>>>>>>> ab000fa (Adds showQuantityBadgeOnMobile prop to FilterNavigatorFlexible component)
         />
       </FilterNavigatorContext.Provider>
     </div>

--- a/react/FilterNavigatorFlexible.js
+++ b/react/FilterNavigatorFlexible.js
@@ -108,11 +108,8 @@ const withSearchPageContextProps = (Component) => ({
           showClearByFilter={showClearByFilter}
           showClearAllFiltersOnDesktop={showClearAllFiltersOnDesktop}
           priceRangeLayout={priceRangeLayout}
-<<<<<<< HEAD
           drawerDirectionMobile={drawerDirectionMobile}
-=======
           showQuantityBadgeOnMobile={showQuantityBadgeOnMobile}
->>>>>>> ab000fa (Adds showQuantityBadgeOnMobile prop to FilterNavigatorFlexible component)
         />
       </FilterNavigatorContext.Provider>
     </div>

--- a/react/components/AccordionFilterGroup.js
+++ b/react/components/AccordionFilterGroup.js
@@ -6,7 +6,6 @@ import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 import AccordionFilterItem from './AccordionFilterItem'
 import FacetCheckboxList from './FacetCheckboxList'
 import useSelectedFilters from '../hooks/useSelectedFilters'
-
 import { getFilterTitle } from '../constants/SearchHelpers'
 import { searchSlugify } from '../utils/slug'
 
@@ -32,7 +31,7 @@ const AccordionFilterGroup = ({
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
   const filters = useSelectedFilters(facets)
-  const selectedFilters = filters.filter(facet => facet.selected)
+  const selectedFilters = filters.filter((facet) => facet.selected)
   const intl = useIntl()
   const facetTitle = getFilterTitle(title, intl)
   const slugifiedFacetTitle = searchSlugify(facetTitle)

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -74,13 +74,19 @@ const FilterSidebar = ({
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
   const currentTree = useCategoryTree(tree, categoryTreeOperations)
 
-  const selectedFacets = React.useMemo(() => { 
+  /* Sometimes there are categories included in selectedFilters
+   * This useMemo extracts only filters that users can
+   * enable and disable directly */
+  const selectedFacetsLength = React.useMemo(() => { 
     const filterKeys = filters.map(filter => filter.key);
 
-    return selectedFilters.filter((facet) => (
+    const selectedFacets = selectedFilters.filter((facet) => (
       filterKeys.includes(facet.key) 
       && facet.selected
-    )) }, [filters, selectedFilters]);
+    ));
+
+    return (selectedFacets || []).length;
+  }, [filters, selectedFilters]);
 
   const isFilterSelected = (slectableFilters, filter) => {
     return slectableFilters.find(
@@ -236,11 +242,11 @@ const FilterSidebar = ({
         <span className={`${handles.filterPopupArrowIcon} ml-auto pl3 pt2`}>
           <IconFilter size={16} viewBox="0 0 17 17" />
 
-          {showQuantityBadgeOnMobile && selectedFacets.length > 0 && (
+          {showQuantityBadgeOnMobile && selectedFacetsLength > 0 && (
             <span
               className={`${styles.filterQuantityBadgeDefault} ${handles.filterQuantityBadge} absolute t-mini bg-muted-2 c-on-muted-2 br4 w1 h1 pa1 flex justify-center items-center lh-solid`}
             >
-              {selectedFacets.length}
+              {selectedFacetsLength}
             </span>
           )}
         </span>

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -83,9 +83,9 @@ const FilterSidebar = ({
     const selectedFacets = selectedFilters.filter((facet) => (
       filterKeys.includes(facet.key) 
       && facet.selected
-    ));
+    )) ?? [];
 
-    return (selectedFacets || []).length;
+    return selectedFacets.length;
   }, [filters, selectedFilters]);
 
   const isFilterSelected = (slectableFilters, filter) => {

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -220,7 +220,7 @@ const FilterSidebar = ({
     <Fragment>
       <button
         className={classNames(
-          `${styles.filterPopupButton} relative ph3 pv5 mv0 mv0 pointer flex justify-center items-center`,
+          `${styles.filterPopupButton} ${showQuantityBadgeOnMobile ? 'relative' :  ''}  ph3 pv5 mv0 mv0 pointer flex justify-center items-center`,
           {
             'bb b--muted-1': open,
             bn: !open,
@@ -238,7 +238,6 @@ const FilterSidebar = ({
 
           {showQuantityBadgeOnMobile && selectedFacets.length > 0 && (
             <span
-              style={{ userSelect: 'none' }}
               className={`${styles.filterQuantityBadgeDefault} ${handles.filterQuantityBadge} absolute t-mini bg-muted-2 c-on-muted-2 br4 w1 h1 pa1 flex justify-center items-center lh-solid`}
             >
               {selectedFacets.length}

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -74,8 +74,6 @@ const FilterSidebar = ({
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
   const currentTree = useCategoryTree(tree, categoryTreeOperations)
 
-  console.log({ filters, selectedFilters });
-
   const selectedFacets = React.useMemo(() => { 
     const filterKeys = filters.map(filter => filter.key);
 

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -32,6 +32,7 @@ const CSS_HANDLES = [
   'filterClearButtonWrapper',
   'filterApplyButtonWrapper',
   'filterTotalProducts',
+  'filterQuantityBadge',
 ]
 
 const FilterSidebar = ({
@@ -55,6 +56,7 @@ const FilterSidebar = ({
   showClearByFilter,
   priceRangeLayout,
   filtersDrawerDirectionMobile,
+  showQuantityBadgeOnMobile,
 }) => {
   const { searchQuery } = useSearchPage()
   const filterContext = useFilterNavigator()
@@ -71,6 +73,16 @@ const FilterSidebar = ({
   const [categoryTreeOperations, setCategoryTreeOperations] = useState([])
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
   const currentTree = useCategoryTree(tree, categoryTreeOperations)
+
+  console.log({ filters, selectedFilters });
+
+  const selectedFacets = React.useMemo(() => { 
+    const filterKeys = filters.map(filter => filter.key);
+
+    return selectedFilters.filter((facet) => (
+      filterKeys.includes(facet.key) 
+      && facet.selected
+    )) }, [filters, selectedFilters]);
 
   const isFilterSelected = (slectableFilters, filter) => {
     return slectableFilters.find(
@@ -210,7 +222,7 @@ const FilterSidebar = ({
     <Fragment>
       <button
         className={classNames(
-          `${styles.filterPopupButton} ph3 pv5 mv0 mv0 pointer flex justify-center items-center`,
+          `${styles.filterPopupButton} relative ph3 pv5 mv0 mv0 pointer flex justify-center items-center`,
           {
             'bb b--muted-1': open,
             bn: !open,
@@ -225,6 +237,15 @@ const FilterSidebar = ({
         </span>
         <span className={`${handles.filterPopupArrowIcon} ml-auto pl3 pt2`}>
           <IconFilter size={16} viewBox="0 0 17 17" />
+
+          {showQuantityBadgeOnMobile && selectedFacets.length > 0 && (
+            <span
+              style={{ userSelect: 'none' }}
+              className={`${styles.filterQuantityBadgeDefault} ${handles.filterQuantityBadge} absolute t-mini bg-muted-2 c-on-muted-2 br4 w1 h1 pa1 flex justify-center items-center lh-solid`}
+            >
+              {selectedFacets.length}
+            </span>
+          )}
         </span>
       </button>
 

--- a/react/components/PriceRange/index.js
+++ b/react/components/PriceRange/index.js
@@ -63,8 +63,8 @@ const PriceRange = ({
         fuzzy: fuzzy || undefined,
         operator: operator || undefined,
         searchState: state,
-        initialMap: runtimeQuery.initialMap ?? map,
-        initialQuery: runtimeQuery.initialQuery ?? query,
+        initialMap: runtimeQuery?.initialMap ?? map,
+        initialQuery: runtimeQuery?.initialQuery ?? query,
       })
 
       setRange([left, right])

--- a/react/searchResult.css
+++ b/react/searchResult.css
@@ -236,7 +236,6 @@
 .filterQuantityBadgeDefault {
   top: -0.7rem;
   right: -0.8rem;
-  user-select: none;
 }
 
 .filters--layout {

--- a/react/searchResult.css
+++ b/react/searchResult.css
@@ -236,6 +236,7 @@
 .filterQuantityBadgeDefault {
   top: -0.7rem;
   right: -0.8rem;
+  user-select: none;
 }
 
 .filters--layout {

--- a/react/searchResult.css
+++ b/react/searchResult.css
@@ -233,6 +233,11 @@
   overflow: hidden;
 }
 
+.filterQuantityBadgeDefault {
+  top: -0.7rem;
+  right: -0.8rem;
+}
+
 .filters--layout {
 }
 


### PR DESCRIPTION
#### What problem is this solving?

At the search page, where products are shown, the user can apply different filters in order to get better results. On desktop, selected filters are displayed on the left side of the screen, and users always know how many filters they've applied.

On mobile, the filters menu is inside a drawer, that is toggled by clicking a button. However, there is no indication if there's any active filter, forcing users to open the drawer in order to know how many filters they have applied.

We added a prop `showQuantityBadgeOnMobile` that enables a badge on top of the filters button, similar to what we have on MinicartIconButton, indicating how many filters the user has applied. It is set to `false` as default, so it doesn't change the behaviour of other stores.

#### How to test it?

Go to the search page on mobile, and select any filter. The number of current filters will be displayed on top of the button that opens the drawer.

[Workspace](https://adicionabadgenosfiltrosselecionados--oficinareserva.myvtex.com/branco/p/pima?_q=pima&fuzzy=0&initialMap=ft&initialQuery=pima&map=cor,tamanho,ft&operator=and)

#### Screenshots or example usage:

![Screenshot from 2022-01-10 14-16-19](https://user-images.githubusercontent.com/15324745/148809180-f9e4cb50-b948-4df1-9980-4ff52afdfb4d.png)
![Screenshot from 2022-01-10 14-16-33](https://user-images.githubusercontent.com/15324745/148809182-42974333-ebac-4bfd-a380-61c09b4098d2.png)


#### Describe alternatives you've considered, if any.

We read the docs and code of FilterNavigation.v3 to see if there was any way of enabling the desired behaviour, but there is none.