### PR TITLE
refactor: streamline loading overlay structure and retain data attrib…

### DIFF
--- a/react/SearchResultFlexible.js
+++ b/react/SearchResultFlexible.js
@@ -225,6 +225,8 @@ const SearchResultFlexible = ({
             >
               <LoadingOverlay loading={showLoading}>
                 <div
+                  data-af-onimpression={searchId ? true : undefined}
+                  data-af-search-id={searchId}
                   className={`${
                     handles.loadingOverlay
                   } w-100 flex flex-column flex-grow-1 ${generateBlockClass(
@@ -232,12 +234,7 @@ const SearchResultFlexible = ({
                     blockClass
                   )}`}
                 >
-                  <div
-                    data-af-onimpression={searchId ? true : undefined}
-                    data-af-search-id={searchId}
-                  >
-                    {children}
-                  </div>
+                  {children}
                 </div>
               </LoadingOverlay>
             </SearchResultContainer>


### PR DESCRIPTION
This pull request makes a small adjustment to the layout structure in the `SearchResultFlexible` component. The main change is moving the `data-af-onimpression` and `data-af-search-id` attributes up one level in the DOM, so they are now applied directly to the outer container div instead of a nested child. This ensures that these data attributes are present on the correct element for tracking or analytics purposes.