### PR TITLE
feat: add shipping facets to SelectFilters section

### DIFF
--- a/react/components/FilterOptionTemplate.js
+++ b/react/components/FilterOptionTemplate.js
@@ -90,6 +90,7 @@ const FilterOptionTemplate = ({
   showClearByFilter,
   preventRouteChange,
   handleClear,
+  isSelectedFiltersSection = false,
 }) => {
   const [open, setOpen] = useState(!initiallyCollapsed)
   const { getSettings } = useRuntime()
@@ -163,7 +164,9 @@ const FilterOptionTemplate = ({
         ? FACETS_RENDER_THRESHOLD
         : filteredFacets.length
 
-    const isRadio = filters.some(filter => filter.key === 'shipping')
+    const isRadio =
+      !isSelectedFiltersSection &&
+      filters.some(filter => filter.key === 'shipping')
 
     return (
       <>
@@ -384,6 +387,7 @@ FilterOptionTemplate.propTypes = {
   preventRouteChange: PropTypes.bool,
   /** Custom clear handler */
   handleClear: PropTypes.func,
+  isSelectedFiltersSection: PropTypes.bool,
 }
 
 export default FilterOptionTemplate

--- a/react/components/SelectedFilters.js
+++ b/react/components/SelectedFilters.js
@@ -23,9 +23,7 @@ const SelectedFilters = ({
   const handles = useCssHandles(CSS_HANDLES)
   const { showFacetTitle } = useContext(SettingsContext)
 
-  const visibleFilters = filters
-    .filter(filter => !filter.hidden)
-    .filter(filter => filter.key !== 'shipping')
+  const visibleFilters = filters.filter(filter => !filter.hidden)
 
   if (!visibleFilters.length) {
     return null
@@ -40,6 +38,7 @@ const SelectedFilters = ({
       filters={visibleFilters}
       collapsable={false}
       selected
+      isSelectedFiltersSection
     >
       {facet => {
         return (


### PR DESCRIPTION
#### What problem is this solving?
This PR add shipping facets to the SelectFilters section so you can uncheck them.
[Task TIS-104](https://vtex-dev.atlassian.net/browse/TIS-104)
#### How to test it?

Select any shipping facet and see it in the select filters section.
After that you can uncheck it.

[Workspace](https://tis187--mundodocabeleireiro.myvtex.com/cabelo/marcas-de-salao/shampoo)

#### Screenshots or example usage:


https://github.com/user-attachments/assets/48b3e20f-a6e4-4cd8-87ee-1435d3e2475a


#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
