### PR TITLE
Fix: sponsored products first in list instead of last

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Sponsored products are now first in the search result list.
+- While the sponsored products request is loading or returns an error, returns an empty list.
 
 ## [3.127.0] - 2023-10-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Bump `vtex.store-resources` version.
+
 ### Fixed
 
 - Sponsored products are now first in the search result list.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Sponsored products are now first in the search result list.
+
 ## [3.127.0] - 2023-10-05
 
 ### Fixed

--- a/react/SearchContent.js
+++ b/react/SearchContent.js
@@ -16,7 +16,7 @@ const SearchContent = () => {
   const sponsoredProducts =
     path(['data', 'sponsoredProducts'], searchQuery) || []
 
-  const products = searchProducts.concat(sponsoredProducts)
+  const products = sponsoredProducts.concat(searchProducts)
 
   const redirect = path(['data', 'productSearch', 'redirect'], searchQuery)
 

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -169,6 +169,21 @@ const useCorrectSearchStateVariables = (
   return result
 }
 
+const sponsoredProductsResult = (
+  sponsoredProductsLoading,
+  sponsoredProductsError,
+  sponsoredProducts
+) => {
+  const showSponsoredProducts =
+    !sponsoredProductsLoading && !sponsoredProductsError
+
+  const sponsoredProductsResponse = showSponsoredProducts
+    ? sponsoredProducts
+    : []
+
+  return sponsoredProductsResponse
+}
+
 const useQueries = (
   variables,
   facetsArgs,
@@ -188,12 +203,19 @@ const useQueries = (
     },
   })
 
-  const { data: { sponsoredProducts } = [] } = useQuery(
-    sponsoredProductsQuery,
-    {
-      variables,
-      skip: sponsoredProductsBehavior === 'skip',
-    }
+  const {
+    data: { sponsoredProducts } = [],
+    loading: sponsoredProductLoading,
+    error: sponsoredProductsError,
+  } = useQuery(sponsoredProductsQuery, {
+    variables,
+    skip: sponsoredProductsBehavior === 'skip',
+  })
+
+  const sponsoredProductsReturn = sponsoredProductsResult(
+    sponsoredProductLoading,
+    sponsoredProductsError,
+    sponsoredProducts
   )
 
   const {
@@ -285,7 +307,7 @@ const useQueries = (
         sampling: facets?.sampling,
       },
       searchMetadata,
-      sponsoredProducts,
+      sponsoredProducts: sponsoredProductsReturn,
     },
     productSearchResult,
     refetch,

--- a/react/package.json
+++ b/react/package.json
@@ -63,7 +63,7 @@
     "vtex.store-drawer": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-drawer@0.16.2/public/@types/vtex.store-drawer",
     "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.156.1/public/@types/vtex.store-graphql",
     "vtex.store-icons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.18.0/public/@types/vtex.store-icons",
-    "vtex.store-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.88.0/public/@types/vtex.store-resources",
+    "vtex.store-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.93.0/public/@types/vtex.store-resources",
     "vtex.structured-data": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.structured-data@0.9.1/public/@types/vtex.structured-data",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.3/public/@types/vtex.styleguide",
     "vtex.tab-layout": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tab-layout@0.4.3/public/@types/vtex.tab-layout"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5626,9 +5626,9 @@ validate-npm-package-license@^3.0.1:
   version "0.18.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.18.0/public/@types/vtex.store-icons#0ee94d549aa283ce3a13ab987c13eac4fdfd1bba"
 
-"vtex.store-resources@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.88.0/public/@types/vtex.store-resources":
-  version "0.88.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.88.0/public/@types/vtex.store-resources#1febd4136aa159ae8bb2f2b5cf2c45624a407ad8"
+"vtex.store-resources@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.93.0/public/@types/vtex.store-resources":
+  version "0.93.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.93.0/public/@types/vtex.store-resources#f7d82498aa2871d25df89c54f8fff2f5a7ac22f7"
 
 "vtex.structured-data@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.structured-data@0.9.1/public/@types/vtex.structured-data":
   version "0.9.1"


### PR DESCRIPTION
#### What problem is this solving?

The sponsored products were being concatenated to the organic search results instead of the inverse, causing them to be last in the list instead of first.