### PR TITLE
[STR-691] Feat/delivery option radio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `delivery-options` to be rendered as radio
+- Bunch of new tests for radio implementation
+
+### Changed
+
+- Logic to display a radio button instead of checkbox
+
 ## [3.140.0] - 2025-09-12
 
 ## [3.139.1] - 2025-09-11

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -168,7 +168,11 @@ const FilterNavigator = ({
     ...delivery,
     facets: delivery.facets.map(facet => ({
       ...facet,
-      name: intl.formatMessage({ id: shippingOptions[facet.name] }),
+      name: shippingOptions[facet.name]
+        ? intl.formatMessage({
+            id: shippingOptions[facet.name],
+          })
+        : facet.name,
     })),
   }))
 

--- a/react/__mocks__/vtex.styleguide.js
+++ b/react/__mocks__/vtex.styleguide.js
@@ -30,6 +30,24 @@ export class Checkbox extends Component {
   }
 }
 
+export const RadioGroup = ({ options = [], value, onChange, ...props }) => (
+  <div data-testid={props['data-testid'] || 'radio-group'}>
+    {options.map(option => (
+      <label key={option.id}>
+        <input
+          type="radio"
+          name={props.name}
+          value={option.value}
+          checked={value === option.value}
+          disabled={option.disabled}
+          onChange={e => onChange && onChange({ currentTarget: e.target })}
+        />
+        {option.label}
+      </label>
+    ))}
+  </div>
+)
+
 export function IconCaret() {
   return <div>IconCaretLeft</div>
 }

--- a/react/__tests__/components/FilterOptionTemplate.test.js
+++ b/react/__tests__/components/FilterOptionTemplate.test.js
@@ -255,6 +255,104 @@ describe('<FilterOptionTemplate />', () => {
     )
   }
 
