### PR TITLE
Fix: Clean sponsored variable while the sponsored request is beign made

### DIFF
--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -188,13 +188,21 @@ const useQueries = (
     },
   })
 
-  const { data: { sponsoredProducts } = [] } = useQuery(
+  const { data: { sponsoredProducts } = [], loading: sponsoredProductLoading } = useQuery(
     sponsoredProductsQuery,
     {
       variables,
       skip: sponsoredProductsBehavior === 'skip',
     }
   )
+
+  const sponsoredProductReturn = () => {
+    if(sponsoredProductLoading) {
+      return []
+    }
+
+    return sponsoredProducts
+  }
 
   const {
     refetch: searchRefetch,
@@ -285,7 +293,7 @@ const useQueries = (
         sampling: facets?.sampling,
       },
       searchMetadata,
-      sponsoredProducts,
+      sponsoredProducts: sponsoredProductReturn(),
     },
     productSearchResult,
     refetch,

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -169,6 +169,21 @@ const useCorrectSearchStateVariables = (
   return result
 }
 
+const sponsoredProductsResult = (
+  sponsoredProductsLoading,
+  sponsoredProductsError,
+  sponsoredProducts
+) => {
+  const showSponsoredProducts =
+    !sponsoredProductsLoading && !sponsoredProductsError
+
+  const sponsoredProductsResponse = showSponsoredProducts
+    ? sponsoredProducts
+    : []
+
+  return sponsoredProductsResponse
+}
+
 const useQueries = (
   variables,
   facetsArgs,
@@ -188,21 +203,20 @@ const useQueries = (
     },
   })
 
-  const { data: { sponsoredProducts } = [], loading: sponsoredProductLoading } = useQuery(
-    sponsoredProductsQuery,
-    {
-      variables,
-      skip: sponsoredProductsBehavior === 'skip',
-    }
+  const {
+    data: { sponsoredProducts } = [],
+    loading: sponsoredProductLoading,
+    error: sponsoredProductsError,
+  } = useQuery(sponsoredProductsQuery, {
+    variables,
+    skip: sponsoredProductsBehavior === 'skip',
+  })
+
+  const sponsoredProductsReturn = sponsoredProductsResult(
+    sponsoredProductLoading,
+    sponsoredProductsError,
+    sponsoredProducts
   )
-
-  const sponsoredProductReturn = () => {
-    if(sponsoredProductLoading) {
-      return []
-    }
-
-    return sponsoredProducts
-  }
 
   const {
     refetch: searchRefetch,
@@ -293,7 +307,7 @@ const useQueries = (
         sampling: facets?.sampling,
       },
       searchMetadata,
-      sponsoredProducts: sponsoredProductReturn(),
+      sponsoredProducts: sponsoredProductsReturn,
     },
     productSearchResult,
     refetch,


### PR DESCRIPTION
#### What problem is this solving?

When a sponsored request takes too long and there is already a page change, the older sponsored product is shown. Which means sponsored products are being shown in weird contexts.

Example:
![image](https://github.com/vtex-apps/search-result/assets/384326/f38a8e1a-027d-4b07-a536-f8ec2f8c6027)

