### PR TITLE
Feature/add pricerange to the siteeditor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Romanina translations
 
+### Added
+- `priceRange` to the `SearchResultLayoutCustomQuery` site editor schema.
+
 ## [3.118.14] - 2022-08-04
 ### Added
 - `json-schema`, `jsdom`, `jest-environment-jsdom` and `node-notifier` to resolutions yarn field

--- a/react/SearchResultLayoutCustomQuery.js
+++ b/react/SearchResultLayoutCustomQuery.js
@@ -71,6 +71,7 @@ const SearchResultLayoutCustomQuery = props => {
             mapField: props.querySchema.mapField,
           })}
       orderByField={props.querySchema.orderByField}
+      priceRangeField={props.querySchema.priceRangeField}
       hideUnavailableItems={props.querySchema.hideUnavailableItems}
       facetsBehavior={props.querySchema.facetsBehavior}
       skusFilter={props.querySchema.skusFilter}

--- a/react/components/LocalQuery.js
+++ b/react/components/LocalQuery.js
@@ -12,6 +12,7 @@ const LocalQuery = props => {
     maxItemsPerPage = DEFAULT_MAX_ITEMS_PER_PAGE,
     queryField = '',
     mapField = '',
+    priceRangeField = '',
     orderByField = SORT_OPTIONS[0].value,
     hideUnavailableItems,
     facetsBehavior,
@@ -20,7 +21,7 @@ const LocalQuery = props => {
     query: {
       order: orderBy = orderByField,
       page: pageQuery,
-      priceRange,
+      priceRange = priceRangeField,
       map = mapField,
     } = {},
     render,

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -141,7 +141,7 @@ const useCorrectSearchStateVariables = (
   return result
 }
 
-const useQueries = (variables, facetsArgs) => {
+const useQueries = (variables, facetsArgs, price) => {
   const { getSettings, query: runtimeQuery } = useRuntime()
   const isLazyFacetsFetchEnabled =
     getSettings('vtex.store')?.enableFiltersFetchOptimization
@@ -164,6 +164,15 @@ const useQueries = (variables, facetsArgs) => {
     },
   })
 
+  const initialMap = (price, runtimeQuery, facetsArgs) => {
+    if(runtimeQuery && runtimeQuery.initialMap) return runtimeQuery.initialMap
+    
+    if(price && facetsArgs.facetMap.indexOf("price") == -1) return (facetsArgs.facetMap + ",price")
+    
+    return facetsArgs.facetMap
+  }
+  
+
   const {
     data: { facets } = {},
     loading: facetsLoading,
@@ -183,7 +192,7 @@ const useQueries = (variables, facetsArgs) => {
       operator: variables.operator,
       fuzzy: variables.fuzzy,
       searchState: variables.searchState || undefined,
-      initialAttributes: runtimeQuery?.initialMap || facetsArgs.facetMap,
+      initialAttributes: initialMap(price, runtimeQuery, facetsArgs),
     },
     skip: !facetsArgs.withFacets,
   })
@@ -359,7 +368,7 @@ const SearchQuery = ({
     productSearchResult,
     facetsLoading,
     fetchMore,
-  } = useQueries(variables, facetsArgs)
+  } = useQueries(variables, facetsArgs, priceRange)
 
   const redirectUrl = data && data.productSearch && data.productSearch.redirect
 

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -164,7 +164,7 @@ const useQueries = (variables, facetsArgs, price) => {
     },
   })
 
-  const initialMap = () => {
+  const getInitialAttributes = () => {
     if (runtimeQuery && runtimeQuery.initialMap) return runtimeQuery.initialMap
 
     if (price && facetsArgs.facetMap.indexOf('price') === -1) {
@@ -193,7 +193,7 @@ const useQueries = (variables, facetsArgs, price) => {
       operator: variables.operator,
       fuzzy: variables.fuzzy,
       searchState: variables.searchState || undefined,
-      initialAttributes: initialMap(),
+      initialAttributes: getInitialAttributes(),
     },
     skip: !facetsArgs.withFacets,
   })

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -164,14 +164,15 @@ const useQueries = (variables, facetsArgs, price) => {
     },
   })
 
-  const initialMap = (price, runtimeQuery, facetsArgs) => {
-    if(runtimeQuery && runtimeQuery.initialMap) return runtimeQuery.initialMap
-    
-    if(price && facetsArgs.facetMap.indexOf("price") == -1) return (facetsArgs.facetMap + ",price")
-    
+  const initialMap = () => {
+    if (runtimeQuery && runtimeQuery.initialMap) return runtimeQuery.initialMap
+
+    if (price && facetsArgs.facetMap.indexOf('price') === -1) {
+      return `${facetsArgs.facetMap},price`
+    }
+
     return facetsArgs.facetMap
   }
-  
 
   const {
     data: { facets } = {},
@@ -192,7 +193,7 @@ const useQueries = (variables, facetsArgs, price) => {
       operator: variables.operator,
       fuzzy: variables.fuzzy,
       searchState: variables.searchState || undefined,
-      initialAttributes: initialMap(price, runtimeQuery, facetsArgs),
+      initialAttributes: initialMap(),
     },
     skip: !facetsArgs.withFacets,
   })

--- a/react/index.js
+++ b/react/index.js
@@ -102,6 +102,11 @@ SearchResult.getSchema = props => {
               title: 'Map',
               type: 'string',
             },
+            priceRangeField: {
+              title: 'PriceRange',
+              type: 'string',
+              description: 'e.g., "10 TO 233"'
+            },
             orderByField: {
               title: 'Order by field',
               type: 'string',

--- a/react/index.js
+++ b/react/index.js
@@ -105,7 +105,7 @@ SearchResult.getSchema = props => {
             priceRangeField: {
               title: 'PriceRange',
               type: 'string',
-              description: 'e.g., "10 TO 233"'
+              description: 'e.g., "10 TO 233"',
             },
             orderByField: {
               title: 'Order by field',


### PR DESCRIPTION
#### What problem is this solving?
When you set a price range via the site editor, the priceRange filter still appears among the filters' options.

(https://vtex-dev.atlassian.net/browse/IS-4144?atlOrigin=eyJpIjoiNGYzZmU1NmViMGVkNDBmYzkxYTI5ZjIyNjQ1NGZhYWMiLCJwIjoiaiJ9)

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://hiago--budgetgolf.myvtex.com/blank-test)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
