### PR TITLE
Fix: filter sidebar closes when clicking shipping option drawer 

### DIFF
--- a/react/components/FilterNavigator/legacy/FilterSidebar.js
+++ b/react/components/FilterNavigator/legacy/FilterSidebar.js
@@ -13,6 +13,7 @@ import { facetOptionShape } from '../../../constants/propTypes'
 import useSelectedFilters from './hooks/useSelectedFilters'
 import searchResult from './searchResult.css'
 import QueryContext from '../../QueryContext'
+import isShippingOptionsComponent from '../../../utils/isShippingOptionsComponent'
 
 const FilterSidebar = ({ filters, preventRouteChange = false }) => {
   const { navigate, setQuery } = useRuntime()
@@ -49,7 +50,11 @@ const FilterSidebar = ({ filters, preventRouteChange = false }) => {
     }
   }
 
-  const handleClose = () => {
+  const handleClose = e => {
+    if (isShippingOptionsComponent(e)) {
+      return
+    }
+
     setOpen(false)
   }
 

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -23,6 +23,7 @@ import {
   filterCategoryDepartmentCollectionAndFT,
 } from '../utils/queryAndMapUtils'
 import { pushFilterManipulationPixelEvent } from '../utils/filterManipulationPixelEvents'
+import isShippingOptionsComponent from '../utils/isShippingOptionsComponent'
 
 const CSS_HANDLES = [
   'filterPopupButton',
@@ -110,7 +111,11 @@ const FilterSidebar = ({
     }
   }
 
-  const handleClose = () => {
+  const handleClose = e => {
+    if (isShippingOptionsComponent(e)) {
+      return
+    }
+
     setOpen(false)
   }
 

--- a/react/utils/isShippingOptionsComponent.js
+++ b/react/utils/isShippingOptionsComponent.js
@@ -1,0 +1,23 @@
+const SHIPPING_OPTION_COMPONENT_DRAWER_CLASS =
+  'vtex-shipping-option-components-0-x-drawer'
+
+const SHIPPING_OPTION_COMPONENT_OVERLAY_CLASS =
+  'vtex-shipping-option-components-0-x-overlay'
+
+const isShippingOptionsComponent = e => {
+  if (!e.target) {
+    return false
+  }
+
+  const shippingOptionsDawerElement = e.target.closest(
+    `.${SHIPPING_OPTION_COMPONENT_DRAWER_CLASS}`
+  )
+
+  const isShippingOptionsOverlayElement = e.target.classList.contains(
+    SHIPPING_OPTION_COMPONENT_OVERLAY_CLASS
+  )
+
+  return shippingOptionsDawerElement || isShippingOptionsOverlayElement
+}
+
+export default isShippingOptionsComponent


### PR DESCRIPTION
#### What problem is this solving?

Filter sidebar closes on mobile after interacting with the shipping option drawer

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->
1. Open in the mobile view
2. Click in the button to insert location inside the shipping filter
3. Interact with the shipping option drawer
4. Return to the filter.

[Workspace](https://dpfacets2--fulfillmentqa.myvtex.com/main-category-1)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

https://github.com/user-attachments/assets/ac1d0a15-2cb6-4756-b64b-4bc521c52a30


#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/4PT6v3PQKG6Yg/giphy.gif)
