### PR TITLE
Add `anonymousId` query argument for A/B testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Created query parameter `anonymousId` for `sponsoredProducts` used on A/B testing.
+
 ## [3.128.2] - 2023-12-07
 
 ### Added

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -208,7 +208,10 @@ const useQueries = (
     loading: sponsoredProductLoading,
     error: sponsoredProductsError,
   } = useQuery(sponsoredProductsQuery, {
-    variables,
+    variables: {
+      ...variables,
+      anonymousId: getCookie('biggy-anonymous'),
+    },
     skip: shouldSkipSponsoredProducts(sponsoredProductsBehavior, settings),
   })
 


### PR DESCRIPTION
#### What problem is this solving?

We need to integrate A/B testing via Osiris. So we need to include the argument `anonymousId` on `sponsoredProducts` query.

#### How to test it?

After searching for a sponsored item, the anoymousId should be sent. This can be verified by inspecting the payload in vtex.search-resolver.

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
