### PR TITLE
Fix documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Documentation for `order-by` block.
+
 ## [3.118.0] - 2022-07-11
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -497,6 +497,12 @@ The `order-by` block renders a dropdown button with [sorting options](#the-sorti
 | `hiddenOptions` | `[string]` | Indicates which sorting options will be hidden. (e.g. `["OrderByNameASC", "OrderByNameDESC"]`) | `undefined`      |
 | `showOrderTitle` | `boolean` | Whether the selected order value (e.g. `Relevance`) will be displayed (`true`) or not (`false`).  | `true`           |
 
+- **`specificationOptions` Object:**
+| Prop name  | Type      | Description                             | Default value |
+| ---------- | --------- | --------------------------------------- | ------------- |
+| value      | string | Value that will be sent for ordering in the API. It must be in the format `{specification key}:{asc/desc}`. For example: `"size:desc"` or `"priceByUnit:asc"`. | `undefined` |
+| label      | string | Label that will be displayed in the sorting options. E.g.: `"Price by unit, ascending"` | `undefined` |
+
 ##### The sorting options for the `order-by` block
 
 | Sorting option           | Value                       |
@@ -513,13 +519,6 @@ The `order-by` block renders a dropdown button with [sorting options](#the-sorti
 
 
 #### The `search-fetch-more` block
-
-- **`specificationOptions` Object:**
-
-| Prop name  | Type      | Description                             | Default value |
-| ---------- | --------- | --------------------------------------- | ------------- |
-| value      | string | Value that will be sent for ordering in the API. It must be in the format `{specification key}:{asc|desc}`. For example: `"size:desc"` or `"priceByUnit:asc"`. | `undefined` |
-| label      | string | Label that will be displayed in the sorting options. E.g.: `"Price by unit, ascending"` | `undefined` |
 
 The `search-fetch-more` block renders a **Show More** button used to load the results of the next search results page. Check the block props in the table below.
 


### PR DESCRIPTION
#### What problem is this solving?

Broken doc. `specificationOptions` should be inside the `order-by` block props
<!--- What is the motivation and context for this change? -->
![image](https://user-images.githubusercontent.com/20840671/179276445-b55da16b-f61b-4b20-a472-d8d0e7547b7a.png)


#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](Link goes here!)

#### Screenshots or example usage:


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
