### PR TITLE
feat: add data attribute `data-af-product-id` to GalleryLayoutRow com…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+ - Add data attributes to GalleryLayoutRow: `data-af-product-id`
+
 ## [3.140.0] - 2025-09-12
 
 ## [3.139.1] - 2025-09-11

--- a/react/components/GalleryLayoutRow.tsx
+++ b/react/components/GalleryLayoutRow.tsx
@@ -63,9 +63,10 @@ const GalleryLayoutRow: React.FC<GalleryLayoutRowProps> = ({
 
         return (
           <div
-            data-af-onclick={searchId ? true : undefined}
+            data-af-onclick={searchId && product.productId ? true : undefined}
             data-af-search-id={searchId}
             data-af-product-position={absoluteProductIndex}
+            data-af-product-id={product.productId}
             key={product.cacheId}
             style={style}
             className={classNames(


### PR DESCRIPTION
This pull request introduces a new data attribute to the `GalleryLayoutRow` component to help identify products in the gallery layout. The main change is the addition of the `data-af-product-id` attribute for each product row, which can be useful for tracking and analytics.

Enhancements to product row data attributes:

* [`react/components/GalleryLayoutRow.tsx`](diffhunk://#diff-6b794a4b7188e3e6bff17db7a0a7ca32243459fcb7494becb387c7e9b5f620a8L66-R69): Added `data-af-product-id={product.productId}` to the gallery row, and updated the logic for `data-af-onclick` to require both `searchId` and `product.productId`.
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R12): Documented the addition of the `data-af-product-id` attribute to `GalleryLayoutRow`.