### PR TITLE
Remove priceRange from URL when clearing all filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Remove `priceRange` from the URL when clearing all filters.
+
 ## [3.117.1] - 2022-05-02
 ### Fixed
 - `searchTitle`s would always be `undefined` inside of gallery components when rendering the results of a full-text search.

--- a/react/components/PriceRange/index.js
+++ b/react/components/PriceRange/index.js
@@ -113,7 +113,7 @@ const PriceRange = ({
 
   const resetOnClear = () => {
     setQuery({
-      priceRange: `${minValue} TO ${maxValue}`
+      priceRange: undefined
     })
     setRange([minValue, maxValue])
     setClearPriceRange(false)


### PR DESCRIPTION
#### What problem is this solving?

When clicking the "clear all" button on mobile, the `priceRange` is added to the URL with the widest range (minimum price to maximum price) that is built using the API response, even if this filter is not part of the URL before clicking the button.

The problem with this is not only that the filter appears in the URL, but also because it may have different results from the initial search. This happens because the minimum and maximum value returned by the API is not accurate, as the API doesn't have enough information to calculate this based on the most up-to-date price of the products.

So, imagine that the price of the cheapest product returned by the API is 10 and the most expensive product has price 100. The API will return `min: 10` and `max: 100`. But when checking the simulation API we find that actually the cheapest product has a promotional price for a seller, so it's price is actually 5. When clicking the "clear all" button, the range will be built using API values (10 TO 100) so the product with price 5 that was on the initial search will disappear from the results.

To avoid these scenarios, `priceRange` should be removed from the URL when clicking on "clear all", keeping only the filters that were part of the initial search

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://aplicarfiltrodesk27016764--calpanycl.myvtex.com/ninos?map=ft)
- on mobile, click on "limpiar" and then "aplicar"
- priceRange shouldn't be part of the URL

#### Screenshots or example usage:

Before:

https://user-images.githubusercontent.com/20840671/167704576-c94769cb-cc59-46ea-b140-052ad5f83cd3.mp4


After:

https://user-images.githubusercontent.com/20840671/167704600-f000a39e-e52f-499f-b60c-0e7adcbaf3d3.mp4


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
