### PR TITLE
fix: decreasing timer to be able to scroll down the category

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
-  "vendor": "aleatory",
-  "version": "3.129.6",
+  "vendor": "vtex",
+  "version": "3.129.5",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/manifest.json
+++ b/manifest.json
@@ -1,13 +1,11 @@
 {
   "name": "search-result",
-  "vendor": "vtex",
-  "version": "3.129.5",
+  "vendor": "aleatory",
+  "version": "3.129.6",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "scripts": {
     "postreleasy": "vtex publish --verbose"
   },

--- a/react/Gallery.tsx
+++ b/react/Gallery.tsx
@@ -1,8 +1,8 @@
 import React, { Fragment, useEffect } from 'react'
 import { ProductList as ProductListStructuredData } from 'vtex.structured-data'
 
-import GalleryLayout from './GalleryLayout'
 import type { GalleryLayoutProps, Slots } from './GalleryLayout'
+import GalleryLayout from './GalleryLayout'
 import type { GalleryProps as GalleryLegacyProps } from './GalleryLegacy'
 import GalleryLegacy from './GalleryLegacy'
 
@@ -50,7 +50,7 @@ const Gallery: React.FC<
 
             setTimeout(() => {
               scrollToElement(elementId, offset)
-            }, 500)
+            }, 50)
           }
         }
       }
@@ -62,7 +62,7 @@ const Gallery: React.FC<
       }
 
       recursiveScroll()
-    }, 1000)
+    }, 50)
 
     return () => clearTimeout(delayedExecution)
   }, [])

--- a/react/Gallery.tsx
+++ b/react/Gallery.tsx
@@ -28,10 +28,9 @@ const Gallery: React.FC<
 
   useEffect(() => {
     const lastClickedProductId = localStorage.getItem('lastClickedProductId')
-    const isMobile = window.innerWidth <= 768
 
     const delayedExecution = setTimeout(() => {
-      const scrollToElement = (elementId: string, offset: number) => {
+      const scrollToElement = (elementId: string, _: number) => {
         const elementToScrollTo = document.getElementById(elementId)
 
         if (elementToScrollTo) {
@@ -47,17 +46,13 @@ const Gallery: React.FC<
               block: 'center',
               inline: 'nearest',
             })
-
-            setTimeout(() => {
-              scrollToElement(elementId, offset)
-            }, 50)
           }
         }
       }
 
       const recursiveScroll = () => {
         if (lastClickedProductId) {
-          scrollToElement(lastClickedProductId, isMobile ? -200 : -200)
+          scrollToElement(lastClickedProductId, -200)
         }
       }
 


### PR DESCRIPTION
#### What problem is this solving?

Bugfix: Scroll down after clicking a product and go back to category.

The issue manifests when attempting to scroll through a category page immediately after clicking on a product within that category and then navigating back to the category page. We've received reports from several stores highlighting this bug and its adverse effects on the overall user experience within the store. 

#### Screenshots or example usage:

[Video showing the bug](https://www.loom.com/share/d174009905834a829d13fd051ac52559?sid=98d2c9a2-2023-4b85-a1f8-dacdb371ea6f)

