### PR TITLE
feat: display collapsible children only when is open

### DIFF
--- a/react/components/FilterNavigator/legacy/FilterOptionTemplate.js
+++ b/react/components/FilterNavigator/legacy/FilterOptionTemplate.js
@@ -87,7 +87,7 @@ const FilterOptionTemplate = ({
             isOpened={open}
             theme={{ content: searchResult.filterContent }}
           >
-            {renderChildren()}
+            {open && renderChildren()}
           </Collapse>
         ) : (
           renderChildren()

--- a/react/components/FilterOptionTemplate.js
+++ b/react/components/FilterOptionTemplate.js
@@ -311,7 +311,7 @@ const FilterOptionTemplate = ({
             thresholdForFacetSearch < filters.length ? (
               <SearchFilterBar name={title} handleChange={setSearchTerm} />
             ) : null}
-            {renderChildren()}
+            {isOpen && renderChildren()}
           </Collapse>
         ) : (
           renderChildren()


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
Os descendentes focalizáveis dentro de um elemento `[aria-hidden="true"]` impedem que esses elementos interativos sejam disponibilizados para usuários de tecnologias adaptativas, por exemplo, leitores de tela. [Aprenda como o elemento aria-hidden afeta elementos focalizáveis](https://dequeuniversity.com/rules/axe/4.7/aria-hidden-focus).
Foi adicionando a validação `isOpen` para exibir os children do filterItem a fim de solucionar o problema de acessibilidade apontado pelo Lighthouse.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://www.samsclub.com.br/vinhos?workspace=accessibilityplp)

Executar teste no Lighthouse ou PageSpeed.

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->
Antes da edição:
![image](https://github.com/vtex-apps/search-result/assets/12280996/3d32bf44-0097-4a59-bd5b-7598a6be35d0)

Depois (deixou de ser acusado pelo Lighthouse):
![image](https://github.com/vtex-apps/search-result/assets/12280996/1c137ed6-2a90-4876-b561-28418b2885f0)


