### PR TITLE
[USAAPPTEAM-726] Fix ShowMoreFilterButton href attr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Remove `map` query parameter from `ShowMoreFilterButton` href attribute when map is `department`
+
 ## [3.118.18] - 2022-10-10
 
 ### Changed

--- a/react/components/loaders/FetchMoreButton.js
+++ b/react/components/loaders/FetchMoreButton.js
@@ -27,7 +27,7 @@ const useShowButton = (to, products, loading, recordsFiltered) => {
 }
 
 function shouldNotIncludeMap(map) {
-  if (!map || map === 'b' || map === 'brand') {
+  if (!map || map === 'b' || map === 'brand' || map === 'department') {
     return true
   }
 


### PR DESCRIPTION
#### What problem is this solving?

A US client has noticed a discrepancy between the canonical URL of their custom search pages, i.e.:

`https://www.budgetgolf.com/category/all-golf-footwear?page=2`

and the URL used as the `href` attribute on the "Show More" button, i.e.:

`https://www.budgetgolf.com/category/all-golf-footwear?page=2&map=department`

This mismatch may be causing Google indexing issues.

This PR prevents the `map` query string from being added to the href attribute if `map` is equal to "department". 

#### How to test it?

Linked here: https://arthur--budgetgolf.myvtex.com/category/all-golf-footwear