### PR TITLE
Types notation and object clone fixes

### DIFF
--- a/react/utils/sortFilterValues.ts
+++ b/react/utils/sortFilterValues.ts
@@ -1,6 +1,6 @@
 import { SPEC_FILTERS, ASC, DESC } from '../constants'
 
-interface Filters {
+interface Filter {
   key: string
   quantity: number
   title: string
@@ -63,9 +63,9 @@ const ensureOrderValue = (order: string): SortRules['order'] => {
 }
 
 export const sortFilterValues = (
-  filters: Filters[],
+  filters: Filter[],
   sortingRules: SortRules[]
-): Filters[] => {
+): Filter[] => {
   // Check if user has entered the right type on store-theme
   if (!Array.isArray(sortingRules)) {
     console.warn(
@@ -101,7 +101,7 @@ export const sortFilterValues = (
   }, {})
 
   // Apply rules for each facet
-  const filtersAdjusted = filters.map((filter) => {
+  const filtersAdjusted = filters.map((filter: Filter) => {
     const isSpecFilter = filter.type === SPEC_FILTERS
     const hasSortingRule = filter.key
       ? Boolean(mappedRules[filter.key.toLowerCase()])
@@ -111,7 +111,7 @@ export const sortFilterValues = (
 
     const { orderBy, order } = mappedRules[filter.key.toLowerCase()]
 
-    const filterCopy = { ...filter }
+    const filterCopy = JSON.parse(JSON.stringify(filter));
 
     filterCopy.facets.sort((a, b) => compare(a[orderBy], b[orderBy], order))
 

--- a/react/utils/sortFilterValues.ts
+++ b/react/utils/sortFilterValues.ts
@@ -5,17 +5,17 @@ interface Filter {
   quantity: number
   title: string
   type: string
-  facets: Facets[]
+  facets: Facet[]
 }
 
-interface Facets {
+interface Facet {
   name: string
   quantity: number
 }
 
 interface SortRules {
   key: string
-  orderBy: keyof Facets
+  orderBy: keyof Facet
   order: typeof ASC | typeof DESC
 }
 

--- a/react/utils/sortFilterValues.ts
+++ b/react/utils/sortFilterValues.ts
@@ -111,11 +111,9 @@ export const sortFilterValues = (
 
     const { orderBy, order } = mappedRules[filter.key.toLowerCase()]
 
-    const filterCopy = JSON.parse(JSON.stringify(filter));
+    filter.facets.sort((a, b) => compare(a[orderBy], b[orderBy], order))
 
-    filterCopy.facets.sort((a, b) => compare(a[orderBy], b[orderBy], order))
-
-    return filterCopy
+    return filter
   })
 
   return filtersAdjusted


### PR DESCRIPTION
- Changed the name of interface `Filters` to `Filter`
- Changed the name of interface `Facets` to `Facet`
- Changed the object clone method

#### What problem is this solving?

1. Typescript code improvements
2. Object Clone improvements
   In this example, we can see what happens when using a clone of object with spread operator: 
<img width="963" alt="Captura de Tela 2022-06-09 às 14 55 48" src="https://user-images.githubusercontent.com/4602864/172914476-27f06e6a-6a22-4f28-9a8e-b6119b1f4be3.png">

When using the spread operator, the variable `filterCopy` points to the same object `filter` in memory. Not making sense to use `filterCopy`.

In this example, we can see what happens when using a clone of object with `JSON.parse` and `JSON.stringify`:
<img width="950" alt="Captura de Tela 2022-06-09 às 14 55 59" src="https://user-images.githubusercontent.com/4602864/172915063-a9293040-b6e6-43dd-9fd6-cdb5c05d4cff.png">

The object in `filterCopy` is really a copy of `filter`, and we can change securely.


#### How to test it?
- `vtex test`

<!-- #### Screenshots or example usage: -->


<!-- #### Related to / Depends on -->



<!-- #### How does this PR make you feel? [:link:](http://giphy.com/) -->

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

<!-- ![](put .gif link here - can be found under "advanced" on giphy) -->
