### PR TITLE
fix: default facets

### DIFF
--- a/react/SearchResultFlexible.js
+++ b/react/SearchResultFlexible.js
@@ -95,7 +95,7 @@ const SearchResultFlexible = ({
         brandsQuantity,
         hiddenFacets,
         deliveries,
-        showShippingFacet
+        showShippingFacet,
       }),
     [
       brands,
@@ -104,6 +104,7 @@ const SearchResultFlexible = ({
       specificationFilters,
       brandsQuantity,
       deliveries,
+      showShippingFacet,
     ]
   )
 

--- a/react/utils/compatibilityLayer.js
+++ b/react/utils/compatibilityLayer.js
@@ -96,7 +96,7 @@ export const detachFiltersByType = facets => {
     groupedFilters.TEXT || []
   )
 
-  const deliveries = getFormattedDeliveries(groupedFilters.DELIVERY || [], true)
+  const deliveries = getFormattedDeliveries(groupedFilters.DELIVERY || [])
 
   const categoriesTrees = pathOr(
     [],
@@ -137,11 +137,7 @@ export const buildQueryArgsFromSelectedFacets = selectedFacets => {
   )
 }
 
-const getFormattedDeliveries = (deliveries, showShippingFacet) => {
-  if (!showShippingFacet) {
-    return deliveries.filter(d => d.name !== SHIPPING_KEY)
-  }
-
+const getFormattedDeliveries = deliveries => {
   const shippingFacet = deliveries.find(d => d.name === SHIPPING_KEY)
 
   if (!shippingFacet) {

--- a/react/utils/compatibilityLayer.js
+++ b/react/utils/compatibilityLayer.js
@@ -2,6 +2,23 @@
 import { groupBy, pathOr, zipObj } from 'ramda'
 
 import { PATH_SEPARATOR, MAP_VALUES_SEP } from '../constants'
+import { SHIPPING_OPTIONS, SHIPPING_KEY } from './getFilters'
+
+const shippingFacetDefault = {
+  name: SHIPPING_KEY,
+  type: 'DELIVERY',
+  hidden: false,
+  quantity: 0,
+  facets: Object.keys(SHIPPING_OPTIONS).map(option => ({
+    id: null,
+    quantity: 0,
+    name: option,
+    key: SHIPPING_KEY,
+    selected: false,
+    map: SHIPPING_KEY,
+    value: option,
+  })),
+}
 
 export const getMainSearches = (query, map) => {
   const querySegments = (query && query.split(PATH_SEPARATOR)) || []
@@ -79,7 +96,7 @@ export const detachFiltersByType = facets => {
     groupedFilters.TEXT || []
   )
 
-  const deliveries = groupedFilters.DELIVERY || []
+  const deliveries = getFormattedDeliveries(groupedFilters.DELIVERY || [], true)
 
   const categoriesTrees = pathOr(
     [],
@@ -117,5 +134,27 @@ export const buildQueryArgsFromSelectedFacets = selectedFacets => {
       return queryArgs
     },
     { query: '', map: '' }
+  )
+}
+
+const getFormattedDeliveries = (deliveries, showShippingFacet) => {
+  if (!showShippingFacet) {
+    return deliveries.filter(d => d.name !== SHIPPING_KEY)
+  }
+
+  const shippingFacet = deliveries.find(d => d.name === SHIPPING_KEY)
+
+  if (!shippingFacet) {
+    return [...deliveries, shippingFacetDefault]
+  }
+
+  const facetsNotIncluded = shippingFacetDefault.facets.filter(facet =>
+    shippingFacet.facets.every(f => f.value !== facet.value)
+  )
+
+  shippingFacet.facets = [...shippingFacet.facets, ...facetsNotIncluded]
+
+  return deliveries.map(facet =>
+    facet.name === SHIPPING_KEY ? shippingFacet : facet
   )
 }

--- a/react/utils/getFilters.js
+++ b/react/utils/getFilters.js
@@ -13,26 +13,11 @@ export const SHIPPING_OPTIONS = {
   'pickup-all': 'store/search.filter.shipping.name.pickup-all',
 }
 
+export const SHIPPING_KEY = 'shipping'
+
 const BRANDS_TYPE = 'Brands'
 const PRICE_RANGES_TYPE = 'PriceRanges'
 const SPECIFICATION_FILTERS_TYPE = 'SpecificationFilters'
-const SHIPPING_KEY = 'shipping'
-
-const shippingFacetDefault = {
-  name: SHIPPING_KEY,
-  type: 'DELIVERY',
-  hidden: false,
-  quantity: 0,
-  facets: Object.keys(SHIPPING_OPTIONS).map(option => ({
-    id: null,
-    quantity: 0,
-    name: option,
-    key: SHIPPING_KEY,
-    selected: false,
-    map: SHIPPING_KEY,
-    value: option,
-  })),
-}
 
 const getFilters = ({
   specificationFilters = [],
@@ -41,9 +26,28 @@ const getFilters = ({
   deliveries = [],
   brandsQuantity = 0,
   hiddenFacets = {},
-  showShippingFacet = false,
+  // showShippingFacet = false,
 }) => {
   const intl = useIntl()
+
+  let deliveriesFormatted = deliveries
+
+  const shipping = deliveries.find(d => d.name === SHIPPING_KEY)
+
+  if (shipping) {
+    const shippingFacet = {
+      ...shipping,
+      title: SHIPPING_TITLE,
+      facets: shipping.facets.map(facet => ({
+        ...facet,
+        name: intl.formatMessage({ id: SHIPPING_OPTIONS[facet.name] }),
+      })),
+    }
+
+    deliveriesFormatted = deliveries.map(facet =>
+      facet.name === SHIPPING_KEY ? shippingFacet : facet
+    )
+  }
 
   const hiddenFacetsNames = (
     path(['specificationFilters', 'hiddenFilters'], hiddenFacets) || []
@@ -64,26 +68,6 @@ const getFilters = ({
         }))
     : []
 
-  const deliveriesFormatted = getFormattedDeliveries(
-    deliveries,
-    showShippingFacet
-  )
-
-  const shippingIndex = deliveriesFormatted.findIndex(
-    d => d.name === SHIPPING_KEY
-  )
-
-  if (shippingIndex !== -1) {
-    deliveriesFormatted[shippingIndex] = {
-      ...deliveriesFormatted[shippingIndex],
-      title: SHIPPING_TITLE,
-      facets: deliveriesFormatted[shippingIndex].facets.map(facet => ({
-        ...facet,
-        name: intl.formatMessage({ id: SHIPPING_OPTIONS[facet.name] }),
-      })),
-    }
-  }
-
   return [
     ...deliveriesFormatted,
     ...mappedSpecificationFilters,
@@ -101,28 +85,6 @@ const getFilters = ({
         facets: priceRanges,
       },
   ].filter(Boolean)
-}
-
-const getFormattedDeliveries = (deliveries, showShippingFacet) => {
-  if (!showShippingFacet) {
-    return deliveries.filter(d => d.name !== SHIPPING_KEY)
-  }
-
-  const shippingFacet = deliveries.find(d => d.name === SHIPPING_KEY)
-
-  if (!shippingFacet) {
-    return [...deliveries, shippingFacetDefault]
-  }
-
-  const facetsNotIncluded = shippingFacetDefault.facets.filter(facet =>
-    shippingFacet.facets.every(f => f.value !== facet.value)
-  )
-
-  shippingFacet.facets = [...shippingFacet.facets, ...facetsNotIncluded]
-
-  return deliveries.map(facet =>
-    facet.name === SHIPPING_KEY ? shippingFacet : facet
-  )
 }
 
 export default getFilters

--- a/react/utils/getFilters.js
+++ b/react/utils/getFilters.js
@@ -26,7 +26,7 @@ const getFilters = ({
   deliveries = [],
   brandsQuantity = 0,
   hiddenFacets = {},
-  // showShippingFacet = false,
+  showShippingFacet = false,
 }) => {
   const intl = useIntl()
 
@@ -46,6 +46,12 @@ const getFilters = ({
 
     deliveriesFormatted = deliveries.map(facet =>
       facet.name === SHIPPING_KEY ? shippingFacet : facet
+    )
+  }
+
+  if (!showShippingFacet) {
+    deliveriesFormatted = deliveriesFormatted.filter(
+      d => d.name !== SHIPPING_KEY
     )
   }
 


### PR DESCRIPTION
#### What problem is this solving?

The default facets were being added before the consultation to obtain them.
To fix this, adding the default facets has been moved to after the get facets query completes.

https://github.com/user-attachments/assets/a7191f25-8b46-476b-ad09-e87ec88b0534

#### How to test it?

Try doing some searches.

[Workspace](https://arthurdpteste--fulfillmentqa.myvtex.com/)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExdWJid2dhemd0OGRjcWF6djcxaWNrNDd0bTl3MmdkdXB3aWtpZGF5YSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/PGewdlXwLPhVVQYoLO/giphy.gif)
