### PR TITLE
Avoiding error with reserved names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Returning the original function to map facets but now using dynamic key to avoid the "reserved words" error
+
+## [3.129.6] - 2024-02-23
+
+### Fixed
+- Removing invalid function from compatibilityLAyer
+
 ## [3.129.5] - 2024-02-02
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "3.129.5",
+  "version": "3.129.6",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/utils/compatibilityLayer.js
+++ b/react/utils/compatibilityLayer.js
@@ -54,7 +54,7 @@ export const buildSelectedFacetsAndFullText = (query, map, priceRange) => {
 }
 
 const addMap = facet => {
-  facet.map = facet.key
+  facet['map'] = facet.key
 
   if (facet.children) {
     facet.children.forEach(facetChild => addMap(facetChild))


### PR DESCRIPTION
#### What problem is this solving?
Error saving `facet.map` due to reserved word

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->
Use filters

[Regular navigation](https://garrucho--elektra.myvtex.com/electronica/tv-y-video/drones?map=c,c,c)

[Using tablet](https://jamal--ewne.myvtex.com/easy?_q=easy&map=ft)

#### Screenshots or example usage:
Error 
![image](https://github.com/vtex-apps/search-result/assets/24723/ac19547f-2c17-47d2-8df7-6df4a8364f0a)

<!--- Add some images or gifs to showcase changes in behavior or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

The first alternative was to remove the function completely since the object already contained the map property during tests, but it turns out that in a few scenarios, this is not true.

<!--- Optional -->
