### PR TITLE
fix: remove InitialQuery from facets

### DIFF
--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -70,6 +70,7 @@ const FilterSidebar = ({
     searchQuery.data.productSearch &&
     searchQuery.data.productSearch.recordsFiltered
 
+  const [ignoreGlobalShipping, setIgnoreGlobalShipping] = useState(false)
   const [filterOperations, setFilterOperations] = useState([])
   const [categoryTreeOperations, setCategoryTreeOperations] = useState([])
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
@@ -240,11 +241,15 @@ const FilterSidebar = ({
      changes the object but we do not want that on mobile */
     return {
       ...filterContext,
-      ...buildNewQueryMap(fullTextAndCollection, filterOperations, [
-        ...selectedFilters,
-      ]),
+      ...buildNewQueryMap(
+        fullTextAndCollection,
+        filterOperations,
+        [...selectedFilters],
+        ignoreGlobalShipping,
+        should => setIgnoreGlobalShipping(should)
+      ),
     }
-  }, [filterOperations, filterContext, selectedFilters])
+  }, [filterContext, filterOperations, selectedFilters, ignoreGlobalShipping])
 
   return (
     <Fragment>

--- a/react/hooks/useFacetNavigation.js
+++ b/react/hooks/useFacetNavigation.js
@@ -228,7 +228,16 @@ const useFacetNavigation = (selectedFacets, scrollToTop = 'none') => {
       isReset = false,
       priceRange = undefined
     ) => {
-      const facets = Array.isArray(maybeFacets) ? maybeFacets : [maybeFacets]
+      const { initialQuery, initialMap } = runtimeQuery
+
+      let facets = Array.isArray(maybeFacets) ? maybeFacets : [maybeFacets]
+
+      if (initialQuery) {
+        facets = facets.filter(
+          facet => !initialQuery.split('/').includes(facet.value)
+        )
+      }
+
       const { query: currentQuery, map: currentMap } = buildNewQueryMap(
         mainSearches,
         facets,
@@ -303,8 +312,6 @@ const useFacetNavigation = (selectedFacets, scrollToTop = 'none') => {
       }
 
       if (!newQuery) {
-        const { initialQuery, initialMap } = runtimeQuery
-
         if (!initialQuery || !initialMap) {
           return
         }


### PR DESCRIPTION
#### What problem is this solving?

When the shipping facet is selected in the mobile view, and the filters are later cleared, the 'ignore' flag is added to the path, removing the initialQuery path.
This PR removes InitialQuery facets from the facets selected in the filter and ensures that the ignore path is added at the end of the initialQuery path.

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

Select a shipping facet in the mobile view and clean the filters.
The expected path format is: {{initialQuery}}/ignore 

[Workspace](https://dpmobile--mundodocabeleireiro.myvtex.com/cabelo/marcas-de-salao/shampoo/)

#### Screenshots or example usage:

https://github.com/user-attachments/assets/228843f3-21ba-4d22-ab8e-cbb559266868
<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
