### PR TITLE
added state to clear and reset price range filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Clear the price range when clicking "Clear" button on mobile.
+
 ## [3.113.1] - 2022-01-26
 
 ### Fixed

--- a/react/components/AccordionFilterContainer.js
+++ b/react/components/AccordionFilterContainer.js
@@ -42,6 +42,8 @@ const AccordionFilterContainer = ({
   showClearByFilter,
   updateOnFilterSelectionOnMobile,
   priceRangeLayout,
+  clearPriceRange,
+  setClearPriceRange
 }) => {
   const intl = useIntl()
   const { getSettings } = useRuntime()
@@ -176,6 +178,8 @@ const AccordionFilterContainer = ({
                 navigationType={navigationType}
                 initiallyCollapsed={initiallyCollapsed}
                 priceRangeLayout={priceRangeLayout}
+                clearPriceRange={clearPriceRange}
+                setClearPriceRange={setClearPriceRange}
               />
             )
 

--- a/react/components/AccordionFilterPriceRange.js
+++ b/react/components/AccordionFilterPriceRange.js
@@ -14,6 +14,8 @@ const AccordionFilterPriceRange = ({
   navigationType,
   initiallyCollapsed,
   priceRangeLayout,
+  clearPriceRange,
+  setClearPriceRange
 }) => {
   return (
     <AccordionFilterItem
@@ -30,6 +32,8 @@ const AccordionFilterPriceRange = ({
           facets={facets}
           priceRange={priceRange}
           priceRangeLayout={priceRangeLayout}
+          clearPriceRange={clearPriceRange}
+          setClearPriceRange={setClearPriceRange}
         />
       </div>
     </AccordionFilterItem>

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -114,7 +114,7 @@ const FilterSidebar = ({
 
   const { push } = usePixel()
   
-  const [clearPriceRange, setClearPriceRange] = useState();
+  const [clearPriceRange, setClearPriceRange] = useState()
 
   const handleClearFilters = (key) => {
     pushFilterManipulationPixelEvent({

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -113,6 +113,8 @@ const FilterSidebar = ({
   }
 
   const { push } = usePixel()
+  
+  const [clearPriceRange, setClearPriceRange] = useState();
 
   const handleClearFilters = (key) => {
     pushFilterManipulationPixelEvent({
@@ -145,6 +147,7 @@ const FilterSidebar = ({
       return
     }
 
+    setClearPriceRange(true)
     setFilterOperations(facetsToRemove)
   }
 
@@ -240,6 +243,8 @@ const FilterSidebar = ({
             categoryFiltersMode={categoryFiltersMode}
             loading={loading}
             onClearFilter={handleClearFilters}
+            clearPriceRange={clearPriceRange}
+            setClearPriceRange={setClearPriceRange}
             showClearByFilter={showClearByFilter}
             updateOnFilterSelectionOnMobile={updateOnFilterSelectionOnMobile}
             priceRangeLayout={priceRangeLayout}

--- a/react/components/PriceRange/index.js
+++ b/react/components/PriceRange/index.js
@@ -17,7 +17,15 @@ import PriceRangeInput from './PriceRangeInput'
 const DEBOUNCE_TIME = 500 // ms
 
 /** Price range slider component */
-const PriceRange = ({ title, facets, priceRange, priceRangeLayout, scrollToTop, clearPriceRange,setClearPriceRange }) => {
+const PriceRange = ({
+  title,
+  facets,
+  priceRange,
+  priceRangeLayout,
+  scrollToTop,
+  clearPriceRange,
+  setClearPriceRange
+}) => {
   const [range, setRange] = useState()
   const { culture, setQuery } = useRuntime()
   const intl = useIntl()
@@ -100,13 +108,10 @@ const PriceRange = ({ title, facets, priceRange, priceRangeLayout, scrollToTop, 
   }
 
   const resetOnClear = () => {
-
     setQuery({
       priceRange: `${minValue} TO ${maxValue}`
     })
-
     setRange([minValue, maxValue])
-
     setClearPriceRange(false)
   } 
 
@@ -151,6 +156,10 @@ PriceRange.propTypes = {
   priceRange: PropTypes.string,
   /** Price range layout (default or inputAndSlider) */
   priceRangeLayout: PropTypes.string,
+  /** Defines whether the price range should be cleared or not */
+  clearPriceRange: PropTypes.bool,
+  /** Set the value of clearPriceRange prop */
+  setClearPriceRange: PropTypes.func,
 }
 
 export default PriceRange

--- a/react/components/PriceRange/index.js
+++ b/react/components/PriceRange/index.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react'
+import React, { useRef, useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { useRuntime } from 'vtex.render-runtime'
 import { useIntl } from 'react-intl'
@@ -17,7 +17,7 @@ import PriceRangeInput from './PriceRangeInput'
 const DEBOUNCE_TIME = 500 // ms
 
 /** Price range slider component */
-const PriceRange = ({ title, facets, priceRange, priceRangeLayout, scrollToTop }) => {
+const PriceRange = ({ title, facets, priceRange, priceRangeLayout, scrollToTop, clearPriceRange,setClearPriceRange }) => {
   const [range, setRange] = useState()
   const { culture, setQuery } = useRuntime()
   const intl = useIntl()
@@ -29,6 +29,7 @@ const PriceRange = ({ title, facets, priceRange, priceRangeLayout, scrollToTop }
   const { fuzzy, operator, searchState } = useSearchState()
 
   const handleChange = ([left, right]) => {
+
     if (navigateTimeoutId.current) {
       clearTimeout(navigateTimeoutId.current)
     }
@@ -97,6 +98,21 @@ const PriceRange = ({ title, facets, priceRange, priceRangeLayout, scrollToTop }
     defaultValues[0] = parseInt(currentMin, 10)
     defaultValues[1] = parseInt(currentMax, 10)
   }
+
+  const resetOnClear = () => {
+
+    setQuery({
+      priceRange: `${minValue} TO ${maxValue}`
+    })
+
+    setRange([minValue, maxValue])
+
+    setClearPriceRange(false)
+  } 
+
+  useEffect(() => {
+    clearPriceRange && resetOnClear()
+  }, [clearPriceRange])
 
   return (
     <FilterOptionTemplate


### PR DESCRIPTION
#### What problem is this solving?

Price Range is not being cleared when clicking in "clear" button on filter sidebar on mobile. We are clearing the price range filter  and correcting the front end component to show the correct values as well.

#### How to test it?

The homepage form the workspace shared has a search result component. 

[Workspace](https://devvitor--amalsandbox.myvtex.com/)

But also it is possible to just link this PR to any other workspace :)

#### Screenshots or example usage:

![Screenshot from 2022-01-17 17-42-25](https://user-images.githubusercontent.com/11010539/149835036-ebabcc50-773e-4cfc-ae30-ff778bd99d79.png)
![Screenshot from 2022-01-17 17-42-30](https://user-images.githubusercontent.com/11010539/149835040-12b6f959-df1a-4548-a7c0-1d9dde92c6a0.png)

#### Describe alternatives you've considered, if any.

None

#### Related to / Depends on

None

#### How does this PR make you feel? [:link:](http://giphy.com/)

Nice

![](put .gif link here - can be found under "advanced" on giphy)
