### PR TITLE
Release new version with Hungarian translation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Hungarian translations.
+- Hungarian translations
 
 ## [3.132.0] - 2024-05-06
 


### PR DESCRIPTION
#### What problem is this solving?

I merged #665 with manual version control thinking I would be able to recreate the same `v3.132.0` version again, but there are some restrictions in place that prohibit pushes to master without PR. Creating this only to deploy a new version easily.
