### PR TITLE
Fix next and prev links in custom search result pages to render server side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Render `prev` and `next` tags server side for pages using `SearchResultLayoutCustomQuery`
+
 ## [3.118.16] - 2022-09-23
 
 ### Added

--- a/react/components/SearchResultCustomQueryWrapper.tsx
+++ b/react/components/SearchResultCustomQueryWrapper.tsx
@@ -71,7 +71,7 @@ function useCanonicalLink() {
   const { route, rootPath = '' } = useRuntime() as RuntimeWithRoute
   const { canonicalPath } = route
 
-  const canonicalHost = window.location?.hostname
+  const canonicalHost = window.__hostname__ ?? window.location?.hostname
 
   if (!canonicalHost || !canonicalPath) {
     return undefined

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -1,0 +1,3 @@
+interface Window extends Window {
+  __hostname__: string | undefined
+}


### PR DESCRIPTION
#### What problem is this solving?

The pagination links (`prev` and `next` tags) are rendering client side. Client side crawling appears to take longer so we want the tags to be rendering server side.

#### How to test it?

Test in workspace [anna](https://anna--budgetgolf.myvtex.com/) in account budgetgolf. Go to a custom search page, click View Page Source and search for `next` or `prev` tags.

#### Screenshots or example usage:
Here's an example custom search page: https://anna--budgetgolf.myvtex.com/category/mens-spiked-golf-shoes?page=2

The pagination links should now appear in the page source:
<img width="1440" alt="Screen Shot 2022-09-27 at 11 27 43 AM" src="https://user-images.githubusercontent.com/53097865/192571807-fb499e4a-e2ea-4442-a72c-9208de7656af.png">

Previously, only the pagination links from the fetch more or fetch previous buttons appeared in the page source:
<img width="1440" alt="Screen Shot 2022-09-27 at 11 48 34 AM" src="https://user-images.githubusercontent.com/53097865/192574094-abadc693-f1bd-40fe-873a-2d207fdfd9c2.png">