### PR TITLE
Fix region-id query issue

### DIFF
--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -172,7 +172,7 @@ const useQueries = (variables, facetsArgs, price) => {
 
   const { data: { searchMetadata } = {} } = useQuery(searchMetadataQuery, {
     variables: {
-      query: variables.query,
+      query: encodeURIComponent(variables.query),
       fullText: variables.fullText,
       selectedFacets: variables.selectedFacets,
     },


### PR DESCRIPTION
By applying the encodeURIComponent, it is possible for the query to receive the value "SW#{sellerId}" in base64, which allows segmenting the catalog by region-id.

#### What problem is this solving?

I'm trying to segment the catalog displayed in the PLP by region-id. However, when passing the value "SW#{sellerId}" converted to base64 as the value of the selectedFacet "region-id", an error occurs, since this value is sent to MetadataSearchV3, which in turn does not accept the equal symbol ("=").

#### How to test it?

Access one of the following workspaces and compare its total products number to a GraphQL Query that does the same query and segmentation.

Query:

```
productSearch(selectedFacets: [{key: "region-id", value: "U1cjb3V0bGV0ZWx1eGJyMDE="}], hideUnavailableItems: true) {
    recordsFiltered
}
```

http://poclistallfreights--electrolux.myvtex.com/outlet-sao-paulo
http://poclistallfreights--electrolux.myvtex.com/outlet-brasilia
http://poclistallfreights--electrolux.myvtex.com/outlet-manaus
http://poclistallfreights--electrolux.myvtex.com/outlet-belo-horizonte
http://poclistallfreights--electrolux.myvtex.com/outlet-barigui
http://poclistallfreights--electrolux.myvtex.com/outlet-campo-largo
http://poclistallfreights--electrolux.myvtex.com/outlet-porto-belo
http://poclistallfreights--electrolux.myvtex.com/outlet-cajuru
http://poclistallfreights--electrolux.myvtex.com/outlet-florianopolis
http://poclistallfreights--electrolux.myvtex.com/outlet-feira-de-santana
http://poclistallfreights--electrolux.myvtex.com/outlet-salvador
http://poclistallfreights--electrolux.myvtex.com/outlet-sao-roque

#### Screenshots or example usage:

![seller-catalog-from-search-result-query-quantidades-01-sao-paulo](https://github.com/user-attachments/assets/3158f2c0-b6c1-47b6-a8a8-f692a4cfda3f)
![seller-catalog-from-search-result-query-quantidades-02-brasilia](https://github.com/user-attachments/assets/24664dac-b0a8-47fe-82cb-3060bd7d3931)
![seller-catalog-from-search-result-query-quantidades-03-manaus](https://github.com/user-attachments/assets/2c292420-2ca4-40dd-849c-f09ecf1fcaaa)
![seller-catalog-from-search-result-query-quantidades-04-belo-horizonte](https://github.com/user-attachments/assets/529204ca-b33c-4e2d-9dd8-d54f40732c85)
![seller-catalog-from-search-result-query-quantidades-05-barigui](https://github.com/user-attachments/assets/1c00bd70-ed24-49c7-9f75-aeea34e9b9e1)
![seller-catalog-from-search-result-query-quantidades-06-campo-largo](https://github.com/user-attachments/assets/991dd71e-5d27-4350-8805-c18305c472b2)
![seller-catalog-from-search-result-query-quantidades-07-porto-belo](https://github.com/user-attachments/assets/4c786696-9ab1-4091-a3f9-a8e6c8e118ef)
![seller-catalog-from-search-result-query-quantidades-08-cajuru](https://github.com/user-attachments/assets/723494a9-2b7a-4d03-98c5-e842e6bec386)
![seller-catalog-from-search-result-query-quantidades-09-florianopolis](https://github.com/user-attachments/assets/b2c0b78d-5c40-4239-a7d8-01343306ae93)
![seller-catalog-from-search-result-query-quantidades-10-feira-de-santana](https://github.com/user-attachments/assets/8477fd93-e971-42a7-a7cd-d8a35997fb43)
![seller-catalog-from-search-result-query-quantidades-11-salvador](https://github.com/user-attachments/assets/56e34d42-377a-4c74-adc8-cf56c4b1efaa)
![seller-catalog-from-search-result-query-quantidades-12-sao-roque](https://github.com/user-attachments/assets/67fd4729-2454-40ab-be34-904fad06e08f)
![seller-catalog-from-search-result-query-quantidades-corretas](https://github.com/user-attachments/assets/08b2b8e8-1382-4de7-9b16-9ec6f5f30aed)


#### Describe alternatives you've considered, if any.

If you pass any string other then the "SW#{sellerId}" you'll receive a result with products, but it is a "false positive", that's why it is important to compare the results to the GraphQL Query.

#### Related to / Depends on

There is a VTEX Support Ticket related to this same issue (1187628).

#### How does this PR make you feel? [:link:](http://giphy.com/)

![https://media.giphy.com/media/erwW0QPCDN5QOe0BA1/giphy.gif?cid=82a1493bclj6txef3ndaa8kk2ie8h8734h0689u4f6hy9mxs&ep=v1_gifs_trending&rid=giphy.gif&ct=g](please help me)
