### PR TITLE
doc: Update README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -510,15 +510,15 @@ The `order-by` block renders a dropdown button with [sorting options](#the-sorti
 | Name Descending          | `"OrderByNameDESC"`         |
 | Collection               | `"OrderByCollection"`         |
 
-
-#### The `search-fetch-more` block
-
 - **`specificationOptions` Object:**
 
 | Prop name  | Type      | Description                             | Default value |
 | ---------- | --------- | --------------------------------------- | ------------- |
 | value      | string | Value that will be sent for ordering in the API. It must be in the format `{specification key}:{asc|desc}`. For example: `"size:desc"` or `"priceByUnit:asc"`. | `undefined` |
 | label      | string | Label that will be displayed in the sorting options. E.g.: `"Price by unit, ascending"` | `undefined` |
+
+
+#### The `search-fetch-more` block
 
 The `search-fetch-more` block renders a **Show More** button used to load the results of the next search results page. Check the block props in the table below.
 


### PR DESCRIPTION
#### What problem is this solving?

Ajustando posição do título "The `search-fetch-more` block" para que fique claro que 'specificationOptions` Object' percente ao 'order-by' e não ao 'fetchMore'.

#### How to test it?

Validar README.md.


#### Screenshots or example usage:

