### PR TITLE
feat: show facet title on filtered by section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added `showFacetTitle` prop to toggle weather the facet title should appear on selected filters section
 
 ## [3.123.2] - 2023-06-29
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -256,6 +256,7 @@ According to your store's scenario, structure the `search-result-layout` or the 
 | - | - | - | - |
 | `hiddenFacets` | `object` | Indicates which filters should be hidden. The possible values are in [this table](#the-hiddenfacets-object). | `undefined` |
 | `showFacetQuantity` | `boolean` | Determines whether the resulting amount in each filter should appear beside its name on the `filter-navigator.v3` block as (`true`) or (`false`) | `false` |
+| `showFacetTitle` | `boolean`      | Whether the facet title should appear on selected filters section on the `filter-navigator.v3` block as (`true`) or (`false`)      | `false`           |
 | `blockClass` | `string` | Unique block ID to be used in [CSS customization](https://developers.vtex.com/docs/guides/vtex-io-documentation-using-css-handles-for-store-customization#using-the-blockclass-property) | `undefined` |
 | `trackingId` | `string` | ID to be used in Google Analytics to track store metrics based on the Search Result block. | `Search result` |
 | `mobileLayout` | `object` | Controls how the search results page will be displayed to users using the mobile layout. The possible values are in [this table](#the-mobilelayout-object). | `undefined` |

--- a/react/SearchResultFlexible.js
+++ b/react/SearchResultFlexible.js
@@ -49,6 +49,7 @@ const SearchResultFlexible = ({
   blockClass,
   preventRouteChange = false,
   showFacetQuantity = false,
+  showFacetTitle = false,
   // Below are set by SearchContext
   searchQuery,
   maxItemsPerPage,
@@ -120,6 +121,7 @@ const SearchResultFlexible = ({
       pagination,
       mobileLayout,
       showFacetQuantity,
+      showFacetTitle,
       trackingId,
       thresholdForFacetSearch,
     }),
@@ -128,6 +130,7 @@ const SearchResultFlexible = ({
       mobileLayout,
       pagination,
       showFacetQuantity,
+      showFacetTitle,
       trackingId,
       thresholdForFacetSearch,
     ]

--- a/react/components/FacetItem.js
+++ b/react/components/FacetItem.js
@@ -1,4 +1,4 @@
-import React, { useContext, useState, useEffect } from 'react'
+import React, { useContext, useState, useEffect, useMemo } from 'react'
 import { Checkbox } from 'vtex.styleguide'
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 import classNames from 'classnames'
@@ -9,7 +9,7 @@ import { pushFilterManipulationPixelEvent } from '../utils/filterManipulationPix
 import SettingsContext from './SettingsContext'
 import useShouldDisableFacet from '../hooks/useShouldDisableFacet'
 
-const CSS_HANDLES = ['filterItem', 'productCount']
+const CSS_HANDLES = ['filterItem', 'productCount', 'filterItemTitle']
 
 // These are used to prevent creating a <Checkbox /> with id equal
 // to any of these words.
@@ -28,8 +28,10 @@ const FacetItem = ({
   facet,
   className,
   preventRouteChange,
+  showTitle = false,
 }) => {
   const { showFacetQuantity } = useContext(SettingsContext)
+
   const [selected, setSelected] = useState(facet.selected)
   const { push } = usePixel()
   const handles = useCssHandles(CSS_HANDLES)
@@ -61,20 +63,41 @@ const FacetItem = ({
 
   const shouldDisable = useShouldDisableFacet(facet)
 
-  const facetLabel =
-    showFacetQuantity && !sampling ? (
-      <>
-        {facet.name}{' '}
-        <span
-          data-testid={`facet-quantity-${facet.value}-${facet.quantity}`}
-          className={handles.productCount}
-        >
-          ({facet.quantity})
-        </span>
-      </>
-    ) : (
-      facet.name
-    )
+  const facetLabel = useMemo(() => {
+    const labelElement =
+      showFacetQuantity && !sampling ? (
+        <>
+          {facet.name}{' '}
+          <span
+            data-testid={`facet-quantity-${facet.value}-${facet.quantity}`}
+            className={handles.productCount}
+          >
+            ({facet.quantity})
+          </span>
+        </>
+      ) : (
+        facet.name
+      )
+
+    if (showTitle) {
+      return (
+        <>
+          <span className={handles.filterItemTitle}>{facetTitle}</span>:{' '}
+          {labelElement}
+        </>
+      )
+    }
+
+    return labelElement
+  }, [
+    facet,
+    handles.productCount,
+    handles.filterItemTitle,
+    facetTitle,
+    showTitle,
+    showFacetQuantity,
+    sampling,
+  ])
 
   return (
     <div

--- a/react/components/SelectedFilters.js
+++ b/react/components/SelectedFilters.js
@@ -23,11 +23,11 @@ const SelectedFilters = ({
   const handles = useCssHandles(CSS_HANDLES)
   const { showFacetTitle } = useContext(SettingsContext)
 
-  if (!filters.length) {
+  const visibleFilters = filters.filter(filter => !filter.hidden)
+
+  if (!visibleFilters.length) {
     return null
   }
-
-  const visibleFilters = filters.filter(filter => !filter.hidden)
 
   const title = intl.formatMessage({ id: 'store/search.selected-filters' })
 

--- a/react/components/SelectedFilters.js
+++ b/react/components/SelectedFilters.js
@@ -1,11 +1,12 @@
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useContext } from 'react'
 import { useIntl } from 'react-intl'
 import { useCssHandles } from 'vtex.css-handles'
 
 import FacetItem from './FacetItem'
 import FilterOptionTemplate from './FilterOptionTemplate'
 import { facetOptionShape } from '../constants/propTypes'
+import SettingsContext from './SettingsContext'
 
 const CSS_HANDLES = ['selectedFilterItem']
 
@@ -20,6 +21,7 @@ const SelectedFilters = ({
 }) => {
   const intl = useIntl()
   const handles = useCssHandles(CSS_HANDLES)
+  const { showFacetTitle } = useContext(SettingsContext)
 
   if (!filters.length) {
     return null
@@ -37,17 +39,20 @@ const SelectedFilters = ({
       collapsable={false}
       selected
     >
-      {facet => (
-        <FacetItem
-          map={map}
-          key={facet.name}
-          facetTitle={facet.title}
-          facet={facet}
-          className={handles.selectedFilterItem}
-          preventRouteChange={preventRouteChange}
-          navigateToFacet={navigateToFacet}
-        />
-      )}
+      {facet => {
+        return (
+          <FacetItem
+            map={map}
+            key={facet.name}
+            showTitle={showFacetTitle}
+            facetTitle={facet.title}
+            facet={facet}
+            className={handles.selectedFilterItem}
+            preventRouteChange={preventRouteChange}
+            navigateToFacet={navigateToFacet}
+          />
+        )
+      }}
     </FilterOptionTemplate>
   )
 }


### PR DESCRIPTION
#### What problem is this solving?
This feature will include the possibility to show the facet title on selected filters section.

```json
  "search-result-layout.desktop": {
    "children": ["flex-layout.row#searchbread", "flex-layout.row#result"],
    "props": {
       ...
      "showFacetTitle": true
       ...
    }
  },
```

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://selectedfacetdemo--beecodedpartnerro.myvtex.com/turbochargers)

#### Screenshots or example usage:

<img width="333" alt="Screenshot 2023-03-15 at 11 22 56" src="https://user-images.githubusercontent.com/127866723/225265365-d843cb8d-509d-44d2-9530-dc35f0ae9dca.png">

