### PR TITLE
fix: installmentCriteria not being passed down as a prop when using custom queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- installmentCriteria not being passed down as a prop in customQueries
+
 ## [3.122.5] - 2023-06-15
 
 ### Fixed

--- a/react/SearchResultLayoutCustomQuery.js
+++ b/react/SearchResultLayoutCustomQuery.js
@@ -75,6 +75,7 @@ const SearchResultLayoutCustomQuery = props => {
       hideUnavailableItems={props.querySchema.hideUnavailableItems}
       facetsBehavior={props.querySchema.facetsBehavior}
       skusFilter={props.querySchema.skusFilter}
+      installmentCriteria={props.querySchema.installmentCriteria}
       query={props.query}
       __unstableProductOriginVtex={
         props.querySchema.__unstableProductOriginVtex

--- a/react/components/LocalQuery.js
+++ b/react/components/LocalQuery.js
@@ -6,10 +6,12 @@ import SearchQuery from './SearchQuery'
 import { SORT_OPTIONS } from '../OrderBy'
 
 const DEFAULT_MAX_ITEMS_PER_PAGE = 10
+const DEFAULT_INSTALLMENT_CRITERIA = 'MAX_WITHOUT_INTEREST'
 
 const LocalQuery = props => {
   const {
     maxItemsPerPage = DEFAULT_MAX_ITEMS_PER_PAGE,
+    installmentCriteria = DEFAULT_INSTALLMENT_CRITERIA,
     queryField = '',
     mapField = '',
     priceRangeField = '',
@@ -43,6 +45,7 @@ const LocalQuery = props => {
       skusFilter={skusFilter}
       simulationBehavior={simulationBehavior}
       lazyItemsQuery={false}
+      installmentCriteria={installmentCriteria}
       __unstableProductOriginVtex={__unstableProductOriginVtex}
     >
       {(searchQuery, extraParams) => {


### PR DESCRIPTION
#### What problem is this solving?

installmentsCriteria not being passed down as props to other components when using custom query  

#### How to test it?

Go to any PLP that has products with interest in a collection, set installmentCriteria as MAX_WITH_INTEREST and it won't apply

[Workspace](https://tkt832677--lojabestoff.myvtex.com/teste3)

![image](https://github.com/vtex-apps/search-result/assets/13649073/a1cc4b3a-bfb3-46ff-9d37-7ac4f370b208)


#### Related to / Depends on

Zendesk: #838947

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/c4Nc0v0g15g9G/giphy.gif)
