### PR TITLE
Add page view event to custom search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `pageInfo` event for custom search pages.
+
 ## [3.122.6] - 2023-06-26
 
 ### Changed

--- a/react/components/SearchResultCustomQueryWrapper.tsx
+++ b/react/components/SearchResultCustomQueryWrapper.tsx
@@ -3,15 +3,16 @@ import type { RuntimeWithRoute } from 'vtex.render-runtime'
 import { canUseDOM, useRuntime, Helmet } from 'vtex.render-runtime'
 import queryString from 'query-string'
 
+import useDataPixel from '../hooks/useDataPixel'
+import { usePageView } from '../hooks/usePageView'
 import type { SearchQuery } from '../utils/searchMetadata'
 import {
   getCategoryMetadata,
   getDepartmentMetadata,
+  getPageEventName,
   getSearchMetadata,
   getTitleTag,
 } from '../utils/searchMetadata'
-import useDataPixel from '../hooks/useDataPixel'
-import { usePageView } from '../hooks/usePageView'
 
 interface GetHelmetLinkParams {
   canonicalLink: string | undefined
@@ -28,26 +29,6 @@ interface IsNotLastPageParams {
   products: any
   to: number | undefined
   recordsFiltered: number | undefined
-}
-
-type PageEventName =
-  | 'internalSiteSearchView'
-  | 'categoryView'
-  | 'departmentView'
-  | 'emptySearchView'
-
-const mapEvent = {
-  InternalSiteSearch: 'internalSiteSearchView',
-  Category: 'categoryView',
-  Department: 'departmentView',
-  EmptySearch: 'emptySearchView',
-}
-
-const fallbackView = 'otherView'
-
-interface Variables {
-  fullText?: string
-  category?: any
 }
 
 function getHelmetLink({ canonicalLink, page, rel }: GetHelmetLinkParams) {
@@ -140,29 +121,6 @@ const getSearchIdentifier = (
   const { query, map } = variables
 
   return query + map + (orderBy ?? '') + (page ?? '')
-}
-
-const pageCategory = (products: unknown[], variables: Variables) => {
-  if (!products || products.length === 0) {
-    return 'EmptySearch'
-  }
-
-  const { category, fullText } = variables
-
-  return fullText ? 'InternalSiteSearch' : category ? 'Category' : 'Department'
-}
-
-const getPageEventName = (
-  products: unknown[],
-  variables: Variables
-): PageEventName => {
-  if (!products) {
-    return fallbackView as PageEventName
-  }
-
-  const category = pageCategory(products, variables)
-
-  return (mapEvent[category] || fallbackView) as PageEventName
 }
 
 const SearchResultCustomQueryWrapper = (props: any) => {

--- a/react/hooks/useDataPixel.ts
+++ b/react/hooks/useDataPixel.ts
@@ -1,0 +1,33 @@
+/* eslint-disable no-restricted-imports */
+import { useEffect, useRef } from 'react'
+import { usePixel } from 'vtex.pixel-manager/PixelContext'
+import { isEmpty } from 'ramda'
+
+type Data = unknown[] | unknown
+
+const useDataPixel = (data: Data, pageIdentifier = '', isLoading = false) => {
+  const { push } = usePixel()
+  const previousIdRef = useRef<string | null>(null)
+
+  const previousId = previousIdRef.current
+
+  useEffect(() => {
+    if (!pageIdentifier || isLoading || previousId === pageIdentifier) {
+      return
+    }
+
+    if (!data || isEmpty(data)) {
+      return
+    }
+
+    if (Array.isArray(data)) {
+      data.forEach(push)
+    } else {
+      push(data)
+    }
+
+    previousIdRef.current = pageIdentifier
+  }, [data, isLoading, pageIdentifier, previousId, push])
+}
+
+export default useDataPixel

--- a/react/hooks/usePageView.ts
+++ b/react/hooks/usePageView.ts
@@ -1,0 +1,41 @@
+/* eslint-disable no-restricted-globals */
+import { useMemo } from 'react'
+import { useRuntime, canUseDOM } from 'vtex.render-runtime'
+
+import useDataPixel from './useDataPixel'
+
+interface UsePageViewArgs {
+  title?: string
+  cacheKey?: string
+  skip?: boolean
+}
+
+export const usePageView = ({
+  title,
+  cacheKey,
+  skip,
+}: UsePageViewArgs = {}) => {
+  const { route, account } = useRuntime()
+  const pixelCacheKey = cacheKey ?? route.routeId
+
+  const eventData = useMemo(() => {
+    if (!canUseDOM || skip) {
+      return null
+    }
+
+    return {
+      event: 'pageView',
+      pageTitle: title ?? document.title,
+      pageUrl: location.href,
+      referrer:
+        document.referrer.indexOf(location.origin) === 0
+          ? undefined
+          : document.referrer,
+      accountName: account,
+      routeId: route?.routeId ? route.routeId : '',
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [account, title, canUseDOM, pixelCacheKey])
+
+  useDataPixel(skip ? null : eventData, pixelCacheKey)
+}

--- a/react/typings/vtex.pixel-manager.d.ts
+++ b/react/typings/vtex.pixel-manager.d.ts
@@ -1,0 +1,7 @@
+declare module 'vtex.pixel-manager/PixelContext' {
+  interface Pixel {
+    push(data: unknown): void
+  }
+
+  export function usePixel(): Pixel
+}

--- a/react/typings/vtex.render-runtime.d.ts
+++ b/react/typings/vtex.render-runtime.d.ts
@@ -21,4 +21,5 @@ declare module 'vtex.render-runtime' {
 
   export function useRuntime(): Runtime
   export const Helmet
+  export const canUseDOM: boolean
 }

--- a/react/utils/searchMetadata.ts
+++ b/react/utils/searchMetadata.ts
@@ -67,6 +67,49 @@ interface GetTitleTagParams {
   removeStoreNameTitle?: boolean
 }
 
+type PageEventName =
+  | 'internalSiteSearchView'
+  | 'categoryView'
+  | 'departmentView'
+  | 'emptySearchView'
+
+const mapEvent = {
+  InternalSiteSearch: 'internalSiteSearchView',
+  Category: 'categoryView',
+  Department: 'departmentView',
+  EmptySearch: 'emptySearchView',
+}
+
+const fallbackView = 'otherView'
+
+interface Variables {
+  fullText?: string
+  category?: any
+}
+
+const pageCategory = (products: unknown[], variables: Variables) => {
+  if (!products || products.length === 0) {
+    return 'EmptySearch'
+  }
+
+  const { category, fullText } = variables
+
+  return fullText ? 'InternalSiteSearch' : category ? 'Category' : 'Department'
+}
+
+export const getPageEventName = (
+  products: unknown[],
+  variables: Variables
+): PageEventName => {
+  if (!products) {
+    return fallbackView as PageEventName
+  }
+
+  const category = pageCategory(products, variables)
+
+  return (mapEvent[category] || fallbackView) as PageEventName
+}
+
 const getDecodeURIComponent = (encodedURIComponent: string) => {
   try {
     return decodeURIComponent(encodedURIComponent)
@@ -88,9 +131,9 @@ export const getTitleTag = ({
   removeStoreNameTitle,
 }: GetTitleTagParams) => {
   /*
-  titleNumber and storeTitleFormatted depend on the value of enablePageNumberTitle and removeStoreNameTitle params,
+  titleNumber and storeTitleFormatted depend on the value of enablePageNumberTitle and removeStoreNameTitle params.
   by default, the value of enablePageNumberTitle and removeStoreNameTitle is false, only if the value of these
-  parameters is true, it will affect the value of titleNumber or storeTitleFormatted
+  parameters is true, it will affect the value of titleNumber or storeTitleFormatted.
   */
   const titleNumber = pageNumber > 0 ? ` #${pageNumber}` : ''
   const storeTitleFormatted = removeStoreNameTitle ? '' : ` - ${storeTitle}`

--- a/react/utils/searchMetadata.ts
+++ b/react/utils/searchMetadata.ts
@@ -1,0 +1,255 @@
+import { zipObj } from 'ramda'
+
+interface SpecificationFilter {
+  facets?: any[]
+  hidden: boolean
+  name: string
+  quantity: number
+  type: string
+}
+
+interface CategoriesTrees {
+  id: string
+  name: string
+  selected: boolean
+  children?: CategoriesTrees[]
+}
+
+interface QueryArgs {
+  query: string
+  map: string
+}
+
+interface Facets {
+  categoriesTrees?: CategoriesTrees[]
+  queryArgs?: QueryArgs
+  specificationFilters?: SpecificationFilter[]
+}
+
+interface Breadcrumb {
+  name: string
+  href: string
+}
+
+interface SearchQueryData {
+  searchMetadata?: {
+    titleTag: string
+    metaTagDescription: string
+  }
+  productSearch?: {
+    breadcrumb: Breadcrumb[]
+    recordsFiltered: number
+    operator?: string
+    searchState?: string
+    correction?: {
+      misspelled: boolean
+    }
+  }
+  facets?: Facets
+}
+
+export interface SearchQuery {
+  loading: boolean
+  products: any
+  data?: SearchQueryData
+  variables: {
+    query: string
+    map: string
+  }
+}
+
+interface GetTitleTagParams {
+  titleTag: string
+  storeTitle: string
+  term?: string
+  pageTitle?: string
+  pageNumber?: number
+  removeStoreNameTitle?: boolean
+}
+
+const getDecodeURIComponent = (encodedURIComponent: string) => {
+  try {
+    return decodeURIComponent(encodedURIComponent)
+  } catch {
+    return encodedURIComponent
+  }
+}
+
+const capitalize = (str?: string) => {
+  return str && str.charAt(0).toUpperCase() + str.slice(1)
+}
+
+export const getTitleTag = ({
+  titleTag,
+  storeTitle,
+  term,
+  pageTitle,
+  pageNumber = 0,
+  removeStoreNameTitle,
+}: GetTitleTagParams) => {
+  /*
+  titleNumber and storeTitleFormatted depend on the value of enablePageNumberTitle and removeStoreNameTitle params,
+  by default, the value of enablePageNumberTitle and removeStoreNameTitle is false, only if the value of these
+  parameters is true, it will affect the value of titleNumber or storeTitleFormatted
+  */
+  const titleNumber = pageNumber > 0 ? ` #${pageNumber}` : ''
+  const storeTitleFormatted = removeStoreNameTitle ? '' : ` - ${storeTitle}`
+
+  if (titleTag) {
+    return `${getDecodeURIComponent(
+      titleTag
+    )}${titleNumber}${storeTitleFormatted}`
+  }
+
+  if (pageTitle) {
+    return `${getDecodeURIComponent(
+      pageTitle
+    )}${titleNumber}${storeTitleFormatted}`
+  }
+
+  if (term) {
+    return `${capitalize(
+      getDecodeURIComponent(term)
+    )}${titleNumber}${storeTitleFormatted}`
+  }
+
+  return storeTitle
+}
+
+const getDepartmentFromSpecificationFilters = (facets?: Facets) => {
+  if (!facets?.queryArgs?.map.split(',').includes('c')) {
+    return
+  }
+
+  const departmentFilter = facets.specificationFilters?.find(specFilter => {
+    return specFilter.facets?.[0].key === 'category-1'
+  })
+
+  return departmentFilter?.facets?.find(facet => facet.selected)
+}
+
+const getDepartment = (searchQuery: SearchQueryData) => {
+  if (searchQuery.facets?.categoriesTrees?.length) {
+    return searchQuery.facets.categoriesTrees.find(
+      department => department.selected
+    )
+  }
+
+  return getDepartmentFromSpecificationFilters(searchQuery.facets)
+}
+
+export const getDepartmentMetadata = (searchQuery?: SearchQueryData) => {
+  if (
+    !searchQuery ||
+    !searchQuery.facets ||
+    !searchQuery.facets.categoriesTrees
+  ) {
+    return
+  }
+
+  const department = getDepartment(searchQuery)
+
+  if (!department) {
+    return
+  }
+
+  return {
+    id: department.id,
+    name: department.name,
+  }
+}
+
+const getCategoryFromSpecificationFilters = (facets?: Facets) => {
+  const totalCategories =
+    facets?.queryArgs?.map.split(',').filter((key: string) => key === 'c')
+      .length ?? 0
+
+  if (totalCategories <= 1) {
+    return
+  }
+
+  const categoryFilter = facets?.specificationFilters?.find(specFilter => {
+    return specFilter.facets?.[0].key === 'category-2'
+  })
+
+  return categoryFilter?.facets?.find(facet => facet.selected)
+}
+
+const getLastCategory = (
+  category: CategoriesTrees,
+  facets?: Facets
+): CategoriesTrees => {
+  const selectedCategory =
+    category.children &&
+    category.children.length > 0 &&
+    category.children.find(currCategory => currCategory.selected)
+
+  if (!selectedCategory) {
+    return getCategoryFromSpecificationFilters(facets) ?? category
+  }
+
+  return getLastCategory(selectedCategory)
+}
+
+export const getCategoryMetadata = (searchQuery?: SearchQueryData) => {
+  if (
+    !searchQuery ||
+    !searchQuery.facets ||
+    !searchQuery.facets.categoriesTrees
+  ) {
+    return
+  }
+
+  const department = getDepartment(searchQuery)
+
+  if (!department) {
+    return
+  }
+
+  const category = getLastCategory(department, searchQuery.facets)
+
+  if (category === department) {
+    return
+  }
+
+  return {
+    id: category.id,
+    name: category.name,
+  }
+}
+
+export const getSearchMetadata = (searchQuery?: SearchQueryData) => {
+  if (
+    !searchQuery ||
+    !searchQuery.productSearch ||
+    !searchQuery.facets ||
+    !searchQuery.facets.queryArgs
+  ) {
+    return
+  }
+
+  const { query, map } = searchQuery.facets.queryArgs
+  const queryMap = zipObj(map.split(','), query.split('/'))
+
+  const searchTerm = queryMap.ft
+
+  let decodedTerm = ''
+
+  // This try/catch works to prevent decoding search terms that end in "%".
+  try {
+    decodedTerm = decodeURIComponent(searchTerm || '')
+  } catch (e) {
+    decodedTerm = decodeURIComponent(encodeURIComponent(searchTerm || ''))
+  }
+
+  const department = getDepartment(searchQuery)
+
+  return {
+    term: decodedTerm || undefined,
+    category: department ? { id: department.id, name: department.name } : null,
+    results: searchQuery.productSearch.recordsFiltered,
+    operator: searchQuery.productSearch.operator,
+    searchState: searchQuery.productSearch.searchState,
+    correction: searchQuery.productSearch.correction,
+  }
+}


### PR DESCRIPTION
#### What problem is this solving?

since page view events are dispatched from `SearchWrapper` and this wrapper doesn't exist on custom pages, these events weren't being dispatched on any custom pages, which was negatively impacting search relevance once the data is incorrect. so, I am adding the events in this wrapper that is used in custom search pages

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://thalyta--cea.myvtex.com/plus-size/feminino)

#### Screenshots or example usage:

[current](https://cea.myvtex.com/plus-size/feminino): only the session ping is sent

<img width="812" alt="Captura de Tela 2023-06-21 às 13 57 02" src="https://github.com/vtex-apps/search-result/assets/20840671/3c17f773-4319-44a2-8aee-82363a7750f6">

[updated](https://thalyta--cea.myvtex.com/plus-size/feminino): sending the page view event for the custom search page
<img width="831" alt="image" src="https://github.com/vtex-apps/search-result/assets/20840671/e9cefb9b-141f-43f1-af7a-5d7c7c605eab">

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
