### PR TITLE
Removing invalid function from compatibilityLAyer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Removing invalid function from compatibilityLAyer
+
 ## [3.129.5] - 2024-02-02
 
 ### Added

--- a/react/utils/compatibilityLayer.js
+++ b/react/utils/compatibilityLayer.js
@@ -53,21 +53,9 @@ export const buildSelectedFacetsAndFullText = (query, map, priceRange) => {
   return [selectedFacets, fullText]
 }
 
-const addMap = facet => {
-  facet.map = facet.key
-
-  if (facet.children) {
-    facet.children.forEach(facetChild => addMap(facetChild))
-  }
-}
-
 export const detachFiltersByType = facets => {
-  facets.forEach(facet => facet.facets.forEach(value => addMap(value)))
-
   const byType = groupBy(filter => filter.type)
-
   const groupedFilters = byType(facets)
-
   const brands = pathOr([], ['BRAND', 0, 'facets'], groupedFilters)
   const brandsQuantity =
     groupedFilters &&


### PR DESCRIPTION
#### What problem is this solving?
This function tries to set a read-only property with a piece of information that is already provided.

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Try using tablet mode](https://jamal--ewne.myvtex.com/easy?_q=easy&map=ft)

#### Screenshots or example usage:
<img width="1108" alt="image" src="https://github.com/vtex-apps/search-result/assets/24723/942f34d3-efd4-4f32-a508-5226427c1bc9">
<img width="1108" alt="image" src="https://github.com/vtex-apps/search-result/assets/24723/e9f6c7b4-9727-46dd-859d-fb58348cb144">

<!--- Add some images or gifs to showcase changes in behavior or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

Spreading the `facet` stops the error but is still useless since the function doesn't make any difference.
