### PR TITLE
feat: add gallery elementToScrollTo behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### changed
 - Behavior `scrollToElement` added to Gallery component for PLP.
-- `lazyItemsRemaining` removed in Gallery component and GalleryLayout. `lazyRender` removed in GalleryLayoutRow component.
 
 ### Changed
 - Bump `vtex.store-resources` version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [3.127.1] - 2023-10-24
 
+### changed
+- Behavior `scrollToElement` added to Gallery component for PLP.
+- `lazyItemsRemaining` removed in Gallery component and GalleryLayout. `lazyRender` removed in GalleryLayoutRow component.
+
 ### Changed
 - Bump `vtex.store-resources` version.
 

--- a/react/Gallery.tsx
+++ b/react/Gallery.tsx
@@ -16,8 +16,15 @@ type GalleryLayoutPropsWithSlots = Omit<GalleryLayoutProps, 'slots'> & Slots
 const Gallery: React.FC<
   GalleryLegacyProps | GalleryLayoutPropsWithSlots
 > = props => {
-  const { layouts, products, showingFacets, summary, preferredSKU, ...slots } =
-    props as GalleryLayoutPropsWithSlots
+  const {
+    layouts,
+    lazyItemsRemaining,
+    products,
+    showingFacets,
+    summary,
+    preferredSKU,
+    ...slots
+  } = props as GalleryLayoutPropsWithSlots
 
   useEffect(() => {
     const lastClickedProductId = localStorage.getItem('lastClickedProductId')
@@ -66,6 +73,7 @@ const Gallery: React.FC<
         <ProductListStructuredData products={products} />
         <GalleryLayout
           layouts={layouts}
+          lazyItemsRemaining={lazyItemsRemaining}
           products={products}
           showingFacets={showingFacets}
           summary={summary}

--- a/react/GalleryLayout.tsx
+++ b/react/GalleryLayout.tsx
@@ -2,11 +2,9 @@ import React, { useContext, useEffect, useMemo } from 'react'
 import type { ComponentType } from 'react'
 import classNames from 'classnames'
 import { ProductListContext } from 'vtex.product-list-context'
-import { Spinner } from 'vtex.styleguide'
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 import { useResponsiveValue } from 'vtex.responsive-values'
 import type { MaybeResponsiveInput } from 'vtex.responsive-values'
-import { useRuntime } from 'vtex.render-runtime'
 import { SearchPageContext } from 'vtex.search-page-context'
 
 import GalleryLayoutRow from './components/GalleryLayoutRow'
@@ -19,8 +17,6 @@ import {
 } from './constants'
 import { useBreadcrumb } from './hooks/useBreadcrumb'
 import { useSearchTitle } from './hooks/useSearchTitle'
-
-const LAZY_RENDER_THRESHOLD = 2
 
 const CSS_HANDLES = ['gallery'] as const
 
@@ -37,7 +33,6 @@ export type Slots = Record<string, ComponentType>
 
 export interface GalleryLayoutProps {
   layouts: LayoutOption[]
-  lazyItemsRemaining: number
   products: Product[]
   showingFacets: boolean
   summary: unknown
@@ -54,7 +49,6 @@ export type PreferredSKU =
 
 const GalleryLayout: React.FC<GalleryLayoutProps> = ({
   layouts,
-  lazyItemsRemaining,
   products,
   showingFacets,
   summary,
@@ -63,7 +57,6 @@ const GalleryLayout: React.FC<GalleryLayoutProps> = ({
 }) => {
   const { trackingId } = useContext(SettingsContext) || {}
   const handles = useCssHandles(CSS_HANDLES)
-  const { getSettings } = useRuntime()
   const { selectedGalleryLayout } = useSearchPageState()
   const searchPageStateDispatch = useSearchPageStateDispatch()
 
@@ -148,9 +141,6 @@ const GalleryLayout: React.FC<GalleryLayoutProps> = ({
     }
   )
 
-  const isLazyRenderEnabled =
-    getSettings('vtex.store')?.enableSearchRenderingOptimization
-
   return (
     <ProductListProvider listName={listName as string}>
       <div id="gallery-layout-container" className={galleryClasses}>
@@ -158,7 +148,6 @@ const GalleryLayout: React.FC<GalleryLayoutProps> = ({
           <GalleryLayoutRow
             key={`${currentLayoutOption.name}-${index}`}
             products={rowProducts}
-            lazyRender={!!isLazyRenderEnabled && index >= LAZY_RENDER_THRESHOLD}
             summary={summary}
             displayMode="normal"
             itemsPerRow={itemsPerRow}
@@ -169,18 +158,6 @@ const GalleryLayout: React.FC<GalleryLayoutProps> = ({
             GalleryItemComponent={slots[currentLayoutOption.component]}
           />
         ))}
-        {typeof lazyItemsRemaining === 'number' && lazyItemsRemaining > 0 && (
-          <div
-            style={{
-              width: '100%',
-              // Approximate number, just to add scroll leeway
-              height: 300 * Math.ceil(lazyItemsRemaining / itemsPerRow),
-            }}
-            className="flex justify-center pt10"
-          >
-            <Spinner />
-          </div>
-        )}
       </div>
       <ProductListEventCaller />
     </ProductListProvider>

--- a/react/components/GalleryLayoutItem.tsx
+++ b/react/components/GalleryLayoutItem.tsx
@@ -44,6 +44,7 @@ const GalleryLayoutItem: React.FC<GalleryLayoutItemProps> = ({
       position,
       list: listName,
     })
+    localStorage.setItem('lastClickedProductId', product.productId)
   }, [
     product,
     push,

--- a/react/components/GalleryLayoutRow.tsx
+++ b/react/components/GalleryLayoutRow.tsx
@@ -15,6 +15,7 @@ interface GalleryLayoutRowProps {
   displayMode: string
   GalleryItemComponent: ComponentType
   itemsPerRow: number
+  lazyRender: boolean
   products: Product[]
   summary: unknown
   rowIndex: number
@@ -27,6 +28,7 @@ const GalleryLayoutRow: React.FC<GalleryLayoutRowProps> = ({
   GalleryItemComponent,
   displayMode,
   itemsPerRow,
+  lazyRender,
   products,
   summary,
   currentLayoutName,
@@ -42,6 +44,7 @@ const GalleryLayoutRow: React.FC<GalleryLayoutRowProps> = ({
   }
 
   const { hasBeenViewed, dummyElement } = useRenderOnView({
+    lazyRender,
     offset: 900,
   })
 

--- a/react/components/GalleryLayoutRow.tsx
+++ b/react/components/GalleryLayoutRow.tsx
@@ -15,7 +15,6 @@ interface GalleryLayoutRowProps {
   displayMode: string
   GalleryItemComponent: ComponentType
   itemsPerRow: number
-  lazyRender: boolean
   products: Product[]
   summary: unknown
   rowIndex: number
@@ -28,7 +27,6 @@ const GalleryLayoutRow: React.FC<GalleryLayoutRowProps> = ({
   GalleryItemComponent,
   displayMode,
   itemsPerRow,
-  lazyRender,
   products,
   summary,
   currentLayoutName,
@@ -44,7 +42,6 @@ const GalleryLayoutRow: React.FC<GalleryLayoutRowProps> = ({
   }
 
   const { hasBeenViewed, dummyElement } = useRenderOnView({
-    lazyRender,
     offset: 900,
   })
 
@@ -68,6 +65,7 @@ const GalleryLayoutRow: React.FC<GalleryLayoutRowProps> = ({
               ]),
               'pa4'
             )}
+            id={product.productId}
           >
             <GalleryItem
               GalleryItemComponent={GalleryItemComponent}


### PR DESCRIPTION
#### What problem is this solving?

The change made involves adding the 'scrollToElement' behavior to the Gallery component, removing the prop 'lazyItemsRemaining' in both the Gallery component and GalleryLayout. Additionally, 'lazyRender' has been removed from the GalleryLayoutRow component. This modification addresses a request wherein, when a user is in the PLP and clicks on a product to move to the PDP, then returns to the PLP, the user remains at the initial position. This ensures that the user does not need to scroll to find the position they were in before navigating to the PDP.

#### How to test it?

This behavior can be tested at: https://renwtesting--renwil.myvtex.com 

#### Screenshots or example usage:

![elementToScrollTo](https://github.com/vtex-apps/search-result/assets/97756584/c5c60f21-50c6-4a78-8c8b-e3d8851a3a13)

#### Related to / Depends on

It is important to mention that the removal of lazyRender and lazyItemsRemaining from the initially mentioned components is due to the need to position the scroll in the PLP at the correct location where the user was before moving to the PDP. An ID is assigned to each item (GalleryLayoutRow component) for this purpose. This ID is captured during the click event to the PDP and retrieved upon returning to the PLP to locate the corresponding ID and scroll to that position. Therefore, it is necessary for these IDs to have already loaded; otherwise, the ID won't be found until manual scrolling is performed. Hence, the removal of lazy rendering.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/CjmvTCZf2U3p09Cn0h/giphy.gif?cid=82a1493bzi3k5df5a75xp5g7tnlx6iwj7pn1gzn5yuyqouom&ep=v1_gifs_trending&rid=giphy.gif&ct=g)
