### PR TITLE
feat: use logistics api format in the selectedPickup data

### DIFF
--- a/react/hooks/useShippingActions.js
+++ b/react/hooks/useShippingActions.js
@@ -42,9 +42,7 @@ const useShippingActions = facet => {
     useShippingOptionState()
 
   useEffect(() => {
-    const pickupPointLabel = selectedPickup
-      ? selectedPickup.pickupPoint.friendlyName
-      : ''
+    const pickupPointLabel = selectedPickup ? selectedPickup.pickupName : ''
 
     const label =
       eventIdentifier === 'pickupPointLabel' ? pickupPointLabel : addressLabel


### PR DESCRIPTION
#### What problem is this solving?

Currently, the front-end receives the list of pickup points in the format seller_pickpuId, while the backend deals with pickuppoints in the format account_pickupId. In order to match the formats, we are using the the seller-register to conver from seller_pickupId to account_pickupId. Now, we already have an api that we can use in front-end to get the pickupPoint in the correct format and this PR replaces the pickupPoint format to be compatible with the new API format.
[card](https://vtex.enterprise.slack.com/lists/T02BCPD0X/F08RTRZ03S5?record_id=Rec096F2CD22H)

#### How to test it?

Add a postal code and select a store.

[Workspace](https://dpcontext--vinotecamx.myvtex.com/vinos-exclusivos)

#### Screenshots or example usage:

https://github.com/user-attachments/assets/da33e76f-91b1-46c5-aaba-13f9d1426c44


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