+  const radioFiltersMock = [
+    {
+      key: 'shipping',
+      name: 'Delivery',
+      value: 'shipping',
+      selected: false,
+      quantity: 1,
+      map: 'shipping',
+    },
+    {
+      key: 'shipping',
+      name: 'Pickup',
+      value: 'pickup',
+      selected: false,
+      quantity: 1,
+      map: 'shipping',
+    },
+  ]
+
+  const deliveryOptionsFiltersMock = [
+    {
+      key: 'delivery-options',
+      name: 'Express',
+      value: 'express',
+      selected: false,
+      quantity: 1,
+      map: 'delivery-options',
+    },
+    {
+      key: 'delivery-options',
+      name: 'Standard',
+      value: 'standard',
+      selected: false,
+      quantity: 1,
+      map: 'delivery-options',
+    },
+  ]
+
+  it('should render RadioFilters and handle radio selection', () => {
+    const mockNavigateRadio = jest.fn()
+    const radioProps = {
+      ...mockProps,
+      filters: radioFiltersMock,
+      title: 'Shipping',
+      navigateToFacet: mockNavigateRadio,
+      isSelectedFiltersSection: false,
+    }
+
+    const { getByLabelText, getByTestId } = render(
+      <SettingsContext.Provider value={{ thresholdForFacetSearch: 10 }}>
+        <FilterOptionTemplate {...radioProps}>
+          {/* children required */}
+          {() => null}
+        </FilterOptionTemplate>
+      </SettingsContext.Provider>
+    )
+
+    expect(getByTestId('radio-filters')).toBeInTheDocument()
+
+    const deliveryRadio = getByLabelText('Delivery')
+    const pickupRadio = getByLabelText('Pickup')
+
+    fireEvent.click(deliveryRadio)
+    expect(mockNavigateRadio).toHaveBeenCalled()
+
+    fireEvent.click(pickupRadio)
+    expect(mockNavigateRadio).toHaveBeenCalled()
+  })
+
+  it('should render RadioButton for shipping filter', () => {
+    const shippingProps = {
+      ...mockProps,
+      filters: radioFiltersMock,
+      title: 'Shipping',
+    }
+
+    const { getByText, getByTestId } = renderComponent(shippingProps)
+
+    expect(getByTestId('radio-filters')).toBeInTheDocument()
+
+    expect(getByText('Delivery')).toBeInTheDocument()
+    expect(getByText('Pickup')).toBeInTheDocument()
+  })
+
+  it('should render RadioButton for delivery-options filter', () => {
+    const deliveryOptionsProps = {
+      ...mockProps,
+      filters: deliveryOptionsFiltersMock,
+      title: 'Delivery Options',
+    }
+
+    const { getByText, getByTestId } = renderComponent(deliveryOptionsProps)
+
+    expect(getByTestId('radio-filters')).toBeInTheDocument()
+    expect(getByText('Express')).toBeInTheDocument()
+    expect(getByText('Standard')).toBeInTheDocument()
+  })
+
   it('should lazy render items', () => {
     useRuntime.mockImplementation(() => ({
       getSettings: () => {

--- a/react/__tests__/components/RadioFilters.test.js
+++ b/react/__tests__/components/RadioFilters.test.js
@@ -1,0 +1,74 @@
+import React from 'react'
+import { render, fireEvent } from '@vtex/test-tools/react'
+
+import RadioFilters from '../../components/RadioFilters'
+
+const radioFacetsMock = [
+  {
+    key: 'shipping',
+    name: 'Delivery',
+    value: 'shipping',
+    selected: false,
+    quantity: 1,
+    map: 'shipping',
+  },
+  {
+    key: 'shipping',
+    name: 'Pickup',
+    value: 'pickup',
+    selected: false,
+    quantity: 1,
+    map: 'shipping',
+  },
+]
+
+describe('<RadioFilters />', () => {
+  it('should render radio options', () => {
+    const { getByLabelText } = render(
+      <RadioFilters facets={radioFacetsMock} onChange={() => {}} />
+    )
+
+    expect(getByLabelText('Delivery')).toBeInTheDocument()
+    expect(getByLabelText('Pickup')).toBeInTheDocument()
+  })
+
+  it('should call onChange when selecting an option', () => {
+    const onChangeMock = jest.fn()
+    const { getByLabelText } = render(
+      <RadioFilters facets={radioFacetsMock} onChange={onChangeMock} />
+    )
+
+    fireEvent.click(getByLabelText('Pickup'))
+    expect(onChangeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ value: 'pickup' })
+    )
+  })
+
+  it('should set selected radio', () => {
+    const selectedFacets = [
+      { ...radioFacetsMock[0], selected: true },
+      radioFacetsMock[1],
+    ]
+
+    const { getByLabelText } = render(
+      <RadioFilters facets={selectedFacets} onChange={() => {}} />
+    )
+
+    expect(getByLabelText('Delivery')).toBeChecked()
+    expect(getByLabelText('Pickup')).not.toBeChecked()
+  })
+
+  it('should disable radio when quantity is 0', () => {
+    const disabledFacets = [
+      { ...radioFacetsMock[0], quantity: 0 },
+      radioFacetsMock[1],
+    ]
+
+    const { getByLabelText } = render(
+      <RadioFilters facets={disabledFacets} onChange={() => {}} />
+    )
+
+    expect(getByLabelText('Delivery')).toBeDisabled()
+    expect(getByLabelText('Pickup')).not.toBeDisabled()
+  })
+})

--- a/react/__tests__/useFacetNavigation.test.js
+++ b/react/__tests__/useFacetNavigation.test.js
@@ -1,6 +1,8 @@
 import { renderHook, act } from '@testing-library/react-hooks'
 
-import useFacetNavigation from '../hooks/useFacetNavigation'
+import useFacetNavigation, {
+  buildNewQueryMap,
+} from '../hooks/useFacetNavigation'
 // eslint-disable-next-line jest/no-mocks-import
 import { useRuntime } from '../__mocks__/vtex.render-runtime'
 import { useFilterNavigator } from '../components/FilterNavigatorContext'
@@ -127,3 +129,73 @@ test('pass array of facets as args work', () => {
 })
 
 // We've removed the concept of preventRouteChange since the urls should be transformed to the new urls format.
+
+describe('buildNewQueryMap - RadioGroup behavior', () => {
+  const radioFacet = {
+    key: 'shipping',
+    name: 'Delivery',
+    value: 'shipping',
+    selected: false,
+    quantity: 1,
+    map: 'shipping',
+  }
+
+  const radioFacetSelected = { ...radioFacet, selected: true }
+  const otherFacet = {
+    key: 'color',
+    name: 'Red',
+    value: 'red',
+    selected: true,
+    quantity: 1,
+    map: 'color',
+  }
+
+  it('removes radio facet from selectedFacets and calls onShouldIgnore(false) when not selected', () => {
+    const onShouldIgnore = jest.fn()
+    const facets = [radioFacet, otherFacet]
+    const selectedFacets = [radioFacet, otherFacet]
+    const result = buildNewQueryMap(
+      {},
+      facets,
+      selectedFacets,
+      false,
+      onShouldIgnore
+    )
+
+    expect(result.query).toContain('shipping')
+    expect(result.query).not.toContain('red')
+    expect(onShouldIgnore).toHaveBeenCalledWith(false)
+  })
+
+  it('keeps radio facet and calls onShouldIgnore(true) when selected', () => {
+    const onShouldIgnore = jest.fn()
+    const facets = [radioFacetSelected, otherFacet]
+    const selectedFacets = [radioFacetSelected, otherFacet]
+    const result = buildNewQueryMap(
+      {},
+      facets,
+      selectedFacets,
+      false,
+      onShouldIgnore
+    )
+
+    expect(result.query).toContain('ignore')
+    expect(onShouldIgnore).toHaveBeenCalledWith(true)
+  })
+
+  it('adds ignore to query and radio key to map when shouldIgnore is true and radio selected', () => {
+    const onShouldIgnore = jest.fn()
+    const facets = [radioFacetSelected, otherFacet]
+    const selectedFacets = [radioFacetSelected, otherFacet]
+    const result = buildNewQueryMap(
+      {},
+      facets,
+      selectedFacets,
+      true,
+      onShouldIgnore
+    )
+
+    expect(result.query).toContain('ignore')
+    expect(result.map).toContain('shipping')
+  })
+})

--- a/react/components/AccordionFilterGroup.js
+++ b/react/components/AccordionFilterGroup.js
@@ -12,6 +12,7 @@ import { getFilterTitle } from '../constants/SearchHelpers'
 import { searchSlugify } from '../utils/slug'
 import RadioFilters from './RadioFilters'
 import { pushFilterManipulationPixelEvent } from '../utils/filterManipulationPixelEvents'
+import { isRadioFilter } from '../constants/filterTypes'
 
 const CSS_HANDLES = ['accordionFilterOpen']
 
@@ -45,7 +46,7 @@ const AccordionFilterGroup = ({
   const facetKey = filters.length > 0 ? filters[0].key : null
   const { push } = usePixel()
 
-  const isRadio = filters.some(filter => filter.key === 'shipping')
+  const isRadio = filters.some(filter => isRadioFilter(filter.key))
 
   return (
     <AccordionFilterItem

--- a/react/components/FilterOptionTemplate.js
+++ b/react/components/FilterOptionTemplate.js
@@ -22,6 +22,7 @@ import useOutsideClick from '../hooks/useOutsideClick'
 import ShowMoreFilterButton from './ShowMoreFilterButton'
 import { useRenderOnView } from '../hooks/useRenderOnView'
 import { FACETS_RENDER_THRESHOLD } from '../constants/filterConstants'
+import { isRadioFilter } from '../constants/filterTypes'
 import RadioFilters from './RadioFilters'
 
 /** Returns true if elementRef has ever been scrolled */
@@ -168,7 +169,7 @@ const FilterOptionTemplate = ({
 
     const isRadio =
       !isSelectedFiltersSection &&
-      filters.some(filter => filter.key === 'shipping')
+      filters.some(filter => isRadioFilter(filter.key))
 
     return (
       <>

--- a/react/components/RadioFilters.js
+++ b/react/components/RadioFilters.js
@@ -58,9 +58,10 @@ const RadioFilters = ({
 
   return (
     <RadioGroup
+      data-testid="radio-filters"
       hideBorder
       size="small"
-      name="shipping"
+      name={facets[0]?.key || 'radio-group'}
       options={facets.map(facet => ({
         id: facet.value,
         value: facet.value,

--- a/react/constants/filterTypes.ts
+++ b/react/constants/filterTypes.ts
@@ -1,0 +1,17 @@
+/**
+ * Types of radio filters available in the application
+ */
+const RADIO_FILTER_TYPES = {
+  SHIPPING: 'shipping',
+  DELIVERY_OPTIONS: 'delivery-options',
+}
+
+/**
+ * Checks if a filter key corresponds to a radio filter type
+ * @param {string} key - Filter key to check
+ * @returns {boolean} True if the key belongs to a radio filter type
+ */
+export const isRadioFilter = (key: string): boolean =>
+  Object.values(RADIO_FILTER_TYPES).includes(key)
+
+export default RADIO_FILTER_TYPES

--- a/react/hooks/useFacetNavigation.js
+++ b/react/hooks/useFacetNavigation.js
@@ -190,10 +190,10 @@ export const buildNewQueryMap = (
   }
 
   const querySegments = selectedFacets.map(facet => facet.value)
-
   const mapSegments = selectedFacets.map(facet => facet.map)
+  const shouldAddIgnoreSegment = shouldIgnore && selectedShippingFacet
 
-  if (shouldIgnore && selectedShippingFacet && selectedShippingFacet.key) {
+  if (shouldAddIgnoreSegment) {
     querySegments.push('ignore')
     mapSegments.push(selectedShippingFacet.key)
   }

--- a/react/hooks/useFacetNavigation.js
+++ b/react/hooks/useFacetNavigation.js
@@ -44,8 +44,6 @@ export const compareFacetWithQueryValues = (
   mapSegment,
   facet
 ) => {
-  if (!facet || !facet.value) return false
-
   return (
     decodeURIComponent(querySegment).toLowerCase() ===
       decodeURIComponent(facet.value).toLowerCase() && mapSegment === facet.map
@@ -57,11 +55,11 @@ const replaceQueryForNewQueryFormat = (
   mapString,
   selectedFacets
 ) => {
-  const queryArray = (queryString || '').split(PATH_SEPARATOR)
-  const mapArray = (mapString || '').split(MAP_VALUES_SEP)
+  const queryArray = queryString.split(PATH_SEPARATOR)
+  const mapArray = mapString.split(MAP_VALUES_SEP)
   const newQueryFormatArray = zip(queryArray, mapArray).map(
     ([querySegment, mapSegment]) => {
-      const facetForQuery = (selectedFacets || []).find(facet => {
+      const facetForQuery = selectedFacets.find(facet => {
         return compareFacetWithQueryValues(querySegment, mapSegment, facet)
       })
 
@@ -77,10 +75,8 @@ const replaceQueryForNewQueryFormat = (
 }
 
 const removeMapForNewURLFormat = (map, selectedFacets) => {
-  const mapArray = (map || '').split(MAP_VALUES_SEP)
-  const mapsToFilter = (selectedFacets || []).reduce((acc, facet) => {
-    if (!facet || !facet.map || !facet.value) return acc
-
+  const mapArray = map.split(MAP_VALUES_SEP)
+  const mapsToFilter = selectedFacets.reduce((acc, facet) => {
     return facet.map === MAP_CATEGORY_CHAR ||
       (facet.newQuerySegment &&
         facet.newQuerySegment.toLowerCase() !== facet.value.toLowerCase())

--- a/react/hooks/useFacetNavigation.js
+++ b/react/hooks/useFacetNavigation.js
@@ -176,7 +176,7 @@ export const buildNewQueryMap = (
   ignoreGlobalShipping,
   onShouldIgnore
 ) => {
-    // RadioGroup behavior - only apply radio logic when radio filters are actually involved
+  // RadioGroup behavior - only apply radio logic when radio filters are actually involved
   let shouldIgnore = ignoreGlobalShipping
   const selectedShippingFacet = facets?.find(facet => isRadioFilter(facet.key))
 

--- a/react/hooks/useFacetNavigation.js
+++ b/react/hooks/useFacetNavigation.js
@@ -178,14 +178,10 @@ export const buildNewQueryMap = (
 ) => {
   // RadioGroup behavior
   let shouldIgnore = ignoreGlobalShipping
-  const selectedShippingFacet = facets
-    ? facets.find(facet => facet && facet.key && isRadioFilter(facet.key))
-    : undefined
+  const selectedShippingFacet = facets?.find(facet => isRadioFilter(facet.key))
 
   if (selectedShippingFacet && !selectedShippingFacet.selected) {
-    selectedFacets = selectedFacets.filter(
-      facet => facet && facet.key && !isRadioFilter(facet.key)
-    )
+    selectedFacets = selectedFacets.filter(facet => !isRadioFilter(facet.key))
     shouldIgnore = false
     onShouldIgnore(false)
   } else if (selectedShippingFacet && selectedShippingFacet.selected) {
@@ -193,13 +189,9 @@ export const buildNewQueryMap = (
     onShouldIgnore(true)
   }
 
-  const querySegments = (selectedFacets || [])
-    .filter(facet => facet && facet.value && !facet.disabled)
-    .map(facet => facet.value)
+  const querySegments = selectedFacets.map(facet => facet.value)
 
-  const mapSegments = (selectedFacets || [])
-    .filter(facet => facet && facet.map && !facet.disabled)
-    .map(facet => facet.map)
+  const mapSegments = selectedFacets.map(facet => facet.map)
 
   if (shouldIgnore && selectedShippingFacet && selectedShippingFacet.key) {
     querySegments.push('ignore')
@@ -214,11 +206,7 @@ export const buildNewQueryMap = (
     mapSegments.push(FULLTEXT_QUERY_KEY)
   }
 
-  if (
-    typeof seller === 'string' &&
-    seller.length > 0 &&
-    mapSegments.indexOf(SELLER_QUERY_KEY) === -1
-  ) {
+  if (seller && mapSegments.indexOf(SELLER_QUERY_KEY) === -1) {
     querySegments.push(seller)
     mapSegments.push(SELLER_QUERY_KEY)
   }

--- a/react/hooks/useFacetNavigation.js
+++ b/react/hooks/useFacetNavigation.js
@@ -176,17 +176,23 @@ export const buildNewQueryMap = (
   ignoreGlobalShipping,
   onShouldIgnore
 ) => {
-  // RadioGroup behavior
+    // RadioGroup behavior - only apply radio logic when radio filters are actually involved
   let shouldIgnore = ignoreGlobalShipping
   const selectedShippingFacet = facets?.find(facet => isRadioFilter(facet.key))
 
-  if (selectedShippingFacet && !selectedShippingFacet.selected) {
-    selectedFacets = selectedFacets.filter(facet => !isRadioFilter(facet.key))
+  // Only use radio filter logic if there's actually a radio filter being processed
+  if (selectedShippingFacet) {
+    if (!selectedShippingFacet.selected) {
+      selectedFacets = selectedFacets.filter(facet => !isRadioFilter(facet.key))
+      shouldIgnore = false
+      onShouldIgnore(false)
+    } else if (selectedShippingFacet.selected) {
+      shouldIgnore = true
+      onShouldIgnore(true)
+    }
+  } else {
+    // No radio filters involved - reset shouldIgnore to prevent contamination
     shouldIgnore = false
-    onShouldIgnore(false)
-  } else if (selectedShippingFacet && selectedShippingFacet.selected) {
-    shouldIgnore = true
-    onShouldIgnore(true)
   }
 
   const querySegments = selectedFacets.map(facet => facet.value)

--- a/react/hooks/useFacetNavigation.js
+++ b/react/hooks/useFacetNavigation.js
@@ -108,15 +108,10 @@ const buildQueryAndMap = (
   facets,
   selectedFacets
 ) => {
-  const facetsToProcess = Array.isArray(facets) ? facets : []
-  const queryAndMap = facetsToProcess.reduce(
+  const queryAndMap = facets.reduce(
     // The spread on facet is important so we can assign facet.newQuerySegment
     ({ query, map }, { ...facet }) => {
-      if (!facet) {
-        return { query, map }
-      }
-
-      const facetValue = facet.value || ''
+      const facetValue = facet.value
 
       facet.newQuerySegment = newFacetPathName(facet)
       if (facet.selected) {
@@ -140,25 +135,21 @@ const buildQueryAndMap = (
 
       if (facet.map === MAP_CATEGORY_CHAR) {
         const lastCategoryIndex = map.lastIndexOf(MAP_CATEGORY_CHAR)
-        const insertionPoint =
-          lastCategoryIndex >= 0 ? lastCategoryIndex + 1 : map.length
 
-        // Insert at the correct position while maintaining other segments
-        const newQuery = [
-          ...query.slice(0, insertionPoint),
-          facetValue,
-          ...query.slice(insertionPoint),
-        ]
-
-        const newMap = [
-          ...map.slice(0, insertionPoint),
-          facet.map,
-          ...map.slice(insertionPoint),
-        ]
-
-        return {
-          query: newQuery,
-          map: newMap,
+        if (lastCategoryIndex >= 0 && lastCategoryIndex !== map.length - 1) {
+          // Corner case: if we are adding a category but there are other filter other than category applied. Add the new category filter to the right of the other categories.
+          return {
+            query: [
+              ...query.slice(0, lastCategoryIndex + 1),
+              facetValue,
+              ...query.slice(lastCategoryIndex + 1),
+            ],
+            map: [
+              ...map.slice(0, lastCategoryIndex + 1),
+              facet.map,
+              ...map.slice(lastCategoryIndex + 1),
+            ],
+          }
         }
       }
 


### PR DESCRIPTION
#### What problem is this solving?

This change unifies and centralizes the handling of radio-type filters (such as `shipping` and `delivery-options`) in the search result navigation logic. It avoids duplicated code, ensures only one radio filter is selected at a time, and improves maintainability and test coverage for these filter behaviors.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

Change the delivery options filters at the workspace

[Workspace](https://regionalization--vendemo.myvtex.com/apparel/5f6ddea8-c501-4822-a4e7-b8bbcf77d8c3?initialMap=c&initialQuery=apparel&map=category-1,delivery-options)

<img width="272" height="449" alt="image" src="https://github.com/user-attachments/assets/81dcd8fa-1ddb-4df5-8bf1-75709c227675" />


#### Summary of what was done:

- Added delivery-options as a radio-type filter alongside shipping.
- Refactored logic to handle radio filters using shared constants and utilities consistently.
- Simplified facet selection and navigation code for radio filters.
- Improved and expanded unit tests to cover radio filter scenarios.

#### Related to / Depends on

Just added the part of the code of this PR here because it's still going to be released, and without this, it's impossible to test.

https://github.com/vtex-apps/search-result/pull/719

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExaG0yZXNmcmtpNTB3cTR1emtyb3M0MjJmYzJ6czkzM29rOXp3eWVtZiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l1EsZQvlGpwhP9EgU/giphy.gif)
