### PR TITLE
fix: data attribute for product position in GalleryLayoutRow component

### DIFF
--- a/react/components/GalleryLayoutRow.tsx
+++ b/react/components/GalleryLayoutRow.tsx
@@ -65,7 +65,7 @@ const GalleryLayoutRow: React.FC<GalleryLayoutRowProps> = ({
           <div
             data-af-onclick={searchId ? true : undefined}
             data-af-search-id={searchId}
-            data-af-product-position={index + 1}
+            data-af-product-position={absoluteProductIndex}
             key={product.cacheId}
             style={style}
             className={classNames(


### PR DESCRIPTION
This pull request makes a small adjustment to the way product positions are tracked in the `GalleryLayoutRow` component. Instead of using the relative index, it now uses `absoluteProductIndex` to set the `data-af-product-position` attribute.