### PR TITLE
fix: duplicated structured data in product search context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Duplicated structured data in product search context
+
 ## [3.133.0] - 2024-08-01
 
 ### Added

--- a/react/Gallery.tsx
+++ b/react/Gallery.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react'
 import { ProductList as ProductListStructuredData } from 'vtex.structured-data'
+import { useRuntime } from 'vtex.render-runtime'
 
 import GalleryLayout from './GalleryLayout'
 import type { GalleryLayoutProps, Slots } from './GalleryLayout'
@@ -16,6 +17,10 @@ type GalleryLayoutPropsWithSlots = Omit<GalleryLayoutProps, 'slots'> & Slots
 const Gallery: React.FC<
   GalleryLegacyProps | GalleryLayoutPropsWithSlots
 > = props => {
+  const {
+    route: { routeId },
+  } = useRuntime()
+
   if ('layouts' in props && props.layouts.length > 0) {
     const {
       layouts,
@@ -29,7 +34,9 @@ const Gallery: React.FC<
 
     return (
       <Fragment>
-        <ProductListStructuredData products={products} />
+        {!routeId.includes('store.search') && (
+          <ProductListStructuredData products={products} />
+        )}
         <GalleryLayout
           layouts={layouts}
           lazyItemsRemaining={lazyItemsRemaining}


### PR DESCRIPTION
### What problem is this solving?

This commit has the intention to fix the duplicated array of itemList in structured data , that occurs on PLP pages. Google rich result is complaining about this duplicated node element causing some crawling issues

We found out that there are two occurrences of ProductListStructuredData in the same PLP.
The [SearchWrapper](https://github.com/vtex-apps/store/blob/96b16702d2ff78291b3f53224504dcbd9803959d/react/SearchWrapper.tsx#L450) element from `vtex-apps/store` is responsible for the first. `Gallery` and `vtex.search-result` is responsible for [the other](https://github.com/vtex-apps/search-result/blob/600e4a9c0f4761f940867ff5846ae21121da6d1d/react/Gallery.tsx#L32) 

What happens is that when in search context we add the structured data, and, in search context, we also use gallery, which is also adding the structured data.

The main purpose is to check if the block is under the context of store.search to check if it's going to add the structured data element or not

This PR simply adds this validation to understand in which context the gallery is being used to avoid duplicated node content


### How to test it?

[Before](https://storetheme.vtex.com/apparel---accessories/)

**Steps to reproduce:**

* Open the link above
* Open DevTools
* Go to Elements tab
* Search (cmd+f) for the following string: `{"@context":"https://schema.org","@type":"ItemList","itemListElement"`

**Expected Behavior:**

* You should find two occurrences of this string
* The content of the Structured JSON that starts with the searched string must be the same (duplicates)
![image](https://github.com/user-attachments/assets/99d6b5d2-1874-47bc-96d6-8a80d547c7bc)


[After](iespinoza--storecomponents.myvtex.com/apparel---accessories/)

**Steps to reproduce:**

* Open the link above
* Open DevTools
* Go to Elements tab
* Search (cmd+f) for the following string: `{"@context":"https://schema.org","@type":"ItemList","itemListElement"`

**Expected Behavior:**

* You should find only one occurrence of this string. 
  * The first occurrence in the HTML, from the `SearchWrapper` component
  
![image](https://github.com/user-attachments/assets/9882ada9-9e92-4779-9dac-0bb4bfa129bf)


#### Describe alternatives you've considered, if any.

We adopted this approach instead of removing it from store.search the gallery component just to be safe, avoiding any undesired behavior since we don't know exactly the side effects that this might cause


### How does this PR make you feel?

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExOHN6dHR3bTQwaXBremUybGMzd2Noenhydm53MHJubXRkcTZjanQ4ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/mc7uduXz800wtqU7WV/giphy.gif)
