### PR TITLE
fix: term not displayed in not found search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Term is not passed as props to NotFoundSearch
+
 ## [3.120.0] - 2023-03-22
 
 ### Added

--- a/react/NotFoundSearch.js
+++ b/react/NotFoundSearch.js
@@ -3,7 +3,9 @@ import React, { Fragment } from 'react'
 import { FormattedMessage } from 'react-intl'
 import { ExtensionPoint } from 'vtex.render-runtime'
 import { useCssHandles } from 'vtex.css-handles'
+import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
 import { range } from 'ramda'
+
 
 const CSS_HANDLES = [
   'searchNotFound',
@@ -20,8 +22,10 @@ const CSS_HANDLES = [
  * Not found page component, rendered when the search doesn't return any
  * products from the API.
  */
-const NotFoundSearch = ({ term }) => {
+const NotFoundSearch = () => {
   const handles = useCssHandles(CSS_HANDLES)
+
+  const { params:{term} } = useSearchPage()
 
   return (
     <Fragment>

--- a/react/NotFoundSearch.js
+++ b/react/NotFoundSearch.js
@@ -24,7 +24,9 @@ const CSS_HANDLES = [
 const NotFoundSearch = () => {
   const handles = useCssHandles(CSS_HANDLES)
 
-  const { params: { term } } = useSearchPage()
+  const {
+    params: { term },
+  } = useSearchPage()
 
   return (
     <Fragment>

--- a/react/NotFoundSearch.js
+++ b/react/NotFoundSearch.js
@@ -6,7 +6,6 @@ import { useCssHandles } from 'vtex.css-handles'
 import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
 import { range } from 'ramda'
 
-
 const CSS_HANDLES = [
   'searchNotFound',
   'searchNotFoundOops',
@@ -25,7 +24,7 @@ const CSS_HANDLES = [
 const NotFoundSearch = () => {
   const handles = useCssHandles(CSS_HANDLES)
 
-  const { params:{term} } = useSearchPage()
+  const { params: { term } } = useSearchPage()
 
   return (
     <Fragment>


### PR DESCRIPTION
#### What problem is this solving?

The term is not passed as props to the not found page, to display the searched term I got the information from the context instead

#### How to test it?

[After](https://tiendaio--tiendamarco.myvtex.com/abx?_q=ABX&map=ft)

<img width="1083" alt="image" src="https://user-images.githubusercontent.com/13649073/227366477-2c319872-2a0e-40d4-ad68-c412fb95cf5b.png">


[Before](https://storetheme.vtex.com/abx?_q=abx&map=ft)

<img width="952" alt="image" src="https://user-images.githubusercontent.com/13649073/227366600-af9b12d7-f68f-4fbe-9ae0-7236c4f04774.png">


#### Related to / Depends on

Zendesk: #773143

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/k3y0F8xrl0RvYVmTsJ/giphy.gif)
