### PR TITLE
Feature: pass placement to product summary and query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Pass `placement` to product search query and product-summary.
+
 ## [3.132.2] - 2024-05-20
 
 ### Fixed

--- a/react/components/GalleryLayoutItem.tsx
+++ b/react/components/GalleryLayoutItem.tsx
@@ -3,7 +3,6 @@ import React, { memo, useCallback, useMemo } from 'react'
 import { usePixel } from 'vtex.pixel-manager'
 import ProductSummary from 'vtex.product-summary/ProductSummaryCustom'
 import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
-import { useRuntime } from 'vtex.render-runtime'
 
 import type { Product } from '../Gallery'
 import type { PreferredSKU } from '../GalleryLayout'
@@ -30,9 +29,6 @@ const GalleryLayoutItem: React.FC<GalleryLayoutItemProps> = ({
 }) => {
   const { push } = usePixel()
   const { searchQuery } = useSearchPage()
-  const {
-    route: { routeId },
-  } = useRuntime()
 
   const product = useMemo(
     () => ProductSummary.mapCatalogProductToProductSummary(item, preferredSKU),
@@ -65,7 +61,6 @@ const GalleryLayoutItem: React.FC<GalleryLayoutItemProps> = ({
       actionOnClick={handleClick}
       listName={listName}
       position={position}
-      placement={routeId}
     />
   )
 }

--- a/react/components/GalleryLayoutItem.tsx
+++ b/react/components/GalleryLayoutItem.tsx
@@ -1,8 +1,9 @@
 import type { ComponentType } from 'react'
-import React, { useMemo, useCallback, memo } from 'react'
-import ProductSummary from 'vtex.product-summary/ProductSummaryCustom'
+import React, { memo, useCallback, useMemo } from 'react'
 import { usePixel } from 'vtex.pixel-manager'
+import ProductSummary from 'vtex.product-summary/ProductSummaryCustom'
 import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
+import { useRuntime } from 'vtex.render-runtime'
 
 import type { Product } from '../Gallery'
 import type { PreferredSKU } from '../GalleryLayout'
@@ -29,6 +30,9 @@ const GalleryLayoutItem: React.FC<GalleryLayoutItemProps> = ({
 }) => {
   const { push } = usePixel()
   const { searchQuery } = useSearchPage()
+  const {
+    route: { routeId },
+  } = useRuntime()
 
   const product = useMemo(
     () => ProductSummary.mapCatalogProductToProductSummary(item, preferredSKU),
@@ -61,6 +65,7 @@ const GalleryLayoutItem: React.FC<GalleryLayoutItemProps> = ({
       actionOnClick={handleClick}
       listName={listName}
       position={position}
+      placement={routeId}
     />
   )
 }

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -1,20 +1,20 @@
-import { useMemo, useRef, useCallback, useEffect, useState } from 'react'
+import { canUseDOM } from 'exenv'
+import { equals } from 'ramda'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useQuery } from 'react-apollo'
 import { useRuntime } from 'vtex.render-runtime'
+import facetsQuery from 'vtex.store-resources/QueryFacetsV2'
 import productSearchQuery from 'vtex.store-resources/QueryProductSearchV3'
 import searchMetadataQuery from 'vtex.store-resources/QuerySearchMetadataV2'
-import facetsQuery from 'vtex.store-resources/QueryFacetsV2'
-import { equals } from 'ramda'
-import { canUseDOM } from 'exenv'
 
-import {
-  buildSelectedFacetsAndFullText,
-  detachFiltersByType,
-  buildQueryArgsFromSelectedFacets,
-} from '../utils/compatibilityLayer'
 import { FACETS_RENDER_THRESHOLD } from '../constants/filterConstants'
 import useRedirect from '../hooks/useRedirect'
 import useSession from '../hooks/useSession'
+import {
+  buildQueryArgsFromSelectedFacets,
+  buildSelectedFacetsAndFullText,
+  detachFiltersByType,
+} from '../utils/compatibilityLayer'
 
 function getCookie(cname) {
   if (!canUseDOM) {
@@ -169,7 +169,12 @@ const useCorrectSearchStateVariables = (
 }
 
 const useQueries = (variables, facetsArgs, price) => {
-  const { getSettings, query: runtimeQuery } = useRuntime()
+  const {
+    getSettings,
+    query: runtimeQuery,
+    route: { routeId },
+  } = useRuntime()
+
   const settings = getSettings('vtex.store')
 
   const isLazyFacetsFetchEnabled = settings?.enableFiltersFetchOptimization
@@ -177,8 +182,13 @@ const useQueries = (variables, facetsArgs, price) => {
   const productSearchResult = useQuery(productSearchQuery, {
     variables: {
       ...variables,
-      showSponsored: true,
       variant: getCookie('sp-variant'),
+      advertisementOptions: {
+        showSponsored: true,
+        sponsoredCount: 3,
+        advertisementPlacement: routeId,
+        repeatSponsoredProducts: true,
+      },
     },
   })
 

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -169,11 +169,7 @@ const useCorrectSearchStateVariables = (
 }
 
 const useQueries = (variables, facetsArgs, price) => {
-  const {
-    getSettings,
-    query: runtimeQuery,
-    route: { routeId },
-  } = useRuntime()
+  const { getSettings, query: runtimeQuery } = useRuntime()
 
   const settings = getSettings('vtex.store')
 
@@ -186,7 +182,7 @@ const useQueries = (variables, facetsArgs, price) => {
       advertisementOptions: {
         showSponsored: true,
         sponsoredCount: 3,
-        advertisementPlacement: routeId,
+        advertisementPlacement: 'top_search',
         repeatSponsoredProducts: true,
       },
     },


### PR DESCRIPTION
#### What problem is this solving?

This is optional, but since I'm update the query for `products`, I'm updating how we call `productSearch` as well.

I'm using `routeId` for placement, which should translate to something like `search#departments` or simply `search`.