### PR TITLE
Filter manipulation on clear filters

### DIFF
--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -186,7 +186,7 @@ const FilterNavigator = ({
   const handleResetFilters = () => {
     pushFilterManipulationPixelEvent({
       name: "reset",
-      value: intl.formatMessage("store/search-result.filter-button.clearAll"),
+      value: intl.formatMessage({id: "store/search-result.filter-button.clearAll"}),
       products: searchQuery?.products ?? [],
       push,
     })

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -8,7 +8,7 @@ import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
 // eslint-disable-next-line no-restricted-imports
 import { flatten } from 'ramda'
-import { FormattedMessage } from 'react-intl'
+import { FormattedMessage, useIntl } from 'react-intl'
 import { Button } from 'vtex.styleguide'
 
 import FilterSidebar from './components/FilterSidebar'
@@ -26,6 +26,8 @@ import styles from './searchResult.css'
 import { CATEGORIES_TITLE } from './utils/getFilters'
 import { newFacetPathName } from './utils/slug'
 import { FACETS_RENDER_THRESHOLD } from './constants/filterConstants'
+import { pushFilterManipulationPixelEvent } from './utils/filterManipulationPixelEvents'
+import { usePixel } from 'vtex.pixel-manager'
 
 const CSS_HANDLES = [
   'filter__container',
@@ -100,6 +102,8 @@ const FilterNavigator = ({
   showClearAllFiltersOnDesktop = false,
   priceRangeLayout = 'slider',
 }) => {
+  const { push } = usePixel()
+  const intl = useIntl()
   const { isMobile } = useDevice()
   const handles = useCssHandles(CSS_HANDLES)
   const [truncatedFacetsFetched, setTruncatedFacetsFetched] = useState(false)
@@ -180,6 +184,12 @@ const FilterNavigator = ({
   const hasFiltersApplied = searchQuery.variables?.selectedFacets?.length > 1
 
   const handleResetFilters = () => {
+    pushFilterManipulationPixelEvent({
+      name: "reset",
+      value: intl.formatMessage("store/search-result.filter-button.clearAll"),
+      products: searchQuery?.products ?? [],
+      push,
+    })
     navigateToFacet(selectedFilters, preventRouteChange)
   }
 


### PR DESCRIPTION
#### What problem is this solving?

It's added the filterManipulation pixel event push for the **reset filters** button

#### How to test it?

Go in a plp (link to the plp is present yet in the workspace url), click on the "Tout Enlever" button (OOTB reset filters button). Then open the browser console and write dataLayer

![data-layer-console](https://user-images.githubusercontent.com/81118704/160438231-5c64ea23-093f-47fa-aa01-5bbd173a95c8.png)

Then press enter and inside the datalayer search for **"filterManipulation"**

![filter-manipulation](https://user-images.githubusercontent.com/81118704/160439121-ce414340-e4e4-4aff-bf50-6082bed4da26.png)

You'll notice that the event has been succesfully pushed and intercepted by GTM

[Workspace](https://filtermanipulationreset--frccwhirlpool.myvtex.com/produits/lavage?__bindingAddress=frccwhirlpool.myvtex.com/&initialMap=c,c&initialQuery=produits/lavage&map=&query=/&searchState)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
