### PR TITLE
feature/infiniteScrollThreshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `infiniteScrollThreshold` prop to the `SearchResultContainer`.
+
 ## [3.119.0] - 2022-12-23
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -252,7 +252,7 @@ According to your store's scenario, structure the `search-result-layout` or the 
 | `defaultGalleryLayout` | `string` | Name of the gallery layout to be used by default in the search results page. This prop is required when several layouts are explicitly defined by the `gallery` block. This prop's value must match the layout name defined in the `name` prop from `layouts` object. |  `undefined` | 
 | `thresholdForFacetSearch` | `number` | The minimum number of facets must be displayed on the interface for a search bar to be displayed. If you declare `0`, the search bar will always be displayed. |  `undefined` | 
 | `preventRouteChange` | `boolean` | Keeps page customizations even when the user applies new filters on it. This prop will merely change the URL’s query string instead of the entire URL; therefore, it prevents a full page reload whenever filters are applied. |  `false` | 
-
+| `infiniteScrollThreshold` | `number` | A threshold value defining when the next fetch will occur. For instance, if set to 0.5, it means the next fetch will be called when user comes below 50% of the total height. |  `undefined` | 
 
 #### The `mobileLayout` object
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -252,7 +252,7 @@ According to your store's scenario, structure the `search-result-layout` or the 
 | `defaultGalleryLayout` | `string` | Name of the gallery layout to be used by default in the search results page. This prop is required when several layouts are explicitly defined by the `gallery` block. This prop's value must match the layout name defined in the `name` prop from `layouts` object. |  `undefined` | 
 | `thresholdForFacetSearch` | `number` | The minimum number of facets must be displayed on the interface for a search bar to be displayed. If you declare `0`, the search bar will always be displayed. |  `undefined` | 
 | `preventRouteChange` | `boolean` | Keeps page customizations even when the user applies new filters on it. This prop will merely change the URL’s query string instead of the entire URL; therefore, it prevents a full page reload whenever filters are applied. |  `false` | 
-| `infiniteScrollThreshold` | `number` | A threshold value defining when the next fetch will occur. For instance, if set to 0.5, it means the next fetch will be called when user comes below 50% of the total height. |  `undefined` | 
+| `infiniteScrollThreshold` | `number` | A threshold value defining when the next fetch will occur. For instance, if set to 0.5, it means the next fetch will be called when user comes below 50% of the total height. Only applies to infinite scroll pagination. |  `undefined` | 
 
 #### The `mobileLayout` object
 

--- a/react/SearchResultFlexible.js
+++ b/react/SearchResultFlexible.js
@@ -61,6 +61,7 @@ const SearchResultFlexible = ({
   trackingId,
   thresholdForFacetSearch,
   lazyItemsRemaining,
+  infiniteScrollThreshold,
 }) => {
   // This makes infinite scroll unavailable.
   // Infinite scroll was deprecated and we have
@@ -156,6 +157,7 @@ const SearchResultFlexible = ({
       facetsLoading,
       lazyItemsRemaining,
       selectedFacets,
+      infiniteScrollThreshold,
     }
   }, [
     hiddenFacets,
@@ -174,6 +176,7 @@ const SearchResultFlexible = ({
     preventRouteChange,
     facetsLoading,
     lazyItemsRemaining,
+    infiniteScrollThreshold,
   ])
 
   const showLoading = searchQuery.loading && !state.isFetchingMore
@@ -199,6 +202,7 @@ const SearchResultFlexible = ({
               page={page}
               facetsLoading={facetsLoading}
               lazyItemsRemaining={lazyItemsRemaining}
+              infiniteScrollThreshold={infiniteScrollThreshold}
             >
               <LoadingOverlay loading={showLoading}>
                 <div

--- a/react/components/SearchResultContainer.js
+++ b/react/components/SearchResultContainer.js
@@ -39,6 +39,7 @@ const SearchResultContainer = props => {
     page,
     children,
     lazyItemsRemaining,
+    infiniteScrollThreshold,
   } = props
 
   const queryData = {
@@ -98,6 +99,7 @@ const SearchResultContainer = props => {
       next={handleFetchMoreNext}
       hasMore={to + 1 < recordsFiltered}
       useWindow={false}
+      scrollThreshold={infiniteScrollThreshold}
     >
       {resultComponent}
     </InfiniteScroll>


### PR DESCRIPTION
#### What problem is this solving?

Currently, infinite scroll isn't maintained anymore (see this [release note](https://github.com/vtex-apps/release-notes/blob/master/docs/2019-week-41-42/infinite-scroll-on-flexible-search-result-page.md)). Despite this, it can still be achieved as explained below:

https://community.vtex.com/t/scroll-infinito-na-vtex-io/32654

It works almost perfectly and, in fact, we are willing to use it at several of our stores in production. However, there is one single property of `react-infinite-scroll-component`, the package used internally to implement infinite scroll, which we must tune to match the required UX: the `scrollThreshold`, whose documentation can be found [here](https://www.npmjs.com/package/react-infinite-scroll-component) and, essentially, controls the threshold for when the next fetch should occur.

In fact, as it is right now, at our tests we identified that, most of the times, the user must scroll down too much in order to trigger the next fetch. With this new property, we will be able to tune this next fetch to happen earlier, hence improving UX.
 
#### How to test it?

1. Access this [Workspace](https://mkt4465vtex--electrolux.myvtex.com/).
2. Navigate to one of the departments at the header menu, for instance, "Eletrodomésticos".
3. Scroll down and check that new products are automatically loaded, that is, infinite scroll is in place.
4. Observe the URL and check that the `page` parameter changes at approximately 40% of the product cards area height, that is, a `scrollThreshold` of 0.4 is in place.

#### Screenshots or example usage:

At the current implementation, `scrollThreshold` is not even set and, therefore, the default one (not that good UX) is used:

<img width="1552" alt="Screenshot 2023-02-01 at 12 29 18" src="https://user-images.githubusercontent.com/115579881/216086858-0f1f16d8-ce41-4a22-90de-40c0d7c2f5be.png">

Hence, with this PR, we expose this `react-infinite-scroll-component` property as a new property of the `SearchResultContainer` we baptized as `infiniteScrollThreshold` so that developers can manually tune this property at storefront level to achieve good UX:

<img width="1552" alt="Screenshot 2023-02-01 at 12 31 50" src="https://user-images.githubusercontent.com/115579881/216087494-12f39339-56c2-49b4-b506-35273b79fde5.png">

For instance, one can then use this new property as bellow:

```json
	"search-result-layout.desktop": {
		"children": [
                        ...
		],
		"props": {
                        ...
                        "preventRouteChange": true,
			"pagination": "infiniteScroll",
			"infiniteScrollThreshold": 0.4
		}
	},
```

It is important to remark that this is a safe new feature, i.e., a non breaking change. In fact, if one does not set this new property, everything behaves exactly as before: we are just making the configuration possible.