### PR TITLE
Yank "enable ssr"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [3.126.1] - 2023-09-15
+### Fixed
+- Yank `3.126.1` changes
+
+## [3.126.1] - 2023-09-15 [YANKED]
 
 ### Fixed
 - Enable ssr on search-result.

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -180,6 +180,8 @@ const useQueries = (
     getSettings('vtex.store')?.enableFiltersFetchOptimization
 
   const productSearchResult = useQuery(productSearchQuery, {
+    ssr: false,
+    skip: !canUseDOM,
     variables: {
       ...variables,
       variant: getCookie('sp-variant'),


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
Some accounts have reported that after v3.126.1 their search-result
layout is breaking, we tracked to this commit and it's safe to remove
at the moment as it was just a step for another bigger commit that
was not merged still, we'll work on reverting this in the future.

This reverts commit 141ec3cd5fe2b7d93a4217a78d63b1a299d3dcea.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://supp--lukshop.myvtex.com/outlet)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->
![image](https://github.com/vtex-apps/search-result/assets/34144667/f3d85064-aea6-488a-8884-954879123296)

