### PR TITLE
[workaround] fix bug where reset doesn't work when dp is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix bug where reset doesn't work when dp is enabled
+
 ## [3.138.7] - 2025-09-03
 
 ## [3.138.6] - 2025-09-03

--- a/react/components/FilterSidebar.js
+++ b/react/components/FilterSidebar.js
@@ -77,6 +77,8 @@ const FilterSidebar = ({
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
   const currentTree = useCategoryTree(tree, categoryTreeOperations)
 
+  const [ignoreGlobalShipping, setIgnoreGlobalShipping] = useState(false)
+
   /* Sometimes there are categories included in selectedFilters
    * This useMemo extracts only filters that users can
    * enable and disable directly */
@@ -160,6 +162,10 @@ const FilterSidebar = ({
       push,
     })
 
+    if (!key) {
+      setOpen(false)
+    }
+
     const isClearByFacet = !!key
 
     shouldClear.current =
@@ -191,7 +197,12 @@ const FilterSidebar = ({
       return
     }
 
-    setFilterOperations(facetsToRemove)
+    if (!key) {
+      setFilterOperations([])
+    } else {
+      setFilterOperations(facetsToRemove)
+    }
+
     navigateToFacet(facetsToRemove, preventRouteChange, !isClearByFacet)
   }
 
@@ -242,11 +253,15 @@ const FilterSidebar = ({
      changes the object but we do not want that on mobile */
     return {
       ...filterContext,
-      ...buildNewQueryMap(fullTextAndCollection, filterOperations, [
-        ...selectedFilters,
-      ]),
+      ...buildNewQueryMap(
+        fullTextAndCollection,
+        filterOperations,
+        [...selectedFilters],
+        ignoreGlobalShipping,
+        should => setIgnoreGlobalShipping(should)
+      ),
     }
-  }, [filterOperations, filterContext, selectedFilters])
+  }, [filterOperations, filterContext, selectedFilters, ignoreGlobalShipping])
 
   return (
     <Fragment>

--- a/react/hooks/useFacetNavigation.js
+++ b/react/hooks/useFacetNavigation.js
@@ -237,6 +237,10 @@ const useFacetNavigation = (selectedFacets, scrollToTop = 'none') => {
         should => setIgnoreGlobalShipping(should)
       )
 
+      if (isReset) {
+        setIgnoreGlobalShipping(false)
+      }
+
       if (scrollToTop !== 'none') {
         window.scroll({ top: 0, left: 0, behavior: scrollToTop })
       }
@@ -302,7 +306,7 @@ const useFacetNavigation = (selectedFacets, scrollToTop = 'none') => {
         urlParams.set('priceRange', priceRange)
       }
 
-      if (!newQuery) {
+      if (!newQuery || newQuery === 'ignore') {
         const { initialQuery, initialMap } = runtimeQuery
 
         if (!initialQuery || !initialMap) {


### PR DESCRIPTION
#### What problem is this solving?

This PR fix a bug where the user is not able to reset the filters. It is described [here](https://vtex.enterprise.slack.com/lists/T02BCPD0X/F08RTRZ03S5?record_id=Rec0972MC4B5M)

This is a workaround, and will only be properly solved [here](https://vtex.enterprise.slack.com/lists/T02BCPD0X/F08RTRZ03S5?record_id=Rec099ZBYUTJR)

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://bugignore--mundodocabeleireiro.myvtex.com/)

