### PR TITLE
Add missing scrollToTop prop to accordion filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Updated English, Spanish and Portuguese translations.
 - Added new strings to remaining languages.
+- `scrollToTop` prop not being passed down to the `PriceRange` component.
 
 ## [3.134.1] - 2024-11-07
 

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -254,6 +254,7 @@ const FilterNavigator = ({
               priceRangeLayout={priceRangeLayout}
               filtersDrawerDirectionMobile={filtersDrawerDirectionMobile}
               showQuantityBadgeOnMobile={showQuantityBadgeOnMobile}
+              scrollToTop={scrollToTop}
             />
           </div>
         </div>

--- a/react/components/AccordionFilterContainer.js
+++ b/react/components/AccordionFilterContainer.js
@@ -43,6 +43,7 @@ const AccordionFilterContainer = ({
   showClearByFilter,
   updateOnFilterSelectionOnMobile,
   priceRangeLayout,
+  scrollToTop,
 }) => {
   const intl = useIntl()
   const { getSettings, setQuery } = useRuntime()
@@ -182,6 +183,7 @@ const AccordionFilterContainer = ({
                 }}
                 onChangePriceRange={onChangePriceRange}
                 showClearByFilter={showClearByFilter}
+                scrollToTop={scrollToTop}
               />
             )
 
@@ -262,6 +264,8 @@ AccordionFilterContainer.propTypes = {
   /** Set the value of clearPriceRange prop */
   setClearPriceRange: PropTypes.func,
   onChangePriceRange: PropTypes.func,
+  /** Defines the scroll behavior after applying any filter */
+  scrollToTop: PropTypes.oneOf(['auto', 'smooth', 'none']),
 }
 
 export default AccordionFilterContainer

--- a/react/components/AccordionFilterPriceRange.js
+++ b/react/components/AccordionFilterPriceRange.js
@@ -17,6 +17,7 @@ const AccordionFilterPriceRange = ({
   onClearFilter,
   showClearByFilter,
   onChangePriceRange,
+  scrollToTop,
 }) => {
   const priceRangeRegex = /^(.*) TO (.*)$/
   const isPriceRangeSelected = priceRange && priceRangeRegex.test(priceRange)
@@ -40,6 +41,7 @@ const AccordionFilterPriceRange = ({
           priceRange={priceRange}
           priceRangeLayout={priceRangeLayout}
           onChangePriceRange={onChangePriceRange}
+          scrollToTop={scrollToTop}
         />
       </div>
     </AccordionFilterItem>

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -58,6 +58,7 @@ const FilterSidebar = ({
   priceRangeLayout,
   filtersDrawerDirectionMobile,
   showQuantityBadgeOnMobile,
+  scrollToTop,
 }) => {
   const { searchQuery } = useSearchPage()
   const filterContext = useFilterNavigator()
@@ -294,6 +295,7 @@ const FilterSidebar = ({
             showClearByFilter={showClearByFilter}
             updateOnFilterSelectionOnMobile={updateOnFilterSelectionOnMobile}
             priceRangeLayout={priceRangeLayout}
+            scrollToTop={scrollToTop}
           />
           <ExtensionPoint id="sidebar-close-button" onClose={handleClose} />
         </FilterNavigatorContext.Provider>


### PR DESCRIPTION
#### What problem is this solving?

The `scrollToTop` prop isn't passed down to the `PriceRange` component when the collapsible navigation type is applied to the filter navigator, causing the window to scroll to the top when query params are updated.

#### How to test it?

Using any component that updates the query params with `setQuery`, from [render-runtime](https://github.com/vtex-apps/render-runtime).

[Workspace (before)](https://mobilefilter--compracerta.myvtex.com/pecas-e-acessorios)
[Workspace (after)](https://mobilefilterfix--compracerta.myvtex.com/pecas-e-acessorios)

#### Screenshots or example usage:

Before

[Before](https://github.com/user-attachments/assets/9daf72d5-d323-4892-821a-cf7f443c3fe3)

After

[After](https://github.com/user-attachments/assets/1a7113da-6265-4982-9f8a-b1e359a6fc5e)

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExOWJ0ZjdwNDFhYXFsODVlN29jMmFnZnI2cjltdGdlcGhlMnN1cm4zciZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/NEvPzZ8bd1V4Y/giphy-downsized.gif)
