### PR TITLE
fix: non-ft pages dont have term in params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Not found pages crashing due term
+
 ## [3.122.1] - 2023-04-25
 ### Fixed
 - Updated readme.md according to task LOC-10476.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
-- Not found pages crashing due term
+- Not found pages crashing due to not having term in params
 
 ## [3.122.1] - 2023-04-25
 ### Fixed

--- a/react/NotFoundSearch.js
+++ b/react/NotFoundSearch.js
@@ -24,9 +24,9 @@ const CSS_HANDLES = [
 const NotFoundSearch = () => {
   const handles = useCssHandles(CSS_HANDLES)
 
-  const {
-    params: { term },
-  } = useSearchPage()
+  const { params } = useSearchPage()
+
+  const term = params?.term ? decodeURI(params?.term) : ''
 
   return (
     <Fragment>


### PR DESCRIPTION
#### What problem is this solving?

Not every not found page has a term inside the param object, this variable is only applied for not found results in full text searches, it was causing render to crash when displaying not found pages without terms (especially for collections and categories pages without results)

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Before](https://termerror--eriksbikeshop.myvtex.com/cycling/bicycles/electric/road-gravel?fuzzy=0&initialMap=ft&initialQuery=electric%20road%20bikes&map=ft,bike-features&operator=and&priceRange=1800%20TO%2014000&query=/electric%20road%20bikes/suspension&searchState=)

<img width="1023" alt="image" src="https://github.com/vtex-apps/search-result/assets/13649073/4919456a-dd05-439a-a758-62970d44c04c">


[Before](https://theme--unidrogas.myvtex.com/test-landing)

<img width="351" alt="image" src="https://github.com/vtex-apps/search-result/assets/13649073/2278808a-9561-41bd-a908-181af73f4cb7">


[After](https://iespinoza--eriksbikeshop.myvtex.com/cycling/bicycles/electric/road-gravel?fuzzy=0&initialMap=ft&initialQuery=electric%20road%20bikes&map=ft,bike-features&operator=and&priceRange=1800%20TO%2014000&query=/electric%20road%20bikes/suspension&searchState=)

<img width="660" alt="image" src="https://github.com/vtex-apps/search-result/assets/13649073/85785001-91cc-4c51-aaf5-3a9dc219559f">

[After](https://iespinoza--unidrogas.myvtex.com/test-landing)

<img width="959" alt="image" src="https://github.com/vtex-apps/search-result/assets/13649073/6c979da8-b646-489c-af78-2fc0a6512c3b">


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/Ih6f3JK5YkZCY9azoQ/giphy-downsized-large.gif)
