### PR TITLE
fix: open the zip code and pickup modals in mobile view

### DIFF
--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -258,6 +258,8 @@ const FilterNavigator = ({
               priceRangeLayout={priceRangeLayout}
               filtersDrawerDirectionMobile={filtersDrawerDirectionMobile}
               showQuantityBadgeOnMobile={showQuantityBadgeOnMobile}
+              onOpenPostalCodeModal={() => setIsPostalCodeModalOpen(true)}
+              onOpenPickupModal={() => setisPickupModalOpen(true)}
             />
           </div>
         </div>

--- a/react/components/AccordionFilterContainer.js
+++ b/react/components/AccordionFilterContainer.js
@@ -43,6 +43,8 @@ const AccordionFilterContainer = ({
   showClearByFilter,
   updateOnFilterSelectionOnMobile,
   priceRangeLayout,
+  onOpenPostalCodeModal,
+  onOpenPickupModal,
 }) => {
   const intl = useIntl()
   const { getSettings, setQuery } = useRuntime()
@@ -205,6 +207,8 @@ const AccordionFilterContainer = ({
                 setTruncatedFacetsFetched={setTruncatedFacetsFetched}
                 onClearFilter={onClearFilter}
                 showClearByFilter={showClearByFilter}
+                onOpenPostalCodeModal={onOpenPostalCodeModal}
+                onOpenPickupModal={onOpenPickupModal}
               />
             )
         }
@@ -262,6 +266,8 @@ AccordionFilterContainer.propTypes = {
   /** Set the value of clearPriceRange prop */
   setClearPriceRange: PropTypes.func,
   onChangePriceRange: PropTypes.func,
+  onOpenPostalCodeModal: PropTypes.func,
+  onOpenPickupModal: PropTypes.func,
 }
 
 export default AccordionFilterContainer

--- a/react/components/AccordionFilterGroup.js
+++ b/react/components/AccordionFilterGroup.js
@@ -32,6 +32,8 @@ const AccordionFilterGroup = ({
   setTruncatedFacetsFetched,
   onClearFilter,
   showClearByFilter,
+  onOpenPostalCodeModal,
+  onOpenPickupModal,
 }) => {
   const { searchQuery } = useSearchPage()
   const handles = useCssHandles(CSS_HANDLES)
@@ -78,6 +80,8 @@ const AccordionFilterGroup = ({
               })
               onFilterCheck({ ...facet, title: facetTitle }, true)
             }}
+            onOpenPostalCodeModal={onOpenPostalCodeModal}
+            onOpenPickupModal={onOpenPickupModal}
           />
         ) : (
           <FacetCheckboxList

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -58,6 +58,8 @@ const FilterSidebar = ({
   priceRangeLayout,
   filtersDrawerDirectionMobile,
   showQuantityBadgeOnMobile,
+  onOpenPostalCodeModal,
+  onOpenPickupModal,
 }) => {
   const { searchQuery } = useSearchPage()
   const filterContext = useFilterNavigator()
@@ -304,6 +306,8 @@ const FilterSidebar = ({
             showClearByFilter={showClearByFilter}
             updateOnFilterSelectionOnMobile={updateOnFilterSelectionOnMobile}
             priceRangeLayout={priceRangeLayout}
+            onOpenPostalCodeModal={onOpenPostalCodeModal}
+            onOpenPickupModal={onOpenPickupModal}
           />
           <ExtensionPoint id="sidebar-close-button" onClose={handleClose} />
         </FilterNavigatorContext.Provider>


### PR DESCRIPTION
#### What problem is this solving?

Until now, only in the desktop view is it possible to open the zip code and pickup modals using the shipping filter buttons.
This PR enables to open the zip code and pickup modals from the shipping filter also in mobile view. 

#### How to test it?

In mobile view, test if the shipping filter buttons correctly trigger the zip code and pickup modals.
[Workspace](https://mobilefilter--mundodocabeleireiro.myvtex.com/)

#### Screenshots or example usage:

https://github.com/user-attachments/assets/c9583682-a185-481c-85eb-347d2ae41310

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
