### PR TITLE
Add shipping options context

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -38,7 +38,8 @@
     "vtex.css-handles": "0.x",
     "vtex.store-drawer": "0.x",
     "vtex.product-list-context": "0.x",
-    "vtex.structured-data": "0.x"
+    "vtex.structured-data": "0.x",
+    "vtex.shipping-option-components": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/SearchResultFlexible.js
+++ b/react/SearchResultFlexible.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useEffect, useRef, useState } from 'react'
+import React, { useMemo, useEffect, useRef } from 'react'
 import {
   SearchPageContext,
   SearchPageStateContext,
@@ -9,9 +9,6 @@ import { useCssHandles } from 'vtex.css-handles'
 import { useRuntime } from 'vtex.render-runtime'
 import { generateBlockClass } from '@vtex/css-handles'
 import { pathOr, isEmpty } from 'ramda'
-import PostalCodeModal from 'vtex.shipping-option-components/PostalCodeModal'
-import PickupModal from 'vtex.shipping-option-components/PickupModal'
-import { usePixelEventCallback } from 'vtex.pixel-manager'
 
 import SearchResultContainer from './components/SearchResultContainer'
 import ContextProviders from './components/ContextProviders'
@@ -19,9 +16,6 @@ import getFilters from './utils/getFilters'
 import LoadingOverlay from './components/LoadingOverlay'
 import { PAGINATION_TYPE } from './constants/paginationType'
 import styles from './searchResult.css'
-
-const DELIVER_DRAWER_PIXEL_EVENT_ID = 'shipping-option-deliver-to'
-const STORE_DRAWER_PIXEL_EVENT_ID = 'shipping-option-store'
 
 const emptyFacets = {
   brands: [],
@@ -71,21 +65,6 @@ const SearchResultFlexible = ({
   thresholdForFacetSearch,
   lazyItemsRemaining,
 }) => {
-  const [isPostalCodeModalOpen, setIsPostalCodeModalOpen] = useState(false)
-  const [isPickupModalOpen, setisPickupModalOpen] = useState(false)
-
-  usePixelEventCallback({
-    eventId: DELIVER_DRAWER_PIXEL_EVENT_ID,
-    handler: () => setIsPostalCodeModalOpen(true),
-  })
-
-  usePixelEventCallback({
-    eventId: STORE_DRAWER_PIXEL_EVENT_ID,
-    handler: () => {
-      setisPickupModalOpen(true)
-    },
-  })
-
   // This makes infinite scroll unavailable.
   // Infinite scroll was deprecated and we have
   // removed it since the flexible search release
@@ -251,14 +230,6 @@ const SearchResultFlexible = ({
                 >
                   {children}
                 </div>
-                <PostalCodeModal
-                  isOpen={isPostalCodeModalOpen}
-                  onClose={() => setIsPostalCodeModalOpen(false)}
-                />
-                <PickupModal
-                  isOpen={isPickupModalOpen}
-                  onClose={() => setisPickupModalOpen(false)}
-                />
               </LoadingOverlay>
             </SearchResultContainer>
           </ContextProviders>

--- a/react/SearchResultFlexible.js
+++ b/react/SearchResultFlexible.js
@@ -11,10 +11,6 @@ import { generateBlockClass } from '@vtex/css-handles'
 import { pathOr, isEmpty } from 'ramda'
 import PostalCodeModal from 'vtex.shipping-option-components/PostalCodeModal'
 import PickupModal from 'vtex.shipping-option-components/PickupModal'
-import {
-  useShippingOptionDispatch,
-  useShippingOptionState,
-} from 'vtex.shipping-option-components/ShippingOptionContext'
 import { usePixelEventCallback } from 'vtex.pixel-manager'
 
 import SearchResultContainer from './components/SearchResultContainer'
@@ -78,14 +74,6 @@ const SearchResultFlexible = ({
   const [isPostalCodeModalOpen, setIsPostalCodeModalOpen] = useState(false)
   const [isPickupModalOpen, setisPickupModalOpen] = useState(false)
 
-  const shippingOptionDispatch = useShippingOptionDispatch()
-  const {
-    isLoading,
-    zipcode: selectedZipCode,
-    pickups,
-    selectedPickup,
-  } = useShippingOptionState()
-
   usePixelEventCallback({
     eventId: DELIVER_DRAWER_PIXEL_EVENT_ID,
     handler: () => setIsPostalCodeModalOpen(true),
@@ -97,20 +85,6 @@ const SearchResultFlexible = ({
       setisPickupModalOpen(true)
     },
   })
-
-  const onSubmit = (zipcode, reload) => {
-    shippingOptionDispatch({
-      type: 'UPDATE_ZIPCODE',
-      args: { zipcode, reload },
-    })
-  }
-
-  const onSelectPickup = (pickup, shouldPersistFacet) => {
-    shippingOptionDispatch({
-      type: 'UPDATE_PICKUP',
-      args: { pickup, shouldPersistFacet },
-    })
-  }
 
   // This makes infinite scroll unavailable.
   // Infinite scroll was deprecated and we have
@@ -280,22 +254,10 @@ const SearchResultFlexible = ({
                 <PostalCodeModal
                   isOpen={isPostalCodeModalOpen}
                   onClose={() => setIsPostalCodeModalOpen(false)}
-                  onSubmit={onSubmit}
-                  isLoading={isLoading}
-                  selectedZipCode={selectedZipCode}
                 />
                 <PickupModal
                   isOpen={isPickupModalOpen}
                   onClose={() => setisPickupModalOpen(false)}
-                  pickupProps={{
-                    onSelectPickup,
-                    onSubmit: value => onSubmit(value, false),
-                    pickups,
-                    inputErrorMessage: '',
-                    selectedPickup,
-                    selectedZipCode,
-                    isLoading,
-                  }}
                 />
               </LoadingOverlay>
             </SearchResultContainer>

--- a/react/components/RadioFilters.js
+++ b/react/components/RadioFilters.js
@@ -1,14 +1,16 @@
 import React, { useEffect, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { RadioGroup } from 'vtex.styleguide'
+import PostalCodeModal from 'vtex.shipping-option-components/PostalCodeModal'
+import PickupModal from 'vtex.shipping-option-components/PickupModal'
 
 import ShippingActionButton from './ShippingActionButton'
 import useShippingActions from '../hooks/useShippingActions'
 
-const RadioItem = ({ facet }) => {
+const RadioItem = ({ facet, onOpenPostalCodeModal, onOpenPickupModal }) => {
   const intl = useIntl()
 
-  const { actionLabel, actionType, openDrawer } = useShippingActions(facet)
+  const { actionLabel, actionType } = useShippingActions(facet)
 
   return (
     <div>
@@ -16,7 +18,11 @@ const RadioItem = ({ facet }) => {
       {actionType ? (
         <ShippingActionButton
           label={intl.formatMessage({ id: actionLabel ?? 'none' })}
-          openDrawer={openDrawer}
+          openDrawer={
+            actionType === 'DELIVERY'
+              ? onOpenPostalCodeModal
+              : onOpenPickupModal
+          }
         />
       ) : undefined}
     </div>
@@ -26,6 +32,8 @@ const RadioItem = ({ facet }) => {
 const RadioFilters = ({ facets, onChange }) => {
   const selectedOption = facets.find(facet => facet.selected)
   const lastValue = selectedOption ? selectedOption.value : undefined
+  const [isPostalCodeModalOpen, setIsPostalCodeModalOpen] = useState(false)
+  const [isPickupModalOpen, setisPickupModalOpen] = useState(false)
 
   const [selectedValue, setSelectedValue] = useState(lastValue)
 
@@ -48,19 +56,35 @@ const RadioFilters = ({ facets, onChange }) => {
   }
 
   return (
-    <RadioGroup
-      hideBorder
-      size="small"
-      name="shipping"
-      options={facets.map(facet => ({
-        id: facet.value,
-        value: facet.value,
-        label: <RadioItem facet={facet} />,
-        disabled: facet.quantity === 0,
-      }))}
-      value={selectedValue}
-      onChange={onRadioSelect}
-    />
+    <>
+      <RadioGroup
+        hideBorder
+        size="small"
+        name="shipping"
+        options={facets.map(facet => ({
+          id: facet.value,
+          value: facet.value,
+          label: (
+            <RadioItem
+              facet={facet}
+              onOpenPostalCodeModal={() => setIsPostalCodeModalOpen(true)}
+              onOpenPickupModal={() => setisPickupModalOpen(true)}
+            />
+          ),
+          disabled: facet.quantity === 0,
+        }))}
+        value={selectedValue}
+        onChange={onRadioSelect}
+      />
+      <PostalCodeModal
+        isOpen={isPostalCodeModalOpen}
+        onClose={() => setIsPostalCodeModalOpen(false)}
+      />
+      <PickupModal
+        isOpen={isPickupModalOpen}
+        onClose={() => setisPickupModalOpen(false)}
+      />
+    </>
   )
 }
 

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -217,7 +217,11 @@ const useQueries = (variables, facetsArgs, price) => {
 
   const detachedFilters =
     facets && facets.facets
-      ? detachFiltersByType(facets.facets)
+      ? detachFiltersByType(
+          facets.facets,
+          !!productSearchResult.data?.productSearch?.options
+            ?.deliveryPromisesEnabled
+        )
       : {
           brands: [],
           brandsQuantity: 0,

--- a/react/hooks/useShippingActions.js
+++ b/react/hooks/useShippingActions.js
@@ -46,10 +46,10 @@ const useShippingActions = facet => {
 
   const { push } = usePixel()
 
-  const { zipcode, selectedPickup, city } = useShippingOptionState()
+  const { zipcode, selectedPickup, city, addressLabel } =
+    useShippingOptionState()
 
   useEffect(() => {
-    const addressLabel = city ? `${city}, ${zipcode}` : zipcode
     const pickupPointLabel = selectedPickup
       ? selectedPickup.pickupPoint.friendlyName
       : ''
@@ -85,6 +85,7 @@ const useShippingActions = facet => {
     isAddressDependent,
     zipcode,
     selectedPickup,
+    addressLabel,
   ])
 
   const openDrawer = useCallback(() => {

--- a/react/hooks/useShippingActions.js
+++ b/react/hooks/useShippingActions.js
@@ -1,5 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
-import { usePixel } from 'vtex.pixel-manager'
+import { useEffect, useState } from 'react'
 import { useShippingOptionState } from 'vtex.shipping-option-components/ShippingOptionContext'
 
 import useShouldDisableFacet from './useShouldDisableFacet'
@@ -21,11 +20,6 @@ const placeHolders = {
   PICKUP_POINT: 'store/search.filter.shipping.action-button.pickup-in-point',
 }
 
-const drawerEvent = {
-  DELIVERY: 'shipping-option-deliver-to',
-  PICKUP_POINT: 'shipping-option-store',
-}
-
 const addressDependentValues = [
   'delivery',
   'pickup-in-point',
@@ -43,8 +37,6 @@ const useShippingActions = facet => {
 
   const isAddressDependent =
     addressDependentValues.findIndex(value => facet.value === value) > -1
-
-  const { push } = usePixel()
 
   const { zipcode, selectedPickup, city, addressLabel } =
     useShippingOptionState()
@@ -88,19 +80,12 @@ const useShippingActions = facet => {
     addressLabel,
   ])
 
-  const openDrawer = useCallback(() => {
-    push({
-      id: drawerEvent[actionType],
-    })
-  }, [actionType, push])
-
   const shouldDisable = useShouldDisableFacet(facet, isAddressSet, isPickupSet)
 
   if (facet.value === 'pickup-nearby' || facet.value === 'pickup') {
     return {
       actionLabel: null,
       actionType: null,
-      openDrawer: null,
       shouldDisable,
     }
   }
@@ -108,7 +93,6 @@ const useShippingActions = facet => {
   return {
     actionType,
     actionLabel,
-    openDrawer,
     shouldDisable,
   }
 }

--- a/react/utils/compatibilityLayer.js
+++ b/react/utils/compatibilityLayer.js
@@ -78,7 +78,10 @@ const addMap = facet => {
   }
 }
 
-export const detachFiltersByType = facets => {
+export const detachFiltersByType = (
+  facets,
+  deliveryPromisesEnabled = false
+) => {
   facets.forEach(facet => facet.facets.forEach(value => addMap(value)))
 
   const byType = groupBy(filter => filter.type)
@@ -96,7 +99,9 @@ export const detachFiltersByType = facets => {
     groupedFilters.TEXT || []
   )
 
-  const deliveries = getFormattedDeliveries(groupedFilters.DELIVERY || [])
+  const deliveries = deliveryPromisesEnabled
+    ? getFormattedDeliveries(groupedFilters.DELIVERY || [])
+    : []
 
   const categoriesTrees = pathOr(
     [],


### PR DESCRIPTION
#### What problem is this solving?

This PR adds the shipping-option-components context, as well as the postal code and pickup modals, which will be opened via the delivery filter on the PLP.
This PR use the deliveryPromisesEnabled value to show or hide delivery filters.

[Task](https://vtex-dev.atlassian.net/browse/TIS-59)

#### How to test it?

Open and use the postal code and pickup modals through the delivery filter in the PLP.

[Workspace](https://dpdemo--mundodocabeleireiro.myvtex.com/cabelo/marcas-de-salao/shampoo/)

#### Screenshots or example usage:

https://github.com/user-attachments/assets/dd79a0a8-da08-4381-85df-3bccc1b87d6f


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
