### PR TITLE
feat: change shipping facets to radio in mobile

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,9 @@
 # Search Result
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-7-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 The Search Result app handles the results returned by the [VTEX Search API](https://developers.vtex.com/docs/guides/search-overview) and displaying them to users.
@@ -30,30 +32,29 @@ Now, you can use all the blocks exported by the `search-result` app. Check out t
 
 #### `search-result` blocks
 
-| Block name   | Description  |
-| -------- | ------------------------ |
-| `search-result-layout`     |  ![https://img.shields.io/badge/-Mandatory-red](https://img.shields.io/badge/-Mandatory-red) Enables you to build the search result page using its three children blocks: `search-result-layout desktop`, `search-result-layout.mobile`, and `search-not-found-layout` . It must be used in the `store.search` template since it uses the context provided by the VTEX Search API.                                                                                 |
-| `search-result-layout.customQuery` | ![https://img.shields.io/badge/-Mandatory-red](https://img.shields.io/badge/-Mandatory-red) Used instead of `search-result-layout` in scenarios in which the search result will be declared in a template that doesn't fetch Search context, such as Home. It accepts a `querySchema` prop that executes search custom queries. It also supports three children blocks: `search-result-layout.desktop`, `search-result-layout.mobile` and `search-not-found-layout` .
-| `search-result-layout.desktop`   | ![https://img.shields.io/badge/-Mandatory-red](https://img.shields.io/badge/-Mandatory-red) Builds the search result page structure for desktop mode.                                                                                                             |
-| `search-result-layout.mobile`   | Builds the search result page structure for mobile mode.  If the `search-result-layout.mobile` is not provided, the `search-result-layout.desktop` will be used instead.                                                                                                            |
-| `search-layout-switcher`       | Enables mobile users to switch between the available layout modes.                                                                                              |
-| `search-not-found-layout`   | Builds the whole search result page structure for scenarios in which no result was fetched. It is rendered whenever users search for a term that doesn't return a product. |                                                      |
-| `gallery`  | ![https://img.shields.io/badge/-Mandatory-red](https://img.shields.io/badge/-Mandatory-red) Displays the gallery with all the products found in the search.  |                    |                                         
-| `gallery-layout-switcher` | Logical block that allows users to switch between the available `gallery`'s layouts. To know how to build your search results with multiple layouts, access the [documentation](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-building-a-search-results-page-with-multiple-layouts).  |                           |                                     
-| `gallery-layout-option` | Defines how each layout option should be rendered for users. To know how to build your search results with multiple layouts, access the [documentation](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-building-a-search-results-page-with-multiple-layouts).  | 
-| `not-found` | Contains a text and a description for the page that was not found in the search. It must be declared as a child of `search-not-found-layout`.  | 
-| `search-content`          | ![https://img.shields.io/badge/-Mandatory-red](https://img.shields.io/badge/-Mandatory-red) Decides, behind the scenes, which block will be displayed: either the `gallery` block (if products are found) or the `not-found` block (if the selected filters lead to an empty search results page). This means that both `gallery` and `not-found` must be declared as `search-content` children.                    |
-| `store.not-found#search`    | When configured, it displays a `404` error message whenever the server cannot return what the browser request was or when it is configured not to handle that request.  |  
-| `search-products-count-per-page` | Displays the total number of products being displayed on the search results page. | 
-| `search-products-progress-bar` | Displays a progress bar of products being displayed on the search results page. |
-| `order-by.v2`            | Allows users to choose the product ordination on the search results page.  | 
-| `filter-navigator.v3`        | Allows users to apply different filters to the search. On mobile, renders a button that, when clicked on, displays all available filters in a sidebar. | 
-| `total-products.v2`        | Displays the total amount of products found for that search. | 
-| `search-title.v2`         | Displays a title for the search that was done. |                                                                                              |
-| `search-fetch-more`         | Displays the **Show More** button. This button is not rendered when the user is on the last page. |                                                                                              |
-| `search-fetch-previous`         | Displays the **Show Previous** button. This button is not rendered when the user is on the first page. |                                   
-| `sidebar-close-button`         | Displays an `X` button on the filter sidebar on mobile. |                                                                                       
-
+| Block name                         | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
+| `search-result-layout`             | ![https://img.shields.io/badge/-Mandatory-red](https://img.shields.io/badge/-Mandatory-red) Enables you to build the search result page using its three children blocks: `search-result-layout desktop`, `search-result-layout.mobile`, and `search-not-found-layout` . It must be used in the `store.search` template since it uses the context provided by the VTEX Search API.                                                                                     |
+| `search-result-layout.customQuery` | ![https://img.shields.io/badge/-Mandatory-red](https://img.shields.io/badge/-Mandatory-red) Used instead of `search-result-layout` in scenarios in which the search result will be declared in a template that doesn't fetch Search context, such as Home. It accepts a `querySchema` prop that executes search custom queries. It also supports three children blocks: `search-result-layout.desktop`, `search-result-layout.mobile` and `search-not-found-layout` . |
+| `search-result-layout.desktop`     | ![https://img.shields.io/badge/-Mandatory-red](https://img.shields.io/badge/-Mandatory-red) Builds the search result page structure for desktop mode.                                                                                                                                                                                                                                                                                                                 |
+| `search-result-layout.mobile`      | Builds the search result page structure for mobile mode. If the `search-result-layout.mobile` is not provided, the `search-result-layout.desktop` will be used instead.                                                                                                                                                                                                                                                                                               |
+| `search-layout-switcher`           | Enables mobile users to switch between the available layout modes.                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `search-not-found-layout`          | Builds the whole search result page structure for scenarios in which no result was fetched. It is rendered whenever users search for a term that doesn't return a product.                                                                                                                                                                                                                                                                                            |     |
+| `gallery`                          | ![https://img.shields.io/badge/-Mandatory-red](https://img.shields.io/badge/-Mandatory-red) Displays the gallery with all the products found in the search.                                                                                                                                                                                                                                                                                                           |     |
+| `gallery-layout-switcher`          | Logical block that allows users to switch between the available `gallery`'s layouts. To know how to build your search results with multiple layouts, access the [documentation](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-building-a-search-results-page-with-multiple-layouts).                                                                                                                                                     |     |
+| `gallery-layout-option`            | Defines how each layout option should be rendered for users. To know how to build your search results with multiple layouts, access the [documentation](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-building-a-search-results-page-with-multiple-layouts).                                                                                                                                                                             |
+| `not-found`                        | Contains a text and a description for the page that was not found in the search. It must be declared as a child of `search-not-found-layout`.                                                                                                                                                                                                                                                                                                                         |
+| `search-content`                   | ![https://img.shields.io/badge/-Mandatory-red](https://img.shields.io/badge/-Mandatory-red) Decides, behind the scenes, which block will be displayed: either the `gallery` block (if products are found) or the `not-found` block (if the selected filters lead to an empty search results page). This means that both `gallery` and `not-found` must be declared as `search-content` children.                                                                      |
+| `store.not-found#search`           | When configured, it displays a `404` error message whenever the server cannot return what the browser request was or when it is configured not to handle that request.                                                                                                                                                                                                                                                                                                |
+| `search-products-count-per-page`   | Displays the total number of products being displayed on the search results page.                                                                                                                                                                                                                                                                                                                                                                                     |
+| `search-products-progress-bar`     | Displays a progress bar of products being displayed on the search results page.                                                                                                                                                                                                                                                                                                                                                                                       |
+| `order-by.v2`                      | Allows users to choose the product ordination on the search results page.                                                                                                                                                                                                                                                                                                                                                                                             |
+| `filter-navigator.v3`              | Allows users to apply different filters to the search. On mobile, renders a button that, when clicked on, displays all available filters in a sidebar.                                                                                                                                                                                                                                                                                                                |
+| `total-products.v2`                | Displays the total amount of products found for that search.                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `search-title.v2`                  | Displays a title for the search that was done.                                                                                                                                                                                                                                                                                                                                                                                                                        |     |
+| `search-fetch-more`                | Displays the **Show More** button. This button is not rendered when the user is on the last page.                                                                                                                                                                                                                                                                                                                                                                     |     |
+| `search-fetch-previous`            | Displays the **Show Previous** button. This button is not rendered when the user is on the first page.                                                                                                                                                                                                                                                                                                                                                                |
+| `sidebar-close-button`             | Displays an `X` button on the filter sidebar on mobile.                                                                                                                                                                                                                                                                                                                                                                                                               |
 
 ## Adding the Search Result to page templates
 
@@ -95,17 +96,15 @@ Using `search-result-layout`:
 
 ```json
 {
-    "store.search": {
-        "blocks": [
-            "search-result-layout"
-        ],
-        "props": {
-            "context": {
-                "skusFilter": "FIRST_AVAILABLE",
-                "simulationBehavior": "default"
-            }
-        }
+  "store.search": {
+    "blocks": ["search-result-layout"],
+    "props": {
+      "context": {
+        "skusFilter": "FIRST_AVAILABLE",
+        "simulationBehavior": "default"
+      }
     }
+  }
 }
 ```
 
@@ -113,21 +112,21 @@ Using `search-result-layout.customQuery`:
 
 ```json
 {
-    "store.home": {
-        "blocks": [
-            "carousel#home",
-            "shelf#home",
-            "search-result-layout.customQuery#home"
-        ]
-    },
-    "search-result-layout.customQuery#home": {
-        "props": {
-            "querySchema": {
-                "skusFilter": "FIRST_AVAILABLE",
-                "simulationBehavior": "default"
-            }
-        }
+  "store.home": {
+    "blocks": [
+      "carousel#home",
+      "shelf#home",
+      "search-result-layout.customQuery#home"
+    ]
+  },
+  "search-result-layout.customQuery#home": {
+    "props": {
+      "querySchema": {
+        "skusFilter": "FIRST_AVAILABLE",
+        "simulationBehavior": "default"
+      }
     }
+  }
 }
 ```
 
@@ -135,19 +134,19 @@ Check all props to configure your search data in the table below:
 
 ### The `context` and `querySchema` props
 
-| Prop name | Type | Description | Default value |
-| - | - | - | - |
-| `queryField` | `string` | ![https://img.shields.io/badge/-Mandatory-red](https://img.shields.io/badge/-Mandatory-red) Query string of the search URL that defines the results that should be fetched in the custom query. For example: `Blue`. This prop only works if the `mapField` prop is declared as well. | `undefined`. |
-| `mapField` | `string` | ![https://img.shields.io/badge/-Mandatory-red](https://img.shields.io/badge/-Mandatory-red) Search URL's `map` parameter to define which results should be fetched in the custom query, for example `specificationFilter_100`. This prop only works if the `queryField` prop is declared as well. | `undefined` |
-| `maxItemsPerPage` | `number` | Maximum number of items per search page. The maximum value of this prop is `50`. If a higher number is added, the query will fail. | `10`|
-| `orderByField` | `enum` | Determines which order products must follow when displayed. The possible values are named after the sorting type: `OrderByReleaseDateDESC`, `OrderByBestDiscountDESC`, `OrderByPriceDESC`, `OrderByPriceASC`, `OrderByNameASC`, `OrderByNameDESC`, or `OrderByTopSaleDESC`. <br/><br/>`ASC` and `DESC` stand for ascending order and descending order, respectively, based on the position of each value's corresponding code in the [ASCII table](http://www.asciitable.com/). <br/><br/>The last option (`OrderByTopSaleDESC`) considers the number of sold units of the product in the past 90 days, taking into account only ecommerce orders (no physical stores orders) from `order-placed` events (e.g. without checking if the payment was approved). If the store has an app, it is possible to consider the events from the app as long as they are implemented on the store's side, they aren't implemented by default. In case the shopper has an ad-blocking extension or a browser restriction that disables sending events, their navigation will not be counted. <br/><br/>If not set to any of the mentioned values, the fallback behavior is sorting by [relevance settings](https://help.vtex.com/tracks/vtex-intelligent-search--19wrbB7nEQcmwzDPl1l4Cb/1qlObWIib6KqgrfX1FCOXS). <br/><br/>`OrderByScoreDESC` is **not** a valid value for this prop. | `""` |
-| `hideUnavailableItems` | `boolean` | Determines whether the search result should hide unavailable items (`true`) or not (`false`). This prop only hides items that are unavailable according to indexed information, without taking into account `simulationBehavior`. | `false` |
-| `facetsBehavior` | `string` | Defines the filters' behavior. When set to `Dynamic`, it restricts the results according to the filters that the user has already selected. If set to `Static`, all filters will continue to be displayed to the user, even if there are no results.| `Static` |
-| `skusFilter` | `enum` | Refines the SKUs returned for each product in the query. The fewer returned SKUs, the more performant your shelf query will be. Available value options: `FIRST_AVAILABLE` (returns only the first available SKU), `ALL_AVAILABLE` (returns all available SKUs), and `ALL` (returns all product's SKUs). | `ALL_AVAILABLE` |
-| `simulationBehavior` | `enum` | Defines whether the search data will be up-to-date (`default`) or fetched using the Cache (`skip`). You should only use the last option if you prefer faster queries than the most up-to-date prices or inventory.| `default` |
-| `installmentCriteria` | `enum` | Defines which price should be displayed when different installments are available. Possible values are: `MAX_WITHOUT_INTEREST` (displays the maximum installment option with no interest attached to it) or `MAX_WITH_INTEREST` (displays the maximum installment option whether it has interest attached to it or not). | `"MAX_WITHOUT_INTEREST"` |
-| `excludedPaymentSystems` | `string` | List of payment systems that should not be considered when displaying the installment options to users. This prop configuration only works if the `installmentCriteria` prop was also declared. In case it was not, all available payment systems will be displayed regardless. | `undefined` |
-| `includedPaymentSystems` | `string` | List of payment systems that should be considered when displaying the installment options to users. This prop configuration only works if the `installmentCriteria` prop was also declared. In case it was not, all available payment systems will be displayed regardless.| `undefined` |
+| Prop name                | Type      | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | Default value            |
+| ------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `queryField`             | `string`  | ![https://img.shields.io/badge/-Mandatory-red](https://img.shields.io/badge/-Mandatory-red) Query string of the search URL that defines the results that should be fetched in the custom query. For example: `Blue`. This prop only works if the `mapField` prop is declared as well.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | `undefined`.             |
+| `mapField`               | `string`  | ![https://img.shields.io/badge/-Mandatory-red](https://img.shields.io/badge/-Mandatory-red) Search URL's `map` parameter to define which results should be fetched in the custom query, for example `specificationFilter_100`. This prop only works if the `queryField` prop is declared as well.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | `undefined`              |
+| `maxItemsPerPage`        | `number`  | Maximum number of items per search page. The maximum value of this prop is `50`. If a higher number is added, the query will fail.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | `10`                     |
+| `orderByField`           | `enum`    | Determines which order products must follow when displayed. The possible values are named after the sorting type: `OrderByReleaseDateDESC`, `OrderByBestDiscountDESC`, `OrderByPriceDESC`, `OrderByPriceASC`, `OrderByNameASC`, `OrderByNameDESC`, or `OrderByTopSaleDESC`. <br/><br/>`ASC` and `DESC` stand for ascending order and descending order, respectively, based on the position of each value's corresponding code in the [ASCII table](http://www.asciitable.com/). <br/><br/>The last option (`OrderByTopSaleDESC`) considers the number of sold units of the product in the past 90 days, taking into account only ecommerce orders (no physical stores orders) from `order-placed` events (e.g. without checking if the payment was approved). If the store has an app, it is possible to consider the events from the app as long as they are implemented on the store's side, they aren't implemented by default. In case the shopper has an ad-blocking extension or a browser restriction that disables sending events, their navigation will not be counted. <br/><br/>If not set to any of the mentioned values, the fallback behavior is sorting by [relevance settings](https://help.vtex.com/tracks/vtex-intelligent-search--19wrbB7nEQcmwzDPl1l4Cb/1qlObWIib6KqgrfX1FCOXS). <br/><br/>`OrderByScoreDESC` is **not** a valid value for this prop. | `""`                     |
+| `hideUnavailableItems`   | `boolean` | Determines whether the search result should hide unavailable items (`true`) or not (`false`). This prop only hides items that are unavailable according to indexed information, without taking into account `simulationBehavior`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | `false`                  |
+| `facetsBehavior`         | `string`  | Defines the filters' behavior. When set to `Dynamic`, it restricts the results according to the filters that the user has already selected. If set to `Static`, all filters will continue to be displayed to the user, even if there are no results.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | `Static`                 |
+| `skusFilter`             | `enum`    | Refines the SKUs returned for each product in the query. The fewer returned SKUs, the more performant your shelf query will be. Available value options: `FIRST_AVAILABLE` (returns only the first available SKU), `ALL_AVAILABLE` (returns all available SKUs), and `ALL` (returns all product's SKUs).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | `ALL_AVAILABLE`          |
+| `simulationBehavior`     | `enum`    | Defines whether the search data will be up-to-date (`default`) or fetched using the Cache (`skip`). You should only use the last option if you prefer faster queries than the most up-to-date prices or inventory.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | `default`                |
+| `installmentCriteria`    | `enum`    | Defines which price should be displayed when different installments are available. Possible values are: `MAX_WITHOUT_INTEREST` (displays the maximum installment option with no interest attached to it) or `MAX_WITH_INTEREST` (displays the maximum installment option whether it has interest attached to it or not).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | `"MAX_WITHOUT_INTEREST"` |
+| `excludedPaymentSystems` | `string`  | List of payment systems that should not be considered when displaying the installment options to users. This prop configuration only works if the `installmentCriteria` prop was also declared. In case it was not, all available payment systems will be displayed regardless.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | `undefined`              |
+| `includedPaymentSystems` | `string`  | List of payment systems that should be considered when displaying the installment options to users. This prop configuration only works if the `installmentCriteria` prop was also declared. In case it was not, all available payment systems will be displayed regardless.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | `undefined`              |
 
 > ℹ️ Pagination does not display results after page 50. You can configure it to display more products per page using the prop `maxItemsPerPage` by increasing the quantity of products on each page.
 
@@ -164,61 +163,51 @@ This allows you to define custom behaviors for each of your store's search pages
 
 ```json
 {
-    "store.search": {
-        "blocks": [
-            "search-result-layout"
-        ],
-        "props": {
-            "context": {
-                "skusFilter": "FIRST_AVAILABLE",
-                "simulationBehavior": "default"
-            }
-        }
-    },
-    "store.search#category": {
-        "blocks": [
-            "search-result-layout"
-        ],
-        "props": {
-            "context": {
-                "skusFilter": "FIRST_AVAILABLE",
-                "simulationBehavior": "default"
-            }
-        }
-    },
-    "store.search#brand": {
-        "blocks": [
-            "search-result-layout"
-        ],
-        "props": {
-            "context": {
-                "skusFilter": "FIRST_AVAILABLE",
-                "simulationBehavior": "default"
-            }
-        }
-    },
-    "store.search#department": {
-        "blocks": [
-            "search-result-layout"
-        ],
-        "props": {
-            "context": {
-                "skusFilter": "FIRST_AVAILABLE",
-                "simulationBehavior": "default"
-            }
-        }
-    },
-    "store.search#subcategory": {
-        "blocks": [
-            "search-result-layout"
-        ],
-        "props": {
-            "context": {
-                "skusFilter": "FIRST_AVAILABLE",
-                "simulationBehavior": "default"
-            }
-        }
+  "store.search": {
+    "blocks": ["search-result-layout"],
+    "props": {
+      "context": {
+        "skusFilter": "FIRST_AVAILABLE",
+        "simulationBehavior": "default"
+      }
     }
+  },
+  "store.search#category": {
+    "blocks": ["search-result-layout"],
+    "props": {
+      "context": {
+        "skusFilter": "FIRST_AVAILABLE",
+        "simulationBehavior": "default"
+      }
+    }
+  },
+  "store.search#brand": {
+    "blocks": ["search-result-layout"],
+    "props": {
+      "context": {
+        "skusFilter": "FIRST_AVAILABLE",
+        "simulationBehavior": "default"
+      }
+    }
+  },
+  "store.search#department": {
+    "blocks": ["search-result-layout"],
+    "props": {
+      "context": {
+        "skusFilter": "FIRST_AVAILABLE",
+        "simulationBehavior": "default"
+      }
+    }
+  },
+  "store.search#subcategory": {
+    "blocks": ["search-result-layout"],
+    "props": {
+      "context": {
+        "skusFilter": "FIRST_AVAILABLE",
+        "simulationBehavior": "default"
+      }
+    }
+  }
 }
 ```
 
@@ -230,68 +219,69 @@ According to your store's scenario, structure the `search-result-layout` or the 
 
 ```json
 {
-    "search-result-layout": {
-        "blocks": [
-            "search-result-layout.desktop",
-            "search-result-layout.mobile",
-            "search-not-found-layout"
-        ]
-    },
-    "search-result-layout.desktop": {
-        "children": [
-            "flex-layout.row#searchbread",
-            "flex-layout.row#searchtitle",
-            "flex-layout.row#result"
-        ],
-        "props": {
-            "preventRouteChange": true
-        }
+  "search-result-layout": {
+    "blocks": [
+      "search-result-layout.desktop",
+      "search-result-layout.mobile",
+      "search-not-found-layout"
+    ]
+  },
+  "search-result-layout.desktop": {
+    "children": [
+      "flex-layout.row#searchbread",
+      "flex-layout.row#searchtitle",
+      "flex-layout.row#result"
+    ],
+    "props": {
+      "preventRouteChange": true
     }
+  }
 }
 ```
 
 #### The `search-result-layout.desktop`, `search-result-layout.mobile`, and `search-not-found-layout` props
 
-| Prop name | Type | Description | Default value |
-| - | - | - | - |
-| `hiddenFacets` | `object` | Indicates which filters should be hidden. The possible values are in [this table](#the-hiddenfacets-object). | `undefined` |
-| `showFacetQuantity` | `boolean` | Determines whether the resulting amount in each filter should appear beside its name on the `filter-navigator.v3` block as (`true`) or (`false`) | `false` |
-| `showFacetTitle` | `boolean`      | Whether the facet title should appear on selected filters section on the `filter-navigator.v3` block as (`true`) or (`false`)      | `false`           |
-| `blockClass` | `string` | Unique block ID to be used in [CSS customization](https://developers.vtex.com/docs/guides/vtex-io-documentation-using-css-handles-for-store-customization#using-the-blockclass-property) | `undefined` |
-| `trackingId` | `string` | ID to be used in Google Analytics to track store metrics based on the Search Result block. | `Search result` |
-| `mobileLayout` | `object` | Controls how the search results page will be displayed to users using the mobile layout. The possible values are in [this table](#the-mobilelayout-object). | `undefined` |
-| `defaultGalleryLayout` | `string` | Name of the gallery layout to be used by default in the search results page. This prop is required when several layouts are explicitly defined by the `gallery` block. This prop's value must match the layout name defined in the `name` prop from `layouts` object. | `undefined` |
-| `thresholdForFacetSearch` | `number` | The minimum number of facets must be displayed on the interface for a search bar to be displayed. If you declare `0`, the search bar will always be displayed. | `undefined` |
-| `preventRouteChange` | `boolean` | Keeps page customizations even when the user applies new filters. This prop will only change the URL’s query string rather than the entire URL, preventing a full page reload whenever filters are applied. | `false` |
+| Prop name                 | Type      | Description                                                                                                                                                                                                                                                           | Default value   |
+| ------------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
+| `hiddenFacets`            | `object`  | Indicates which filters should be hidden. The possible values are in [this table](#the-hiddenfacets-object).                                                                                                                                                          | `undefined`     |
+| `showFacetQuantity`       | `boolean` | Determines whether the resulting amount in each filter should appear beside its name on the `filter-navigator.v3` block as (`true`) or (`false`)                                                                                                                      | `false`         |
+| `showFacetTitle`          | `boolean` | Whether the facet title should appear on selected filters section on the `filter-navigator.v3` block as (`true`) or (`false`)                                                                                                                                         | `false`         |
+| `blockClass`              | `string`  | Unique block ID to be used in [CSS customization](https://developers.vtex.com/docs/guides/vtex-io-documentation-using-css-handles-for-store-customization#using-the-blockclass-property)                                                                              | `undefined`     |
+| `trackingId`              | `string`  | ID to be used in Google Analytics to track store metrics based on the Search Result block.                                                                                                                                                                            | `Search result` |
+| `mobileLayout`            | `object`  | Controls how the search results page will be displayed to users using the mobile layout. The possible values are in [this table](#the-mobilelayout-object).                                                                                                           | `undefined`     |
+| `defaultGalleryLayout`    | `string`  | Name of the gallery layout to be used by default in the search results page. This prop is required when several layouts are explicitly defined by the `gallery` block. This prop's value must match the layout name defined in the `name` prop from `layouts` object. | `undefined`     |
+| `thresholdForFacetSearch` | `number`  | The minimum number of facets must be displayed on the interface for a search bar to be displayed. If you declare `0`, the search bar will always be displayed.                                                                                                        | `undefined`     |
+| `preventRouteChange`      | `boolean` | Keeps page customizations even when the user applies new filters. This prop will only change the URL’s query string rather than the entire URL, preventing a full page reload whenever filters are applied.                                                           | `false`         |
+| `showShippingFacet`       | `boolean` | Determines whether Shipping filters should be displayed (`true`) or not (`false`).                                                                                                                                                                                    | `false`         |
 
 #### The `mobileLayout` object
 
-| Prop name | Type | Description | Default value |
-| - | - | - | - |
-| `mode1` | `enum` | Defines the default layout for the mobile search results page. Possible values are: `normal`, `small` or `inline`. | `normal` |
-| `mode2` | `enum` | Defines which layout will be set for the mobile search results page when users click on the layout selector button. Possible values also are `normal`, `small`, or `inline`. | `small` |
+| Prop name | Type   | Description                                                                                                                                                                  | Default value |
+| --------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `mode1`   | `enum` | Defines the default layout for the mobile search results page. Possible values are: `normal`, `small` or `inline`.                                                           | `normal`      |
+| `mode2`   | `enum` | Defines which layout will be set for the mobile search results page when users click on the layout selector button. Possible values also are `normal`, `small`, or `inline`. | `small`       |
 
 #### The `hiddenFacets` object
 
-| Prop name | Type | Description | Default value |
-| - | - | - | - |
-| `brands` | `boolean` | Determines whether Brand filters should be hidden (`true`) or not (`false`). | `false` |
-| `categories` | `boolean` | Determines whether Category filters should be hidden (`true`) or not (`false`). | `false` |
-| `priceRange` | `boolean` | Determines whether Price filters should be hidden (`true`) or not (`false`). | `false` |
-| `specificationFilters` | `object` | Indicates which specification filters should be hidden. The possible values are in [this table](#the-specificationfilters-object). | `undefined` |
+| Prop name              | Type      | Description                                                                                                                        | Default value |
+| ---------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `brands`               | `boolean` | Determines whether Brand filters should be hidden (`true`) or not (`false`).                                                       | `false`       |
+| `categories`           | `boolean` | Determines whether Category filters should be hidden (`true`) or not (`false`).                                                    | `false`       |
+| `priceRange`           | `boolean` | Determines whether Price filters should be hidden (`true`) or not (`false`).                                                       | `false`       |
+| `specificationFilters` | `object`  | Indicates which specification filters should be hidden. The possible values are in [this table](#the-specificationfilters-object). | `undefined`   |
 
 #### The `specificationFilters` object
 
-| Prop name | Type | Description | Default value |
-| - | - | - | - |
-| `hideAll` | `boolean` | Determines whether specification filters should be hidden (`true`) or not (`false`). | `false` |
-| `hiddenFilters` | `object` | Object array of specification filters that should be hidden. The possible values are in [this table](#the-hiddenfilters-object). | `undefined` |
+| Prop name       | Type      | Description                                                                                                                      | Default value |
+| --------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `hideAll`       | `boolean` | Determines whether specification filters should be hidden (`true`) or not (`false`).                                             | `false`       |
+| `hiddenFilters` | `object`  | Object array of specification filters that should be hidden. The possible values are in [this table](#the-hiddenfilters-object). | `undefined`   |
 
 #### The `hiddenFilters` object
 
-| Prop name | Type | Description | Default value |
-| - | - | - | - |
-| `name` | `string` | Name of the specification filter that you want to hide. | `undefined` |
+| Prop name | Type     | Description                                             | Default value |
+| --------- | -------- | ------------------------------------------------------- | ------------- |
+| `name`    | `string` | Name of the specification filter that you want to hide. | `undefined`   |
 
 ### Using the Flex Layout to build your search results page
 
@@ -313,71 +303,71 @@ To understand how to build your search results with multiple layouts using the `
 
 ##### The `gallery-layout-switcher` props
 
-| Prop name | Type | Description | Default value |
-| - | - | - | - |
-| `layouts` | `object` | List of layouts used to arrange and display the items on the search results page. If no value is provided, the `gallery` block must receive a `product-summary-shelf` block instead as a child. Check [this table](#the-layouts-object) for props of this block. | `undefined` |
-| `undefined` | `block` | Defines which blocks should be rendered per layout. The prop name is not `undefined`, you must include the value passed on the `component` prop. This prop's value must match the block name of your choosing to be rendered in that specific layout. | `undefined` |
-| `customSummaryInterval` | `number` | Defines the item interval at which the **Gallery** should render a custom `product-summary` block. For example, declaring `5` would render a custom block at every four items rendered, as shown [on this image](https://user-images.githubusercontent.com/1207017/101687291-0cff1780-3a49-11eb-9c00-678b70001c8a.jpg). It is important to know that this prop doesn't support `layouts` yet. | `undefined` |
-| `CustomSummary` | `block` | Defines a block to be rendered according to the interval defined by the `customSummaryInterval` prop. | `undefined` |
-| `preferredSKU` | `PreferredSKUEnum` | Controls which SKU will be initially selected in the product summary. | `"FIRST_AVAILABLE"` |
+| Prop name               | Type               | Description                                                                                                                                                                                                                                                                                                                                                                                   | Default value       |
+| ----------------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| `layouts`               | `object`           | List of layouts used to arrange and display the items on the search results page. If no value is provided, the `gallery` block must receive a `product-summary-shelf` block instead as a child. Check [this table](#the-layouts-object) for props of this block.                                                                                                                              | `undefined`         |
+| `undefined`             | `block`            | Defines which blocks should be rendered per layout. The prop name is not `undefined`, you must include the value passed on the `component` prop. This prop's value must match the block name of your choosing to be rendered in that specific layout.                                                                                                                                         | `undefined`         |
+| `customSummaryInterval` | `number`           | Defines the item interval at which the **Gallery** should render a custom `product-summary` block. For example, declaring `5` would render a custom block at every four items rendered, as shown [on this image](https://user-images.githubusercontent.com/1207017/101687291-0cff1780-3a49-11eb-9c00-678b70001c8a.jpg). It is important to know that this prop doesn't support `layouts` yet. | `undefined`         |
+| `CustomSummary`         | `block`            | Defines a block to be rendered according to the interval defined by the `customSummaryInterval` prop.                                                                                                                                                                                                                                                                                         | `undefined`         |
+| `preferredSKU`          | `PreferredSKUEnum` | Controls which SKU will be initially selected in the product summary.                                                                                                                                                                                                                                                                                                                         | `"FIRST_AVAILABLE"` |
 
 For `PreferredSKUEnum`:
 
-| Name | Value | Description |
-| - | - | - |
+| Name            | Value             | Description                                                    |
+| --------------- | ----------------- | -------------------------------------------------------------- |
 | First Available | `FIRST_AVAILABLE` | First available SKU in stock found or first SKU without stock. |
-| Last Available | `LAST_AVAILABLE` | Last available SKU in stock found or last SKU without stock. |
-| Cheapest | `PRICE_ASC` | Cheapest SKU in stock found or first SKU without stock. |
-| Most Expensive | `PRICE_DESC` | Most expensive SKU in stock found or first SKU without stock. |
+| Last Available  | `LAST_AVAILABLE`  | Last available SKU in stock found or last SKU without stock.   |
+| Cheapest        | `PRICE_ASC`       | Cheapest SKU in stock found or first SKU without stock.        |
+| Most Expensive  | `PRICE_DESC`      | Most expensive SKU in stock found or first SKU without stock.  |
 
 > ⚠️ There's a way to select which SKU should take preference over this prop. You can create a product specification (field) and per product assign the value of the desired SKU to be initially selected. Keep in mind that if the specification doesn't exist or if the value is empty, it will use the `preferredSKU` prop as fallback. You can read more about it, and how to implement it in [Recipes](https://developers.vtex.com/docs/guides/storefront-implementation)
 
 ##### The `layouts` object
 
-| Prop name | Type | Description | Default value |
-| - | - | - | - |
-| `name` | `string` | ![https://img.shields.io/badge/-Mandatory-red](https://img.shields.io/badge/-Mandatory-red) Layout name. This value must be unique i.e. not equal to other layout names declared in the `gallery` block. | `undefined` |
-| `component` | `string` | ![https://img.shields.io/badge/-Mandatory-red](https://img.shields.io/badge/-Mandatory-red) Names the `undefined` prop from the `gallery` block, which is responsible for declaring the block to be rendered in this layout. This prop's value can be any of your choosing as long as it is PascalCased i.e. has the first letter of each word in its name capitalized. **Caution**: For this to work, the chosen value must be named after the `gallery` block's `undefined` prop. _Do not use the `component` prop's value to directly pass the desired block name itself_. Check out the example below in order to understand the underlying logic behind this prop. | `undefined` |
-| `itemsPerRow` | `number` / `object` | ![https://img.shields.io/badge/-Mandatory-red](https://img.shields.io/badge/-Mandatory-red) Number of items to be displayed in each row of this layout. This prop works with [responsive values](https://developers.vtex.com/docs/apps/vtex.responsive-values/), therefore it also accepts an object with different numbers for desktop, tablet or phone screen sizes (_see the table below_). | `undefined` |
+| Prop name     | Type                | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | Default value |
+| ------------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `name`        | `string`            | ![https://img.shields.io/badge/-Mandatory-red](https://img.shields.io/badge/-Mandatory-red) Layout name. This value must be unique i.e. not equal to other layout names declared in the `gallery` block.                                                                                                                                                                                                                                                                                                                                                                                                                                                                | `undefined`   |
+| `component`   | `string`            | ![https://img.shields.io/badge/-Mandatory-red](https://img.shields.io/badge/-Mandatory-red) Names the `undefined` prop from the `gallery` block, which is responsible for declaring the block to be rendered in this layout. This prop's value can be any of your choosing as long as it is PascalCased i.e. has the first letter of each word in its name capitalized. **Caution**: For this to work, the chosen value must be named after the `gallery` block's `undefined` prop. _Do not use the `component` prop's value to directly pass the desired block name itself_. Check out the example below in order to understand the underlying logic behind this prop. | `undefined`   |
+| `itemsPerRow` | `number` / `object` | ![https://img.shields.io/badge/-Mandatory-red](https://img.shields.io/badge/-Mandatory-red) Number of items to be displayed in each row of this layout. This prop works with [responsive values](https://developers.vtex.com/docs/apps/vtex.responsive-values/), therefore it also accepts an object with different numbers for desktop, tablet or phone screen sizes (_see the table below_).                                                                                                                                                                                                                                                                          | `undefined`   |
 
 ##### The `itemsPerRow` object
 
-| Prop name | Type | Description | Default value |
-| - | - | - | - |
-| `desktop` | `number` | Number of slides to be shown on desktop devices. | `undefined` |
-| `tablet` | `number` | Number of slides to be shown on tablet devices. | `undefined` |
-| `phone` | `number` | Number of slides to be shown on phone devices. | `undefined` |
+| Prop name | Type     | Description                                      | Default value |
+| --------- | -------- | ------------------------------------------------ | ------------- |
+| `desktop` | `number` | Number of slides to be shown on desktop devices. | `undefined`   |
+| `tablet`  | `number` | Number of slides to be shown on tablet devices.  | `undefined`   |
+| `phone`   | `number` | Number of slides to be shown on phone devices.   | `undefined`   |
 
 ##### Example of a `gallery` block
 
 ```json
 {
-    "gallery": {
-        "props": {
-            "layouts": [
-                {
-                    "name": "whole",
-                    "component": "OneOrTwoLineSummary",
-                    "itemsPerRow": 1
-                },
-                {
-                    "name": "two",
-                    "component": "OneOrTwoLineSummary",
-                    "itemsPerRow": 2
-                },
-                {
-                    "name": "many",
-                    "component": "ManyByLineSummary",
-                    "itemsPerRow": {
-                        "desktop": 5,
-                        "mobile": 1
-                    }
-                }
-            ],
-            "OneOrTwoLineSummary": "product-summary.shelf",
-            "ManyByLineSummary": "product-summary.shelf"
+  "gallery": {
+    "props": {
+      "layouts": [
+        {
+          "name": "whole",
+          "component": "OneOrTwoLineSummary",
+          "itemsPerRow": 1
+        },
+        {
+          "name": "two",
+          "component": "OneOrTwoLineSummary",
+          "itemsPerRow": 2
+        },
+        {
+          "name": "many",
+          "component": "ManyByLineSummary",
+          "itemsPerRow": {
+            "desktop": 5,
+            "mobile": 1
+          }
         }
+      ],
+      "OneOrTwoLineSummary": "product-summary.shelf",
+      "ManyByLineSummary": "product-summary.shelf"
     }
+  }
 }
 ```
 
@@ -391,49 +381,40 @@ It receives no props and expects [the `gallery-layout-option` block](#the-galler
 
 This block defines how each layout option should be rendered for users.
 
-| Prop name | Type | Description | Default value |
-| - | - | - | - |
-| `name` | `string` | ![https://img.shields.io/badge/-Mandatory-red](https://img.shields.io/badge/-Mandatory-red) Name of the layout option. This prop's value must match the one passed to the [`name` prop](#the-layouts-object). | `undefined` |
+| Prop name | Type     | Description                                                                                                                                                                                                   | Default value |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `name`    | `string` | ![https://img.shields.io/badge/-Mandatory-red](https://img.shields.io/badge/-Mandatory-red) Name of the layout option. This prop's value must match the one passed to the [`name` prop](#the-layouts-object). | `undefined`   |
 
 ##### Example of the `gallery-layout-switcher` and the `gallery-layout-option` blocks
 
 ```jsonc
 {
-    "gallery-layout-switcher": {
-        "children": [
-            //It follows the same whole -> two -> many order
-            "gallery-layout-option#whole",
-            "gallery-layout-option#two",
-            "gallery-layout-option#many"
-        ]
+  "gallery-layout-switcher": {
+    "children": [
+      //It follows the same whole -> two -> many order
+      "gallery-layout-option#whole",
+      "gallery-layout-option#two",
+      "gallery-layout-option#many"
+    ]
+  },
+  "gallery-layout-option#whole": {
+    "props": {
+      "name": "whole"
     },
-    "gallery-layout-option#whole": {
-        "props": {
-            "name": "whole"
-        },
-        "children": [
-            "icon-single-grid",
-            "rich-text#option-whole"
-        ]
+    "children": ["icon-single-grid", "rich-text#option-whole"]
+  },
+  "gallery-layout-option#two": {
+    "props": {
+      "name": "two"
     },
-    "gallery-layout-option#two": {
-        "props": {
-            "name": "two"
-        },
-        "children": [
-            "icon-inline-grid",
-            "rich-text#option-two"
-        ]
+    "children": ["icon-inline-grid", "rich-text#option-two"]
+  },
+  "gallery-layout-option#many": {
+    "props": {
+      "name": "many"
     },
-    "gallery-layout-option#many": {
-        "props": {
-            "name": "many"
-        },
-        "children": [
-            "icon-menu",
-            "rich-text#option-many"
-        ]
-    }
+    "children": ["icon-menu", "rich-text#option-many"]
+  }
 }
 ```
 
@@ -441,53 +422,53 @@ This block defines how each layout option should be rendered for users.
 
 This block renders a filter selector for the fetched results.
 
-| Prop name | Type | Description | Default value |
-| - | - | - | - |
-| `categoryFiltersMode` | `enum` |  Determines whether the category filters should use the `href` attribute with the category pages' URLs (`href`) or not (`default`). By default, the filters use HTML divs with `role="link"`. You may change this behavior by setting this prop's value to `href`, thereby creating a link building to improve the SEO ranking of your category pages. | `default` |
-| `layout` | `enum` |  Determines whether the **Filter Navigator** layout should be responsive (`responsive`) or not (`desktop`). You may use `desktop` when the **Filter Navigator** is configured to display in a [drawer](https://developers.vtex.com/docs/guides/vtex-store-drawer). | `responsive` |
-| `maxItemsDepartment` | `number` | Maximum number of departments to be displayed before the **See More** button is triggered. | `8` |
-| `maxItemsCategory` | `number` | Maximum number of category items to be displayed before the **See More** button is triggered. | `8` |
-| `initiallyCollapsed` | `boolean` | Makes the search filters start out collapsed (`true`) or open (`false`). | `false` |
-| `openFiltersMode` | `enum` | Defines how many filters can be opened simultaneously on the **Filter Navigator** component. The possible values are `many` (more than one filter can be opened simultaneously) and `one` (only one filter can be opened). Notice that if `one` is declared, all filters will collapse before user interaction, regardless of the value passed to the `initiallyCollapsed` prop. | `many` |
-| `filtersTitleHtmlTag` | `string` | HTML tag for the filter's title. | `h5` |
-| `scrollToTop` | `enum` | Scrolls the page to the top (`auto` or `smooth`) or not (`none`) when selecting a facet. | `none` |
-| `truncateFilters` | `boolean` |  Determines whether a filter selector with more than 10 filter options should shorten the list and display a `See more` button (`true`) or not (`false`). | `false` |
-| `closeOnOutsideClick` | `boolean` |  Determines whether the **Filter Navigator** component should be closed when users click outside of it (`true`) or not (`false`). This prop only works if the `openFiltersMode` prop is set as `one`. | `false` |
-| `appliedFiltersOverview` | `enum` |  Determines whether an overview of the applied filters should be displayed (`show`) or not (`hide`). | `hide` |
-| `totalProductsOnMobile` | `enum` |  Determines whether the Filter Navigator should display the total number of products on mobile devices (`show`) or not (`hide`). | `hide` |
-| `fullWidthOnMobile` | `boolean` |  Determines whether the `filter-navigator.v3` will be rendered on mobile using the full screen width (`true`) or not (`false`). | `false` |
-| `navigationTypeOnMobile` | `enum` | Defines how mobile users should navigate on the filter selector component. The possible values are `page` (only one list of options can be seen at a time) or `collapsible` (all lists of options can be seen simultaneously). | `page` |
-| `updateOnFilterSelectionOnMobile` | `boolean` |  Determines whether the search results on mobile should be updated according to filter selection (`true`) or not (`false`). This prop only works if the `preventRouteChange` prop is declared as `true`. | `false` |
-| `drawerDirectionMobile` | `Enum` |  Determines whether the search filters on mobile opens to the left (`drawerLeft`) or to the right (`drawerRight`) | `drawerLeft` |
-| `showClearByFilter` | `boolean` |  Determines whether a clear button (responsible for erasing all filter options selected by the user) should be displayed alongside the filter name (`true`) or not (`false`). | `false` |
-| `showClearAllFiltersOnDesktop` | `boolean` |  Determines whether a clear button should be displayed (`true`) or not (`false`). This button will reset all selected filters. | `false` |
-| `priceRangeLayout` | `enum` |  Determines whether a text field enters the desired price range should be displayed (`inputAndSlider`) or not (`slider`). | `slider` |
-| `facetOrdering` | `array` | Array of objects (see below) that applies custom sorting rules for filters. The default behavior sorts the items by quantity, in descending order. | `undefined` |
-| `showQuantityBadgeOnMobile` | `boolean` | Displays a badge for mobile users indicating how many active filters there are. | `false` |
+| Prop name                         | Type      | Description                                                                                                                                                                                                                                                                                                                                                                      | Default value |
+| --------------------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `categoryFiltersMode`             | `enum`    | Determines whether the category filters should use the `href` attribute with the category pages' URLs (`href`) or not (`default`). By default, the filters use HTML divs with `role="link"`. You may change this behavior by setting this prop's value to `href`, thereby creating a link building to improve the SEO ranking of your category pages.                            | `default`     |
+| `layout`                          | `enum`    | Determines whether the **Filter Navigator** layout should be responsive (`responsive`) or not (`desktop`). You may use `desktop` when the **Filter Navigator** is configured to display in a [drawer](https://developers.vtex.com/docs/guides/vtex-store-drawer).                                                                                                                | `responsive`  |
+| `maxItemsDepartment`              | `number`  | Maximum number of departments to be displayed before the **See More** button is triggered.                                                                                                                                                                                                                                                                                       | `8`           |
+| `maxItemsCategory`                | `number`  | Maximum number of category items to be displayed before the **See More** button is triggered.                                                                                                                                                                                                                                                                                    | `8`           |
+| `initiallyCollapsed`              | `boolean` | Makes the search filters start out collapsed (`true`) or open (`false`).                                                                                                                                                                                                                                                                                                         | `false`       |
+| `openFiltersMode`                 | `enum`    | Defines how many filters can be opened simultaneously on the **Filter Navigator** component. The possible values are `many` (more than one filter can be opened simultaneously) and `one` (only one filter can be opened). Notice that if `one` is declared, all filters will collapse before user interaction, regardless of the value passed to the `initiallyCollapsed` prop. | `many`        |
+| `filtersTitleHtmlTag`             | `string`  | HTML tag for the filter's title.                                                                                                                                                                                                                                                                                                                                                 | `h5`          |
+| `scrollToTop`                     | `enum`    | Scrolls the page to the top (`auto` or `smooth`) or not (`none`) when selecting a facet.                                                                                                                                                                                                                                                                                         | `none`        |
+| `truncateFilters`                 | `boolean` | Determines whether a filter selector with more than 10 filter options should shorten the list and display a `See more` button (`true`) or not (`false`).                                                                                                                                                                                                                         | `false`       |
+| `closeOnOutsideClick`             | `boolean` | Determines whether the **Filter Navigator** component should be closed when users click outside of it (`true`) or not (`false`). This prop only works if the `openFiltersMode` prop is set as `one`.                                                                                                                                                                             | `false`       |
+| `appliedFiltersOverview`          | `enum`    | Determines whether an overview of the applied filters should be displayed (`show`) or not (`hide`).                                                                                                                                                                                                                                                                              | `hide`        |
+| `totalProductsOnMobile`           | `enum`    | Determines whether the Filter Navigator should display the total number of products on mobile devices (`show`) or not (`hide`).                                                                                                                                                                                                                                                  | `hide`        |
+| `fullWidthOnMobile`               | `boolean` | Determines whether the `filter-navigator.v3` will be rendered on mobile using the full screen width (`true`) or not (`false`).                                                                                                                                                                                                                                                   | `false`       |
+| `navigationTypeOnMobile`          | `enum`    | Defines how mobile users should navigate on the filter selector component. The possible values are `page` (only one list of options can be seen at a time) or `collapsible` (all lists of options can be seen simultaneously).                                                                                                                                                   | `page`        |
+| `updateOnFilterSelectionOnMobile` | `boolean` | Determines whether the search results on mobile should be updated according to filter selection (`true`) or not (`false`). This prop only works if the `preventRouteChange` prop is declared as `true`.                                                                                                                                                                          | `false`       |
+| `drawerDirectionMobile`           | `Enum`    | Determines whether the search filters on mobile opens to the left (`drawerLeft`) or to the right (`drawerRight`)                                                                                                                                                                                                                                                                 | `drawerLeft`  |
+| `showClearByFilter`               | `boolean` | Determines whether a clear button (responsible for erasing all filter options selected by the user) should be displayed alongside the filter name (`true`) or not (`false`).                                                                                                                                                                                                     | `false`       |
+| `showClearAllFiltersOnDesktop`    | `boolean` | Determines whether a clear button should be displayed (`true`) or not (`false`). This button will reset all selected filters.                                                                                                                                                                                                                                                    | `false`       |
+| `priceRangeLayout`                | `enum`    | Determines whether a text field enters the desired price range should be displayed (`inputAndSlider`) or not (`slider`).                                                                                                                                                                                                                                                         | `slider`      |
+| `facetOrdering`                   | `array`   | Array of objects (see below) that applies custom sorting rules for filters. The default behavior sorts the items by quantity, in descending order.                                                                                                                                                                                                                               | `undefined`   |
+| `showQuantityBadgeOnMobile`       | `boolean` | Displays a badge for mobile users indicating how many active filters there are.                                                                                                                                                                                                                                                                                                  | `false`       |
 
 - **`facetOrdering` object:**
 
-| Prop name | Type | Description | Default value |
-| - | - | - | - |
-| `key` | `string` | Facet key that will be sorted. Possible values are `category-1`, `category-2`, `category-3` (for department, category and subcategory), `brand` or a product specification name. | `undefined` |
-| `orderBy` | `enum` | Field from facets that should be used when sorting the entries. Possible values are `name` and `quantity`. | `undefined` |
-| `order` | `enum` | Determines whether the filter should be sorted by ascending (`ASC`) or descending (`DESC`) order. | `ASC` |
+| Prop name | Type     | Description                                                                                                                                                                      | Default value |
+| --------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `key`     | `string` | Facet key that will be sorted. Possible values are `category-1`, `category-2`, `category-3` (for department, category and subcategory), `brand` or a product specification name. | `undefined`   |
+| `orderBy` | `enum`   | Field from facets that should be used when sorting the entries. Possible values are `name` and `quantity`.                                                                       | `undefined`   |
+| `order`   | `enum`   | Determines whether the filter should be sorted by ascending (`ASC`) or descending (`DESC`) order.                                                                                | `ASC`         |
 
 For example:
 
 ```jsonc
 {
-    "filter-navigator.v3": {
-        "props": {
-            "facetOrdering": [
-                {
-                    "key": "brand",
-                    "orderBy": "name",
-                    "order": "ASC"
-                }
-            ]
+  "filter-navigator.v3": {
+    "props": {
+      "facetOrdering": [
+        {
+          "key": "brand",
+          "orderBy": "name",
+          "order": "ASC"
         }
+      ]
     }
+  }
 }
 ```
 
@@ -499,18 +480,18 @@ The `order-by` block renders a dropdown button with [sorting options](#the-sorti
 
 ##### The `order-by` props
 
-| Prop name | Type | Description | Default value |
-| - | - | - | - |
+| Prop name              | Type       | Description                                                                                                                     | Default value |
+| ---------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------- |
 | `specificationOptions` | `[object]` | Indicates which sorting options by specification will be displayed. This only works for stores using `vtex.search-resolver@1.x` | `undefined`   |
-| `hiddenOptions`  | `[string]` | Indicates which sorting options will be hidden. (e.g. `["OrderByNameASC", "OrderByNameDESC"]`)  | `undefined`   |
-| `showOrderTitle` | `boolean`  | Determines whether the selected order value (e.g. `Relevance`) will be displayed (`true`) or not (`false`).      | `true`  |
+| `hiddenOptions`        | `[string]` | Indicates which sorting options will be hidden. (e.g. `["OrderByNameASC", "OrderByNameDESC"]`)                                  | `undefined`   |
+| `showOrderTitle`       | `boolean`  | Determines whether the selected order value (e.g. `Relevance`) will be displayed (`true`) or not (`false`).                     | `true`        |
 
 - **`specificationOptions` Object:**
-  
-  | Prop name | Type | Description | Default value |
-  | - | - | - | - |
-  | value | string | Value that will be sent for sorting in the API. It must be in the format `{specification key}:{asc/desc}`. For example: `"size:desc"` or `"priceByUnit:asc"`. | `undefined` |
-  | label | string | Label that will be displayed in the sorting options. E.g.: `"Price by unit, ascending"` | `undefined` |
+
+  | Prop name | Type   | Description                                                                                                                                                   | Default value |
+  | --------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+  | value     | string | Value that will be sent for sorting in the API. It must be in the format `{specification key}:{asc/desc}`. For example: `"size:desc"` or `"priceByUnit:asc"`. | `undefined`   |
+  | label     | string | Label that will be displayed in the sorting options. E.g.: `"Price by unit, ascending"`                                                                       | `undefined`   |
 
 ##### Sorting options for the `order-by` block
 
@@ -534,9 +515,9 @@ The `search-fetch-more` block renders a **Show More** button used to load the re
 
 ##### The `search-fetch-more` prop
 
-| Prop name | Type | Description | Default value |
-| - | - | - | - |
-| `htmlElementForButton` | `enum` | Which HTML element will be displayed for `Show more` button component. Possible values are: `a` (displays a `<a>` element with `href` and `rel` attributes) or `button` (displays a `<button>` element without `href` and `rel` attributes). | `button` |
+| Prop name              | Type   | Description                                                                                                                                                                                                                                  | Default value |
+| ---------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `htmlElementForButton` | `enum` | Which HTML element will be displayed for `Show more` button component. Possible values are: `a` (displays a `<a>` element with `href` and `rel` attributes) or `button` (displays a `<button>` element without `href` and `rel` attributes). | `button`      |
 
 #### The `search-fetch-previous` block
 
@@ -546,9 +527,9 @@ The `search-fetch-previous` block renders a `Show Previous` button used to load 
 
 ##### The `search-fetch-previous` prop
 
-| Prop name | Type | Description | Default value |
-| - | - | - | - |
-| `htmlElementForButton` | `enum` | Which HTML element will be displayed for `Show previous` button component. Possible values are: `a` (displays a `<a>` element with `href` and `rel` attributes) or `button` (displays a `<button>` element without `href` and `rel` attributes). | `button` |
+| Prop name              | Type   | Description                                                                                                                                                                                                                                      | Default value |
+| ---------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
+| `htmlElementForButton` | `enum` | Which HTML element will be displayed for `Show previous` button component. Possible values are: `a` (displays a `<a>` element with `href` and `rel` attributes) or `button` (displays a `<button>` element without `href` and `rel` attributes). | `button`      |
 
 #### The `search-products-count-per-page` block
 

--- a/react/components/AccordionFilterGroup.js
+++ b/react/components/AccordionFilterGroup.js
@@ -2,6 +2,8 @@ import React from 'react'
 import { useIntl } from 'react-intl'
 import classNames from 'classnames'
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
+import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
+import { usePixel } from 'vtex.pixel-manager'
 
 import AccordionFilterItem from './AccordionFilterItem'
 import FacetCheckboxList from './FacetCheckboxList'
@@ -9,6 +11,7 @@ import useSelectedFilters from '../hooks/useSelectedFilters'
 import { getFilterTitle } from '../constants/SearchHelpers'
 import { searchSlugify } from '../utils/slug'
 import RadioFilters from './RadioFilters'
+import { pushFilterManipulationPixelEvent } from '../utils/filterManipulationPixelEvents'
 
 const CSS_HANDLES = ['accordionFilterOpen']
 
@@ -30,6 +33,7 @@ const AccordionFilterGroup = ({
   onClearFilter,
   showClearByFilter,
 }) => {
+  const { searchQuery } = useSearchPage()
   const handles = useCssHandles(CSS_HANDLES)
   const filters = useSelectedFilters(facets)
   const selectedFilters = filters.filter(facet => facet.selected)
@@ -37,6 +41,7 @@ const AccordionFilterGroup = ({
   const facetTitle = getFilterTitle(title, intl)
   const slugifiedFacetTitle = searchSlugify(facetTitle)
   const facetKey = filters.length > 0 ? filters[0].key : null
+  const { push } = usePixel()
 
   const isRadio = filters.some(filter => filter.key === 'shipping')
 
@@ -65,6 +70,12 @@ const AccordionFilterGroup = ({
           <RadioFilters
             facets={filters}
             onChange={facet => {
+              pushFilterManipulationPixelEvent({
+                name: facetTitle,
+                value: facet.name,
+                products: searchQuery?.products ?? [],
+                push,
+              })
               onFilterCheck({ ...facet, title: facetTitle }, true)
             }}
           />

--- a/react/components/AccordionFilterGroup.js
+++ b/react/components/AccordionFilterGroup.js
@@ -8,6 +8,7 @@ import FacetCheckboxList from './FacetCheckboxList'
 import useSelectedFilters from '../hooks/useSelectedFilters'
 import { getFilterTitle } from '../constants/SearchHelpers'
 import { searchSlugify } from '../utils/slug'
+import RadioFilters from './RadioFilters'
 
 const CSS_HANDLES = ['accordionFilterOpen']
 
@@ -37,6 +38,8 @@ const AccordionFilterGroup = ({
   const slugifiedFacetTitle = searchSlugify(facetTitle)
   const facetKey = filters.length > 0 ? filters[0].key : null
 
+  const isRadio = filters.some(filter => filter.key === 'shipping')
+
   return (
     <AccordionFilterItem
       facetKey={facetKey}
@@ -58,16 +61,25 @@ const AccordionFilterGroup = ({
           className
         )}
       >
-        <FacetCheckboxList
-          onFilterCheck={onFilterCheck}
-          facets={filters}
-          quantity={quantity}
-          facetTitle={facetTitle}
-          truncateFilters={truncateFilters}
-          navigationType={navigationType}
-          truncatedFacetsFetched={truncatedFacetsFetched}
-          setTruncatedFacetsFetched={setTruncatedFacetsFetched}
-        />
+        {isRadio ? (
+          <RadioFilters
+            facets={filters}
+            onChange={facet => {
+              onFilterCheck({ ...facet, title: facetTitle }, true)
+            }}
+          />
+        ) : (
+          <FacetCheckboxList
+            onFilterCheck={onFilterCheck}
+            facets={filters}
+            quantity={quantity}
+            facetTitle={facetTitle}
+            truncateFilters={truncateFilters}
+            navigationType={navigationType}
+            truncatedFacetsFetched={truncatedFacetsFetched}
+            setTruncatedFacetsFetched={setTruncatedFacetsFetched}
+          />
+        )}
       </div>
     </AccordionFilterItem>
   )

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -95,9 +95,19 @@ const FilterSidebar = ({
     )
   }
 
-  const handleFilterCheck = filter => {
+  const handleFilterCheck = (filter, isRadio = false) => {
     if (updateOnFilterSelectionOnMobile && preventRouteChange) {
       navigateToFacet(filter, preventRouteChange)
+
+      return
+    }
+
+    if (isRadio) {
+      setFilterOperations(
+        filterOperations
+          .filter(facet => facet.key !== filter.key)
+          .concat(filter)
+      )
 
       return
     }


### PR DESCRIPTION
#### What problem is this solving?

This PR add a radio button to the shipping facets in mobile.

#### How to test it?

Open the PLP in mobile and use the shipping filter. 

[Workspace](https://dpdemo--mundodocabeleireiro.myvtex.com/)

#### Screenshots or example usage:

https://github.com/user-attachments/assets/2a6b94e6-4f67-459f-8571-4ca25c7ed95e


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
