### PR TITLE
Set initialMap when changing price range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Price range that was disappearing when clearing filters on mobile.
+
 ## [3.113.2] - 2022-02-01
 
 ### Fixed

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -143,6 +143,7 @@ const FilterSidebar = ({
 
     if (updateOnFilterSelectionOnMobile && preventRouteChange) {
       navigateToFacet(facetsToRemove, preventRouteChange)
+      setClearPriceRange(true)
 
       return
     }

--- a/react/components/PriceRange/index.js
+++ b/react/components/PriceRange/index.js
@@ -13,6 +13,7 @@ import { getFilterTitle } from '../../constants/SearchHelpers'
 import FilterOptionTemplate from '../FilterOptionTemplate'
 import useSearchState from '../../hooks/useSearchState'
 import PriceRangeInput from './PriceRangeInput'
+import { useFilterNavigator } from '../FilterNavigatorContext'
 
 const DEBOUNCE_TIME = 500 // ms
 
@@ -27,9 +28,10 @@ const PriceRange = ({
   setClearPriceRange
 }) => {
   const [range, setRange] = useState()
-  const { culture, setQuery } = useRuntime()
+  const { culture, setQuery, query: runtimeQuery } = useRuntime()
   const intl = useIntl()
   const navigateTimeoutId = useRef()
+  const { map, query } = useFilterNavigator()
 
   const { push } = usePixel()
   const { searchQuery } = useSearchPage()
@@ -61,6 +63,8 @@ const PriceRange = ({
         fuzzy: fuzzy || undefined,
         operator: operator || undefined,
         searchState: state,
+        initialMap: runtimeQuery.initialMap ?? map,
+        initialQuery: runtimeQuery.initialQuery ?? query,
       })
 
       setRange([left, right])


### PR DESCRIPTION
#### What problem is this solving?

the price range filter was disappearing when clicking on clear filters because it was being considered an initial filter

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://thalyta--alssports.myvtex.com/climbing/hardware/?map=c,c)
- change the price range
- click the button to clear all filters
- the price range filter should still appear in the filter list

#### Screenshots or example usage:


https://user-images.githubusercontent.com/20840671/152058277-eb617b85-16e4-4894-a29b-1b709f31d43b.mp4

https://user-images.githubusercontent.com/20840671/152058285-4b8ea33d-69f2-4d7a-961c-4ee9acc3956c.mp4



<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
