### PR TITLE
feat: choose shipping facets to show

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Enable the choice of shipping facets that appear in the filter
+
 ## [3.135.0] - 2025-01-08
 
 ### Fixed

--- a/react/SearchResultFlexible.js
+++ b/react/SearchResultFlexible.js
@@ -51,6 +51,7 @@ const SearchResultFlexible = ({
   showFacetQuantity = false,
   showFacetTitle = false,
   showShippingFacet = false,
+  availableShippingValues = [],
   // Below are set by SearchContext
   searchQuery,
   maxItemsPerPage,
@@ -98,6 +99,7 @@ const SearchResultFlexible = ({
         hiddenFacets,
         deliveries,
         showShippingFacet,
+        availableShippingValues,
         production,
       }),
     [
@@ -108,6 +110,7 @@ const SearchResultFlexible = ({
       brandsQuantity,
       deliveries,
       showShippingFacet,
+      availableShippingValues,
       production,
     ]
   )

--- a/react/__mocks__/exenv.js
+++ b/react/__mocks__/exenv.js
@@ -1,0 +1,1 @@
+export const exenv = { canUseDOM: true }

--- a/react/utils/getFilters.js
+++ b/react/utils/getFilters.js
@@ -67,7 +67,7 @@ const getFilters = ({
 
   if (
     !showShippingFacet ||
-    !(production && variant && variant.indexOf('delivery_promises') !== -1)
+    (production && variant && variant.indexOf('delivery_promises') === -1)
   ) {
     deliveriesFormatted = deliveriesFormatted.filter(
       d => d.name !== SHIPPING_KEY

--- a/react/utils/getFilters.js
+++ b/react/utils/getFilters.js
@@ -39,7 +39,7 @@ const getFilters = ({
 
   let shipping = deliveries.find(d => d.name === SHIPPING_KEY)
 
-  if (availableShippingValues.length !== 0) {
+  if (shipping && availableShippingValues.length !== 0) {
     shipping = {
       ...shipping,
       facets: shipping.facets.filter(facet =>
@@ -67,7 +67,7 @@ const getFilters = ({
 
   if (
     !showShippingFacet ||
-    (production && variant && variant.indexOf('delivery_promises') === -1)
+    !(production && variant && variant.indexOf('delivery_promises') !== -1)
   ) {
     deliveriesFormatted = deliveriesFormatted.filter(
       d => d.name !== SHIPPING_KEY

--- a/react/utils/getFilters.js
+++ b/react/utils/getFilters.js
@@ -29,6 +29,7 @@ const getFilters = ({
   brandsQuantity = 0,
   hiddenFacets = {},
   showShippingFacet = false,
+  availableShippingValues = [],
   production = true,
 }) => {
   // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -36,10 +37,19 @@ const getFilters = ({
 
   let deliveriesFormatted = deliveries
 
-  const shipping = deliveries.find(d => d.name === SHIPPING_KEY)
+  let shipping = deliveries.find(d => d.name === SHIPPING_KEY)
+
+  if (availableShippingValues.length !== 0) {
+    shipping = {
+      ...shipping,
+      facets: shipping.facets.filter(facet =>
+        availableShippingValues.includes(facet.name)
+      ),
+    }
+  }
 
   if (shipping) {
-    const shippingFacet = {
+    const shippingFormattedFacetsName = {
       ...shipping,
       title: SHIPPING_TITLE,
       facets: shipping.facets.map(facet => ({
@@ -49,7 +59,7 @@ const getFilters = ({
     }
 
     deliveriesFormatted = deliveries.map(facet =>
-      facet.name === SHIPPING_KEY ? shippingFacet : facet
+      facet.name === SHIPPING_KEY ? shippingFormattedFacetsName : facet
     )
   }
 


### PR DESCRIPTION
#### What problem is this solving?

We need to allow the client to choose the shipping facets that will be shown in the filter.

#### How to test it?

Update the store-theme adding the `availableShippingValues` atribute in search-result-layout props.

``` json
"search-result-layout.desktop": {
    "children": [
      "flex-layout.row#searchbread",
      "flex-layout.row#searchtitle",
      "flex-layout.row#result"
    ],
    "props": {
      "availableShippingValues": [
        "pickup-nearby",
        "pickup-in-point",
        "delivery"
      ]
    }
```

[Workspace](https://dpdemo--mundodocabeleireiro.myvtex.com/)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->
<img width="335" alt="image" src="https://github.com/user-attachments/assets/95a46d3c-e2d9-451c-b0af-5b8f49546e7a" />

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
