### PR TITLE
Release v3.138.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.138.8] - 2025-09-04
+
 ## [3.138.7] - 2025-09-03
 
 ## [3.138.6] - 2025-09-03

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "3.138.7",
+  "version": "3.138.8",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",


### PR DESCRIPTION
This pull request introduces a new patch release for the `search-result` project. The changes are versioning-related and do not include any code or feature modifications.

Versioning updates:

* Bumped the project version from `3.138.7` to `3.138.8` in `manifest.json` to prepare for a new release.
* Added a new entry for version `3.138.8` dated 2025-09-04 in the `CHANGELOG.md` file.