### PR TITLE
Fix search-result ssr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Search result ssr
+
 ## [3.128.0] - 2023-11-28
 
 ### Added

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -20,7 +20,7 @@ import useSession from '../hooks/useSession'
 
 function getCookie(cname) {
   if (!canUseDOM) {
-    return null
+    return undefined
   }
 
   const name = `${cname}=`
@@ -39,7 +39,7 @@ function getCookie(cname) {
     }
   }
 
-  return ''
+  return undefined
 }
 
 const DEFAULT_PAGE = 1
@@ -197,8 +197,6 @@ const useQueries = (
   const isLazyFacetsFetchEnabled = settings?.enableFiltersFetchOptimization
 
   const productSearchResult = useQuery(productSearchQuery, {
-    ssr: false,
-    skip: !canUseDOM,
     variables: {
       ...variables,
       variant: getCookie('sp-variant'),


### PR DESCRIPTION
#### What problem is this solving?

#639  removed the `ssr:false` flag from the search-result that was accidentally placed after deploying the AB feature.
This PR had to be deprecated due to layout shift issues

What we didn't know is that the variant variable was obtaining different results between SSR and CSR. In SSR the value for this variable is `null`, but for CSR, when the sp-variant cookie does not exist, the result was an empty string

This PR removes the ssr:false flag again and corrects the divergence in the variant variable.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://hiago--storecomponents.myvtex.com/apparel---accessories/)
You can disable the javaspcript from you browser in order to check the ssr rendered page.
On chrome: Open dev-tools> press cmd+shift+p > type "disable javascript"

#### Screenshots or example usage:

Before:
![Captura de Tela 2023-12-07 às 12 12 39](https://github.com/vtex-apps/search-result/assets/40380674/bd1fefb5-9cd1-4668-a1be-312b7ee13379)


Affter:

![Captura de Tela 2023-12-07 às 12 12 02](https://github.com/vtex-apps/search-result/assets/40380674/1f26b362-74fa-402a-9dea-8216f7c81aeb)
