### PR TITLE
  IS-4519 Clear price range when using clear all button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Reset price slider when clearing all filters.
+
 ## [3.122.1] - 2023-04-25
 ### Fixed
 - Updated readme.md according to task LOC-10476.

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -104,6 +104,7 @@ const FilterNavigator = ({
   const { isMobile } = useDevice()
   const handles = useCssHandles(CSS_HANDLES)
   const [truncatedFacetsFetched, setTruncatedFacetsFetched] = useState(false)
+  const [clearPriceRange, setClearPriceRange] = useState()
 
   const mobileLayout =
     (isMobile && layout === LAYOUT_TYPES.responsive) ||
@@ -182,6 +183,7 @@ const FilterNavigator = ({
 
   const handleResetFilters = () => {
     navigateToFacet(selectedFilters, preventRouteChange)
+    setClearPriceRange(true)
   }
 
   const selectedCategories = getSelectedCategories(tree)
@@ -290,6 +292,8 @@ const FilterNavigator = ({
               showClearByFilter={showClearByFilter}
               priceRangeLayout={priceRangeLayout}
               scrollToTop={scrollToTop}
+              clearPriceRange={clearPriceRange}
+              setClearPriceRange={setClearPriceRange}
             />
             {showClearAllFiltersOnDesktop && hasFiltersApplied && (
               <div

--- a/react/components/AvailableFilters.js
+++ b/react/components/AvailableFilters.js
@@ -39,6 +39,8 @@ const Filter = ({
   showClearByFilter,
   priceRangeLayout,
   scrollToTop,
+  clearPriceRange,
+  setClearPriceRange,
 }) => {
   const { type, title, facets, quantity, oneSelectedCollapse = false } = filter
 
@@ -53,6 +55,8 @@ const Filter = ({
           preventRouteChange={preventRouteChange}
           priceRangeLayout={priceRangeLayout}
           scrollToTop={scrollToTop}
+          clearPriceRange={clearPriceRange}
+          setClearPriceRange={setClearPriceRange}
         />
       )
 

--- a/react/components/PriceRange/index.js
+++ b/react/components/PriceRange/index.js
@@ -144,7 +144,7 @@ const PriceRange = ({
         onChange={handleChange}
         defaultValues={defaultValues}
         formatValue={value => formatCurrency({ intl, culture, value })}
-        values={range}
+        values={priceRange && range ? range : [minValue, maxValue]}
         range
       />
     </FilterOptionTemplate>


### PR DESCRIPTION
#### What problem is this solving?

Price range values didn't change when clicking the "clear all" button

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://thalyta--beautycounterqa.myvtex.com/skin-care)
- Change the values on the price slider
- try to click the clear all button. The values should return to the initial values.

#### Screenshots or example usage:

Before:

https://github.com/vtex-apps/search-result/assets/20840671/bf2b4388-a4a0-4655-af59-50bdbe83118a

After:

https://github.com/vtex-apps/search-result/assets/20840671/39360d64-6807-4d2a-ba85-bc74b4458ffe



#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

Depends on Slider PR (TBD)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
