### PR TITLE
Fix/varing impressions list name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `searchTitle`s would always be `undefined` inside of gallery components when rendering the results of a full-text search.
 
 ## [3.117.0] - 2022-04-07
 ### Added

--- a/react/GalleryLayout.tsx
+++ b/react/GalleryLayout.tsx
@@ -68,7 +68,7 @@ const GalleryLayout: React.FC<GalleryLayoutProps> = ({
   const searchPageStateDispatch = useSearchPageStateDispatch()
 
   const breadcrumb = useBreadcrumb()
-  const searchTitle = useSearchTitle(breadcrumb ?? []).trim()
+  const searchTitle = useSearchTitle(breadcrumb ?? [], { matchFt: true }).trim()
 
   // Not using ?? operator because trackingId and searchTitle can be ''
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing

--- a/react/GalleryLegacy.tsx
+++ b/react/GalleryLegacy.tsx
@@ -72,7 +72,7 @@ const Gallery: React.FC<GalleryProps> = ({
   const { getSettings } = useRuntime()
   const responsiveMaxItemsPerRow = useResponsiveValue(maxItemsPerRow)
   const breadcrumb = useBreadcrumb()
-  const searchTitle = useSearchTitle(breadcrumb ?? []).trim()
+  const searchTitle = useSearchTitle(breadcrumb ?? [], { matchFt: true }).trim()
 
   // Not using ?? operator because trackingId and searchTitle can be ''
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing


### PR DESCRIPTION
#### What problem is this solving?

Both `GalleryLayout` and `GalleryLegacy` components are responsible for the rendering of instances of `ProductListProvider` components and for passing the values for the `listName` prop. This prop is used then to distinguish different lists of products that will get their `impression` events sent.

Currently, there's an issue where, if the user is already on a search page and then searches for a different term, that only matches a `full-text` search, the list of product impressions doesn't get reset, since the `ProductListContext` still thinks it's wrapping the same list. This happens because, for every full-text search, both gallery components were passing the default value of `Search Result` to the prop `listName` when rendering a `ProductListProvider`. And this behavior was caused by a call to  `useSearchTitle` always returning `undefined` for full-text searches.

#### How to test it?

Unfortunately, this is very tricky to test on a workspace, so there's a beta version of this branch already installed on the `master` workspace of the `storecomponents` account. So to test this, you can go straight to [storecomponents](http://storecomponents.myvtex.com/).

You'll need a Chrome extension to fully test this. The one I used is called _"datalayer checker"_. After you have an extension that allows you so see the events being fired to the datalayer, follow these steps:

1. From the homepage, search for `shoes`.
2. Check the datalayer and you should see the following

![Captura de Tela 2022-04-28 às 10 45 50](https://user-images.githubusercontent.com/27777263/165766586-081d3718-f045-4f23-b161-118315427aff.png)

3. Now search for a different term, such as `clock`.
4. Check the datalayer and you should see the following

![Captura de Tela 2022-04-28 às 10 47 44](https://user-images.githubusercontent.com/27777263/165766972-241ddb42-00ab-462b-9ad5-fcbae414d13c.png)

5. Lastly, search for `bell`, and check the datalayer again, you should see something like:

![Captura de Tela 2022-04-28 às 10 48 40](https://user-images.githubusercontent.com/27777263/165767145-a8fd71f1-020a-4617-8f45-16d2297983b9.png)

The most important thing to notice here is that, after each search, when we look at the `productImpression` event, the `position` property is always starting from 1. That is **not** the case using the latest stable version of `vtex.search-result`.

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/TWTCdemH9OoEmx3iYq/giphy.gif)
