### PR TITLE
Fix filters when changing price range on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Filters when changing price range on mobile.
+
 ## [3.123.1] - 2023-06-29
 ### Fixed
 - `search-products-count-per-page` block is written twice in the doc.

--- a/react/components/AccordionFilterContainer.js
+++ b/react/components/AccordionFilterContainer.js
@@ -30,6 +30,7 @@ const AccordionFilterContainer = ({
   tree,
   onCategorySelect,
   priceRange,
+  onChangePriceRange,
   appliedFiltersOverview,
   navigationType,
   initiallyCollapsed,
@@ -179,6 +180,7 @@ const AccordionFilterContainer = ({
                 onClearFilter={() => {
                   setQuery({ priceRange: undefined })
                 }}
+                onChangePriceRange={onChangePriceRange}
                 showClearByFilter={showClearByFilter}
               />
             )
@@ -259,6 +261,7 @@ AccordionFilterContainer.propTypes = {
   clearPriceRange: PropTypes.bool,
   /** Set the value of clearPriceRange prop */
   setClearPriceRange: PropTypes.func,
+  onChangePriceRange: PropTypes.func,
 }
 
 export default AccordionFilterContainer

--- a/react/components/AccordionFilterPriceRange.js
+++ b/react/components/AccordionFilterPriceRange.js
@@ -16,6 +16,7 @@ const AccordionFilterPriceRange = ({
   priceRangeLayout,
   onClearFilter,
   showClearByFilter,
+  onChangePriceRange,
 }) => {
   const priceRangeRegex = /^(.*) TO (.*)$/
   const isPriceRangeSelected = priceRange && priceRangeRegex.test(priceRange)
@@ -38,6 +39,7 @@ const AccordionFilterPriceRange = ({
           facets={facets}
           priceRange={priceRange}
           priceRangeLayout={priceRangeLayout}
+          onChangePriceRange={onChangePriceRange}
         />
       </div>
     </AccordionFilterItem>

--- a/react/components/AvailableFilters.js
+++ b/react/components/AvailableFilters.js
@@ -54,6 +54,9 @@ const Filter = ({
           priceRangeLayout={priceRangeLayout}
           scrollToTop={scrollToTop}
           showClearByFilter={showClearByFilter}
+          onChangePriceRange={newPriceRange =>
+            navigateToFacet([], preventRouteChange, false, newPriceRange)
+          }
         />
       )
 

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -118,14 +118,18 @@ const FilterSidebar = ({
     setOpen(true)
   }
 
-  const handleApply = () => {
+  const handleApply = (newPriceRange = undefined) => {
     setOpen(false)
 
-    if (updateOnFilterSelectionOnMobile && preventRouteChange) {
+    if (
+      updateOnFilterSelectionOnMobile &&
+      preventRouteChange &&
+      !newPriceRange
+    ) {
       return
     }
 
-    navigateToFacet(filterOperations, preventRouteChange)
+    navigateToFacet(filterOperations, preventRouteChange, false, newPriceRange)
     setFilterOperations([])
   }
 
@@ -272,6 +276,7 @@ const FilterSidebar = ({
             onFilterCheck={handleFilterCheck}
             onCategorySelect={handleUpdateCategories}
             priceRange={priceRange}
+            onChangePriceRange={handleApply}
             appliedFiltersOverview={appliedFiltersOverview}
             navigationType={navigationType}
             initiallyCollapsed={initiallyCollapsed}
@@ -309,7 +314,7 @@ const FilterSidebar = ({
               block
               variation="secondary"
               size="regular"
-              onClick={handleApply}
+              onClick={() => handleApply()}
             >
               <FormattedMessage id="store/search-result.filter-button.apply" />
             </Button>

--- a/react/components/PriceRange/index.js
+++ b/react/components/PriceRange/index.js
@@ -11,9 +11,7 @@ import { pushFilterManipulationPixelEvent } from '../../utils/filterManipulation
 import { facetOptionShape } from '../../constants/propTypes'
 import { getFilterTitle } from '../../constants/SearchHelpers'
 import FilterOptionTemplate from '../FilterOptionTemplate'
-import useSearchState from '../../hooks/useSearchState'
 import PriceRangeInput from './PriceRangeInput'
-import { useFilterNavigator } from '../FilterNavigatorContext'
 
 const DEBOUNCE_TIME = 500 // ms
 
@@ -25,16 +23,14 @@ const PriceRange = ({
   priceRangeLayout,
   scrollToTop,
   showClearByFilter,
+  onChangePriceRange,
 }) => {
   const { culture, setQuery, query: runtimeQuery } = useRuntime()
   const intl = useIntl()
   const navigateTimeoutId = useRef()
-  const { map, query } = useFilterNavigator()
 
   const { push } = usePixel()
   const { searchQuery } = useSearchPage()
-
-  const { fuzzy, operator, searchState } = useSearchState()
 
   const handleChange = ([left, right]) => {
     if (navigateTimeoutId.current) {
@@ -49,22 +45,9 @@ const PriceRange = ({
     })
 
     navigateTimeoutId.current = setTimeout(() => {
-      const state =
-        typeof sessionStorage !== 'undefined'
-          ? sessionStorage.getItem('searchState') ?? searchState
-          : searchState ?? undefined
-
       // avoid page from reloading again after clear all button is clicked
       if (runtimeQuery?.priceRange || left !== minValue || right !== maxValue) {
-        setQuery({
-          priceRange: `${left} TO ${right}`,
-          page: undefined,
-          fuzzy: fuzzy || undefined,
-          operator: operator || undefined,
-          searchState: state,
-          initialMap: runtimeQuery?.initialMap ?? map,
-          initialQuery: runtimeQuery?.initialQuery ?? query,
-        })
+        onChangePriceRange(`${left} TO ${right}`)
       }
 
       if (scrollToTop !== 'none') {
@@ -154,6 +137,7 @@ PriceRange.propTypes = {
   setClearPriceRange: PropTypes.func,
   /** Whether a clear button that clear all options in a specific filter should appear beside the filter's name (true) or not (false). */
   showClearByFilter: PropTypes.bool,
+  onChangePriceRange: PropTypes.func,
 }
 
 export default PriceRange

--- a/react/hooks/useFacetNavigation.js
+++ b/react/hooks/useFacetNavigation.js
@@ -201,7 +201,12 @@ const useFacetNavigation = (selectedFacets, scrollToTop = 'none') => {
   const mainSearches = getMainSearches(query, map)
 
   const navigateToFacet = useCallback(
-    (maybeFacets, preventRouteChange = false, isReset = false) => {
+    (
+      maybeFacets,
+      preventRouteChange = false,
+      isReset = false,
+      priceRange = undefined
+    ) => {
       const facets = Array.isArray(maybeFacets) ? maybeFacets : [maybeFacets]
       const { query: currentQuery, map: currentMap } = buildNewQueryMap(
         mainSearches,
@@ -228,7 +233,7 @@ const useFacetNavigation = (selectedFacets, scrollToTop = 'none') => {
           searchState: state,
           initialMap: runtimeQuery.initialMap ?? map,
           initialQuery: runtimeQuery.initialQuery ?? query,
-          ...(isReset ? { priceRange: undefined } : {}),
+          ...(isReset ? { priceRange: undefined } : { priceRange }),
         }
 
         setQuery(queries)
@@ -269,6 +274,10 @@ const useFacetNavigation = (selectedFacets, scrollToTop = 'none') => {
           'searchState',
           sessionStorage.getItem('searchState') ?? searchState
         )
+      }
+
+      if (priceRange) {
+        urlParams.set('priceRange', priceRange)
       }
 
       if (!newQuery) {


### PR DESCRIPTION
#### What problem is this solving?

When we change the priceRange while some filters are not applied, the selected filters sometimes disappear, and when you click on apply they are set to the url. this happens because priceRange is not using the standard function `navigateToFacet`, and thus doesn't share the current state of the other filters

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://thalyta--storecomponents.myvtex.com/apparel---accessories)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

Before:

https://github.com/vtex-apps/search-result/assets/20840671/c2496536-143a-449f-a5ba-83129eb61d21


After:

https://github.com/vtex-apps/search-result/assets/20840671/b23bc8d3-b30c-44dc-bb07-21128847e195

#### Describe alternatives you've considered, if any.




<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
