### PR TITLE
Send initialAttributes on first iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Send `initialAttributes` on first iteration.
+
 ## [3.112.0] - 2022-01-12
 
 ### Added

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -188,7 +188,7 @@ const useQueries = (variables, facetsArgs) => {
       operator: variables.operator,
       fuzzy: variables.fuzzy,
       searchState: variables.searchState || undefined,
-      initialAttributes: runtimeQuery?.initialMap,
+      initialAttributes: runtimeQuery?.initialMap || facetsArgs.facetMap,
     },
     skip: !facetsArgs.withFacets,
   })

--- a/react/hooks/useFacetNavigation.js
+++ b/react/hooks/useFacetNavigation.js
@@ -238,6 +238,8 @@ const useFacetNavigation = (selectedFacets, scrollToTop = 'none') => {
           fuzzy: fullTextQuery ? fuzzy || undefined : undefined,
           operator: fullTextQuery ? operator || undefined : undefined,
           searchState: state,
+          initialMap: runtimeQuery.initialMap ?? map,
+          initialQuery: runtimeQuery.initialQuery ?? query,
         }
 
         setQuery(queries)


### PR DESCRIPTION
#### What problem is this solving?

Send `initialAttributes` on first iteration and also when `preventRouteChange` is `true` (in this case the `initialAttributes` was never being sent)
<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace - with `preventRouteChange` as true](https://thalyta--carrefourbr.myvtex.com/)

- when entering a navigation page, for example category page, the category filter should not appear. [workspace](https://thalyta--carrefourbr.myvtex.com/eletrodomesticos/geladeira#crfint=hm-tlink%7Cgeladeira%7C1%7Cgeladeira-brastemp%7C2)
- when entering a navigation page, for example department page, and filtering by something (eg category), the department filter should not appear, but the category filter should. [workspace](https://thalyta--carrefourbr.myvtex.com/eletrodomesticos)
- when entering a full text search and filtering by something (eg department), the department filter should appear. [workspace](https://thalyta--carrefourbr.myvtex.com/busca/ar%20condicionado)

[Workspace - with `preventRouteChange` as false](https://thalyta--arteni.myvtex.com/)
* just to make sure the changes won't affect stores that don't have `preventRouteChange` as true. 
the specifications of when the filters should appear or not aren't applicable to this store because it doesn't have the necessary configuration to hide the initial filters
