### PR TITLE
add shipping default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Shipping facet: when `availableShippingValues` is an empty array, only `delivery`, `pickup-in-point`, and `pickup-nearby` are shown; a non-empty array replaces that list (e.g. add `pickup-all`).
+- Refactored shipping formatting in `getFilters` by extracting `getDeliveriesFormatted`.
+
 ## [3.143.5] - 2026-03-18
 
 ### Fixed

--- a/react/utils/getFilters.js
+++ b/react/utils/getFilters.js
@@ -19,6 +19,46 @@ const BRANDS_TYPE = 'Brands'
 const PRICE_RANGES_TYPE = 'PriceRanges'
 const SPECIFICATION_FILTERS_TYPE = 'SpecificationFilters'
 
+const defaultShippingValues = ['delivery', 'pickup-in-point', 'pickup-nearby']
+
+const getDeliveriesFormatted = (
+  deliveries,
+  availableShippingValues,
+  showShippingFacet
+) => {
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const intl = useIntl()
+  const shipping = deliveries.find(d => d.name === SHIPPING_KEY)
+
+  if (!shipping) {
+    return deliveries
+  }
+
+  if (!showShippingFacet) {
+    return deliveries.filter(d => d.name !== SHIPPING_KEY)
+  }
+
+  const shippingValues =
+    availableShippingValues.length !== 0
+      ? availableShippingValues
+      : defaultShippingValues
+
+  const shippingFormatted = {
+    ...shipping,
+    title: SHIPPING_TITLE,
+    facets: shipping.facets
+      .filter(facet => shippingValues.includes(facet.name))
+      .map(facet => ({
+        ...facet,
+        name: intl.formatMessage({ id: shippingOptions[facet.name] }),
+      })),
+  }
+
+  return deliveries.map(facet =>
+    facet.name === SHIPPING_KEY ? shippingFormatted : facet
+  )
+}
+
 const getFilters = ({
   specificationFilters = [],
   priceRanges = [],
@@ -29,42 +69,11 @@ const getFilters = ({
   showShippingFacet = false,
   availableShippingValues = [],
 }) => {
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const intl = useIntl()
-
-  let deliveriesFormatted = deliveries
-
-  let shipping = deliveries.find(d => d.name === SHIPPING_KEY)
-
-  if (shipping && availableShippingValues.length !== 0) {
-    shipping = {
-      ...shipping,
-      facets: shipping.facets.filter(facet =>
-        availableShippingValues.includes(facet.name)
-      ),
-    }
-  }
-
-  if (shipping) {
-    const shippingFormattedFacetsName = {
-      ...shipping,
-      title: SHIPPING_TITLE,
-      facets: shipping.facets.map(facet => ({
-        ...facet,
-        name: intl.formatMessage({ id: shippingOptions[facet.name] }),
-      })),
-    }
-
-    deliveriesFormatted = deliveries.map(facet =>
-      facet.name === SHIPPING_KEY ? shippingFormattedFacetsName : facet
-    )
-  }
-
-  if (!showShippingFacet) {
-    deliveriesFormatted = deliveriesFormatted.filter(
-      d => d.name !== SHIPPING_KEY
-    )
-  }
+  const deliveriesFormatted = getDeliveriesFormatted(
+    deliveries,
+    availableShippingValues,
+    showShippingFacet
+  )
 
   const hiddenFacetsNames = (
     path(['specificationFilters', 'hiddenFilters'], hiddenFacets) || []


### PR DESCRIPTION
#### What problem is this solving?

 Improve delivery formatting logic in getFilters and add shipping default values.
- If availableShippingValues is empty (the default), only these three options are shown: delivery, pickup-in-point, and pickup-nearby.
- If availableShippingValues contains at least one item, that list replaces the default values. For the store to show pickup-all, it must set availableShippingValues and include the string 'pickup-all' in that array.
- Extracted delivery formatting into a separate function `getDeliveriesFormatted`.
- Enhanced readability and maintainability of the code.

[task DPT-157](https://vtex-dev.atlassian.net/browse/DPT-157)
#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://defaultshipping--mundodocabeleireiro.myvtex.com/cabelo/marcas-de-salao/shampoo)

#### Screenshots or example usage:
With availableShippingValues

<img width="291" height="378" alt="image" src="https://github.com/user-attachments/assets/6a6e102b-54ae-4bdf-ac2f-5f565b729056" />
<img width="291" height="378" alt="image" src="https://github.com/user-attachments/assets/82ca014d-d2e0-41de-9b69-7db1e43179d5" />

Default without availableShippingValues

<img width="291" height="378" alt="image" src="https://github.com/user-attachments/assets/8fb5da3d-58e1-4294-bd1d-2003f3b9d52c" />
<img width="291" height="378" alt="image" src="https://github.com/user-attachments/assets/ed5e5a95-4721-44c8-8d3c-c9ad11beb033" />


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExd2I1OTIwcnFzdWxtOWh6MGphbDFyYzhvZ3hobGxkaW40eTdzaW1wMCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/d7nd6bdypnYjGT1jP3/giphy.gif)
