### PR TITLE
Fix pagination and FetchPreviousButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Reset page when `priceRange` changes.
+
 ## [3.113.0] - 2022-01-25
 
 ### Changed

--- a/react/FetchMore.js
+++ b/react/FetchMore.js
@@ -24,7 +24,7 @@ const FetchMore = ({ htmlElementForButton = 'button' }) => {
     query: path(['variables', 'query'], searchQuery),
     map: path(['variables', 'map'], searchQuery),
     orderBy: path(['variables', 'orderBy'], searchQuery),
-    priceRange: path(['variables', 'priceRange'], searchQuery),
+    priceRange: path(['variables', 'selectedFacets'], searchQuery)?.find(facet => facet.key === 'priceRange')?.value,
   }
 
   const { handleFetchMoreNext, loading, to, nextPage } = useFetchMore({

--- a/react/FetchPrevious.js
+++ b/react/FetchPrevious.js
@@ -22,7 +22,7 @@ const FetchPrevious = ({ htmlElementForButton = 'button' }) => {
     query: path(['variables', 'query'], searchQuery),
     map: path(['variables', 'map'], searchQuery),
     orderBy: path(['variables', 'orderBy'], searchQuery),
-    priceRange: path(['variables', 'priceRange'], searchQuery),
+    priceRange: path(['variables', 'selectedFacets'], searchQuery)?.find(facet => facet.key === 'priceRange')?.value,
   }
 
   const { handleFetchMorePrevious, loading, from, previousPage } = useFetchMore(

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -104,15 +104,17 @@ const useCombinedRefetch = (productRefetch, facetsRefetch) => {
 
 const isCurrentDifferent = (ref, currentVal) => ref.current !== currentVal
 
-const useShouldResetPage = (query, map, orderBy) => {
+const useShouldResetPage = (query, map, orderBy, priceRange) => {
   const queryRef = useRef(query)
   const mapRef = useRef(map)
   const orderByRef = useRef(orderBy)
+  const priceRangeRef = useRef(priceRange)
 
   return (
     isCurrentDifferent(queryRef, query) ||
     isCurrentDifferent(mapRef, map) ||
-    isCurrentDifferent(orderByRef, orderBy)
+    isCurrentDifferent(orderByRef, orderBy) ||
+    isCurrentDifferent(priceRangeRef, priceRange)
   )
 }
 
@@ -285,7 +287,7 @@ const SearchQuery = ({
   We want this behaviour so we can show the correct items even if the pageQuery
   changes. It should change only on a new render or if the query or orderby 
   change, hence the useCorrectPage that updates its value */
-  const shouldReset = useShouldResetPage(query, map, orderBy)
+  const shouldReset = useShouldResetPage(query, map, orderBy, priceRange)
   const page = useCorrectPage(
     pageQuery ? parseInt(pageQuery, 10) : DEFAULT_PAGE,
     shouldReset


### PR DESCRIPTION
#### What problem is this solving?

When browsing a search page without being on page 1 and changing the price range, the page wasn't being updated and returned an empty search even though there were products for that price range

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

- [Before](https://www.dzarm.com.br/outlet?order=OrderByPriceASC&page=3)
- [After](https://thalyta--dzarm.myvtex.com/outlet?order=OrderByPriceASC&page=3)
- change the price range to a small range which will return few results (for example, 19,00 to 29,00)

#### Screenshots or example usage:

https://user-images.githubusercontent.com/20840671/150182421-3ca5ca80-3ccc-4179-91cd-8356916e8fbc.mp4


https://user-images.githubusercontent.com/20840671/150182431-f61dd20c-23d5-404d-8510-e0e5c9669897.mp4


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
