### PR TITLE
feat: select global shipping method in PLP filters

### DIFF
--- a/react/utils/setCookie.ts
+++ b/react/utils/setCookie.ts
@@ -1,0 +1,8 @@
+export default function setCookie(name: string, val: string) {
+  const date = new Date()
+  const value = val
+
+  date.setTime(date.getTime() + 30 * 60 * 1000)
+
+  document.cookie = `${name}=${value}; expires=${date.toUTCString()}; path=/`
+}


### PR DESCRIPTION
#### What problem is this solving?

When global filter is applied, activate filter by default in PLP.
[Task](https://vtex-dev.atlassian.net/browse/TIS-112)

#### How to test it?
Before select any delivery facet:

- Select a zip code and open the PLP, the delivery facet must be selected.

- Or select a store and open the PLP, the pickup facet must be selected.

[Workspace](https://tis112--mundodocabeleireiro.myvtex.com/cabelo/marcas-de-salao/shampoo/pickup-in-point?initialMap=c,c,c&initialQuery=cabelo/marcas-de-salao/shampoo&map=category-1,category-2,category-3,shipping)

#### Screenshots or example usage:

https://github.com/user-attachments/assets/dd0657cd-5a6b-4ff3-841f-334d1292bd31


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
