### PR TITLE
remove dp variant validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- Remove DP variant validation.
+
 ## [3.136.0] - 2025-01-16
 
 ### Added

--- a/react/SearchResultFlexible.js
+++ b/react/SearchResultFlexible.js
@@ -87,7 +87,7 @@ const SearchResultFlexible = ({
     deliveries,
   } = facets
 
-  const { query: runtimeQuery, production } = useRuntime()
+  const { query: runtimeQuery } = useRuntime()
 
   const filters = useMemo(
     () =>
@@ -100,7 +100,6 @@ const SearchResultFlexible = ({
         deliveries,
         showShippingFacet,
         availableShippingValues,
-        production,
       }),
     [
       brands,
@@ -111,7 +110,6 @@ const SearchResultFlexible = ({
       deliveries,
       showShippingFacet,
       availableShippingValues,
-      production,
     ]
   )
 

--- a/react/utils/getFilters.js
+++ b/react/utils/getFilters.js
@@ -1,8 +1,6 @@
 import { path, contains, isEmpty } from 'ramda'
 import { useIntl } from 'react-intl'
 
-import getCookie from './getCookie'
-
 export const SHIPPING_TITLE = 'store/search.filter.title.shipping'
 export const CATEGORIES_TITLE = 'store/search.filter.title.categories'
 export const BRANDS_TITLE = 'store/search.filter.title.brands'
@@ -30,7 +28,6 @@ const getFilters = ({
   hiddenFacets = {},
   showShippingFacet = false,
   availableShippingValues = [],
-  production = true,
 }) => {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const intl = useIntl()
@@ -63,12 +60,7 @@ const getFilters = ({
     )
   }
 
-  const variant = getCookie('sp-variant')
-
-  if (
-    !showShippingFacet ||
-    (production && variant && variant.indexOf('delivery_promises') === -1)
-  ) {
+  if (!showShippingFacet) {
     deliveriesFormatted = deliveriesFormatted.filter(
       d => d.name !== SHIPPING_KEY
     )


### PR DESCRIPTION
#### What problem is this solving?

We will not use osiris anymore so we can remove the `variant` validation that we do before rendering the component

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://hiago--mundodocabeleireiro.myvtex.com/cabelo)

