### PR TITLE
Chore: updates the Intelligent Search teams on CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-* @vtex-apps/store-framework-devs @vtex-apps/search-engagement-team
+* @vtex-apps/store-framework-devs @vtex-apps/intelligent-search-apps
 docs/ @vtex-apps/technical-writers
 messages/ @vtex-apps/localization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Updates `@vtex-apps/search-engagement-team` to `@vtex-apps/intelligent-search-apps` on CODEOWNERS.
+
 ## [3.128.1] - 2023-12-07
 
 ### Fixed


### PR DESCRIPTION
#### What problem is this solving?
The `@vtex-apps/search-engagement-team` was updated to `@vtex-apps/intelligent-search-apps`. This PR fixes the issue on CODEOWNERS.