### PR TITLE
Fix: clear all filters button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- "Clear all filters" button behavior when `preventRouteChange` is true
+
 ## [3.124.0] - 2023-07-03
 - Added `showFacetTitle` prop to toggle weather the facet title should appear on selected filters section
 

--- a/react/hooks/useFacetNavigation.js
+++ b/react/hooks/useFacetNavigation.js
@@ -225,8 +225,8 @@ const useFacetNavigation = (selectedFacets, scrollToTop = 'none') => {
             : searchState ?? undefined
 
         const queries = {
-          map: `${currentMap}`,
-          query: `/${currentQuery}`,
+          ...(currentMap && { map: `${currentMap}` }),
+          query: `/${isReset ? runtimeQuery.initialQuery : currentQuery}`,
           page: undefined,
           fuzzy: fullTextQuery ? fuzzy || undefined : undefined,
           operator: fullTextQuery ? operator || undefined : undefined,
@@ -251,8 +251,7 @@ const useFacetNavigation = (selectedFacets, scrollToTop = 'none') => {
       )
 
       if (
-        searchQuery &&
-        searchQuery.variables &&
+        searchQuery?.variables &&
         (!urlParams.get('initialQuery') || !urlParams.get('initialMap'))
       ) {
         const { map: mapVariable, query: queryVariable } = searchQuery.variables


### PR DESCRIPTION
#### What problem is this solving?

Clear all filters button was not working when `preventRouteChange` was set to true, due to incorrect and/or missing information being injected into the query string. This would result in the filter navigator block disappearing entirely.

This PR fixes the behavior so that the button correctly clears the selected facets.

#### How to test it?

Linked here: https://moto5179test--motorolasandbox.myvtex.com/family

Note: when the page first loads, you must click "Show Filters" to show the filter navigator.
1. Select any facet
2. Click the Clear All Filters button
3. Previously, the bug would cause the entire filter navigator block to disappear at this point. Now, it resets correctly.