### PR TITLE
Feat/add search id onimpression

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,9 +5,7 @@
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "scripts": {
     "postreleasy": "vtex publish --verbose"
   },

--- a/react/SearchResultFlexible.js
+++ b/react/SearchResultFlexible.js
@@ -199,6 +199,8 @@ const SearchResultFlexible = ({
 
   const showLoading = searchQuery.loading && !state.isFetchingMore
 
+  const searchId = searchQuery?.data?.productSearch?.searchId
+
   return (
     <SearchPageContext.Provider value={context}>
       <SearchPageStateContext.Provider value={state}>
@@ -230,7 +232,12 @@ const SearchResultFlexible = ({
                     blockClass
                   )}`}
                 >
-                  {children}
+                  <div
+                    data-af-onimpression={searchId ? true : undefined}
+                    data-af-search-id={searchId}
+                  >
+                    {children}
+                  </div>
                 </div>
               </LoadingOverlay>
             </SearchResultContainer>

--- a/react/components/GalleryLayoutRow.tsx
+++ b/react/components/GalleryLayoutRow.tsx
@@ -7,6 +7,7 @@ import { useRenderOnView } from '../hooks/useRenderOnView'
 import GalleryItem from './GalleryLayoutItem'
 import type { Product } from '../Gallery'
 import type { PreferredSKU } from '../GalleryLayout'
+import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
 
 const CSS_HANDLES = ['galleryItem'] as const
 
@@ -52,6 +53,9 @@ const GalleryLayoutRow: React.FC<GalleryLayoutRowProps> = ({
     return dummyElement
   }
 
+  const { searchQuery } = useSearchPage()
+  const searchId = searchQuery?.data?.productSearch?.searchId
+  
   return (
     <>
       {products.map((product, index) => {
@@ -59,6 +63,8 @@ const GalleryLayoutRow: React.FC<GalleryLayoutRowProps> = ({
 
         return (
           <div
+            data-af-onclick={searchId ? true : undefined}
+            data-af-search-id={searchId}
             key={product.cacheId}
             style={style}
             className={classNames(

--- a/react/components/GalleryLayoutRow.tsx
+++ b/react/components/GalleryLayoutRow.tsx
@@ -2,12 +2,12 @@ import type { ComponentType } from 'react'
 import React, { memo } from 'react'
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 import classNames from 'classnames'
+import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
 
 import { useRenderOnView } from '../hooks/useRenderOnView'
 import GalleryItem from './GalleryLayoutItem'
 import type { Product } from '../Gallery'
 import type { PreferredSKU } from '../GalleryLayout'
-import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
 
 const CSS_HANDLES = ['galleryItem'] as const
 
@@ -37,6 +37,7 @@ const GalleryLayoutRow: React.FC<GalleryLayoutRowProps> = ({
   listName,
   preferredSKU,
 }) => {
+  const { searchQuery } = useSearchPage()
   const handles = useCssHandles(CSS_HANDLES)
 
   const style = {
@@ -53,9 +54,8 @@ const GalleryLayoutRow: React.FC<GalleryLayoutRowProps> = ({
     return dummyElement
   }
 
-  const { searchQuery } = useSearchPage()
   const searchId = searchQuery?.data?.productSearch?.searchId
-  
+
   return (
     <>
       {products.map((product, index) => {


### PR DESCRIPTION
This pull request adds analytics tracking attributes to key components in the search and gallery layouts. The main goal is to expose the `searchId` from the search context and attach it to rendered elements for impression and click tracking, enabling improved analytics integration.

**Analytics Tracking Enhancements:**

* [`react/SearchResultFlexible.js`](diffhunk://#diff-795377d833d04d69d0d8be746d024371b9976239283ee4df38e47a2aed4ca041R202-R203): Extracts `searchId` from the search context and adds `data-af-onimpression` and `data-af-search-id` attributes to the container div for impression tracking. [[1]](diffhunk://#diff-795377d833d04d69d0d8be746d024371b9976239283ee4df38e47a2aed4ca041R202-R203) [[2]](diffhunk://#diff-795377d833d04d69d0d8be746d024371b9976239283ee4df38e47a2aed4ca041R234-R241)

* [`react/components/GalleryLayoutRow.tsx`](diffhunk://#diff-6b794a4b7188e3e6bff17db7a0a7ca32243459fcb7494becb387c7e9b5f620a8R10): Uses the search context to access `searchId` and adds `data-af-onclick` and `data-af-search-id` attributes to each gallery item for click tracking. [[1]](diffhunk://#diff-6b794a4b7188e3e6bff17db7a0a7ca32243459fcb7494becb387c7e9b5f620a8R10) [[2]](diffhunk://#diff-6b794a4b7188e3e6bff17db7a0a7ca32243459fcb7494becb387c7e9b5f620a8R56-R67)