### PR TITLE
Feature: use settings to determine whether or not to fetch ads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Use the advanced setting `fetchSponsoredProductsOnSearch` to determine whether or not to fetch sponsored products.
+
 ## [3.127.1] - 2023-10-24
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "3.128.0-beta.1",
+  "version": "3.127.1",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "3.128.0-beta.0",
+  "version": "3.128.0-beta.1",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/manifest.json
+++ b/manifest.json
@@ -1,13 +1,11 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "3.127.1",
+  "version": "3.128.0-beta.0",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "scripts": {
     "postreleasy": "vtex publish --verbose"
   },

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,9 @@
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",
-  "registries": ["smartcheckout"],
+  "registries": [
+    "smartcheckout"
+  ],
   "scripts": {
     "postreleasy": "vtex publish --verbose"
   },

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -169,6 +169,12 @@ const useCorrectSearchStateVariables = (
   return result
 }
 
+const skipSponsoredProducts = ({ sponsoredProductsBehavior, settings }) => {
+  const fetchSponsoredProductsConfig = settings?.fetchSponsoredProductsOnSearch
+
+  return !fetchSponsoredProductsConfig && sponsoredProductsBehavior === 'skip'
+}
+
 const sponsoredProductsResult = (
   sponsoredProductsLoading,
   sponsoredProductsError,
@@ -191,8 +197,9 @@ const useQueries = (
   sponsoredProductsBehavior = 'skip'
 ) => {
   const { getSettings, query: runtimeQuery } = useRuntime()
-  const isLazyFacetsFetchEnabled =
-    getSettings('vtex.store')?.enableFiltersFetchOptimization
+  const settings = getSettings('vtex.store')
+
+  const isLazyFacetsFetchEnabled = settings?.enableFiltersFetchOptimization
 
   const productSearchResult = useQuery(productSearchQuery, {
     ssr: false,
@@ -209,7 +216,7 @@ const useQueries = (
     error: sponsoredProductsError,
   } = useQuery(sponsoredProductsQuery, {
     variables,
-    skip: sponsoredProductsBehavior === 'skip',
+    skip: skipSponsoredProducts({ sponsoredProductsBehavior, settings }),
   })
 
   const sponsoredProductsReturn = sponsoredProductsResult(

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -13,6 +13,7 @@ import {
   detachFiltersByType,
   buildQueryArgsFromSelectedFacets,
 } from '../utils/compatibilityLayer'
+import shouldSkipSponsoredProducts from '../utils/shouldSkipSponsoredProducts'
 import { FACETS_RENDER_THRESHOLD } from '../constants/filterConstants'
 import useRedirect from '../hooks/useRedirect'
 import useSession from '../hooks/useSession'
@@ -169,12 +170,6 @@ const useCorrectSearchStateVariables = (
   return result
 }
 
-const skipSponsoredProducts = ({ sponsoredProductsBehavior, settings }) => {
-  const fetchSponsoredProductsConfig = settings?.fetchSponsoredProductsOnSearch
-
-  return !fetchSponsoredProductsConfig && sponsoredProductsBehavior === 'skip'
-}
-
 const sponsoredProductsResult = (
   sponsoredProductsLoading,
   sponsoredProductsError,
@@ -216,7 +211,7 @@ const useQueries = (
     error: sponsoredProductsError,
   } = useQuery(sponsoredProductsQuery, {
     variables,
-    skip: skipSponsoredProducts({ sponsoredProductsBehavior, settings }),
+    skip: shouldSkipSponsoredProducts(sponsoredProductsBehavior, settings),
   })
 
   const sponsoredProductsReturn = sponsoredProductsResult(

--- a/react/utils/shouldSkipSponsoredProducts.ts
+++ b/react/utils/shouldSkipSponsoredProducts.ts
@@ -1,0 +1,23 @@
+type SponsoredProductsBehavior = 'skip' | string
+
+type Settings = {
+  fetchSponsoredProductsOnSearch: boolean
+} & Record<string, unknown>
+
+/**
+ * This function checks the store's settings, as well as the passed value of
+ * `sponsoredProductsBehavior` passed in the store-theme, to determine if the
+ * sponsored products request should be skipped or not.
+ * Some accounts may not have configured the store's settings, so we need to check if the
+ * `sponsoredProductsBehavior` parameter for compatibility.
+ */
+const shouldSkipSponsoredProducts = (
+  sponsoredProductsBehavior: SponsoredProductsBehavior,
+  settings: Settings
+) => {
+  const fetchSponsoredProductsConfig = settings?.fetchSponsoredProductsOnSearch
+
+  return !fetchSponsoredProductsConfig && sponsoredProductsBehavior === 'skip'
+}
+
+export default shouldSkipSponsoredProducts


### PR DESCRIPTION
#### What problem is this solving?

In order to stop requiring changes to the store theme for fetching ads, we now use the setting `fetchSponsoredProductsOnSearch`.

#### How to test it?

Use the workspace below and log `window.__RUNTIME__.settings['vtex.store']` in your console. You should find the setting `fetchSponsoredProductsOnSearch`.

[Workspace](https://oneclickads--sjdigital.myvtex.com/cotonete?_q=cotonete&map=ft)

#### Screenshots or example usage:

![image](https://github.com/vtex-apps/search-result/assets/15937541/34e9a0ec-92eb-4310-916e-db76d8c7bda4)

#### Related to / Depends on

Depends on:
- [ ] https://github.com/vtex-apps/admin-pages/pull/456
- [ ] https://github.com/vtex-apps/store/pull/581
