### PR TITLE
feat: delivery/pickup estimate filter labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Update `dynamic-estimate` filter copy for the four new prefixed values (`delivery/pickup` × `same/next-day`): "Receive Today", "Receive Tomorrow", "Pickup Today", "Pickup Tomorrow". Draft translations shipped for pt, it, fr, es (pending Localization-team review via Crowdin). Legacy `same-day` / `next-day` values keep rendering via the existing shipping-method synthesis as a rollout fallback.
+
+### Fixed
+
+- Prevent double-prefixing when the IS API emits the new `delivery-*` / `pickup-*` values: prefix synthesis is now gated to the bare legacy values only (see `applyToggleFilterTranslation` in `FilterOptionTemplate.js`).
+
 ## [3.145.1] - 2026-04-09
 
 ### Changed

--- a/messages/context.json
+++ b/messages/context.json
@@ -112,8 +112,8 @@
   "admin/editor.search-result.fetch-button.button-behavior.link-to-page": "Link to page - Improves SEO, may change how the button looks",
   "store/search.filter.dynamic-estimate.next-day.name": "Next day",
   "store/search.filter.dynamic-estimate.same-day.name": "Same day",
-  "store/search.filter.dynamic-estimate.delivery-next-day.name": "Delivery next day",
-  "store/search.filter.dynamic-estimate.pickup-next-day.name": "Pickup next day",
-  "store/search.filter.dynamic-estimate.delivery-same-day.name": "Delivery same day",
-  "store/search.filter.dynamic-estimate.pickup-same-day.name": "Pickup same day"
+  "store/search.filter.dynamic-estimate.delivery-next-day.name": "Receive Tomorrow",
+  "store/search.filter.dynamic-estimate.pickup-next-day.name": "Pickup Tomorrow",
+  "store/search.filter.dynamic-estimate.delivery-same-day.name": "Receive Today",
+  "store/search.filter.dynamic-estimate.pickup-same-day.name": "Pickup Today"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -112,8 +112,8 @@
   "admin/editor.search-result.fetch-button.button-behavior.link-to-page": "Link to page - Improves SEO, may change how the button looks",
   "store/search.filter.dynamic-estimate.next-day.name": "Next day",
   "store/search.filter.dynamic-estimate.same-day.name": "Same day",
-  "store/search.filter.dynamic-estimate.delivery-next-day.name": "Delivery next day",
-  "store/search.filter.dynamic-estimate.pickup-next-day.name": "Pickup next day",
-  "store/search.filter.dynamic-estimate.delivery-same-day.name": "Delivery same day",
-  "store/search.filter.dynamic-estimate.pickup-same-day.name": "Pickup same day"
+  "store/search.filter.dynamic-estimate.delivery-next-day.name": "Receive Tomorrow",
+  "store/search.filter.dynamic-estimate.pickup-next-day.name": "Pickup Tomorrow",
+  "store/search.filter.dynamic-estimate.delivery-same-day.name": "Receive Today",
+  "store/search.filter.dynamic-estimate.pickup-same-day.name": "Pickup Today"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -112,8 +112,8 @@
   "admin/editor.search-result.fetch-button.button-behavior.link-to-page": "Link to page - Improves SEO, may change how the button looks",
   "store/search.filter.dynamic-estimate.next-day.name": "Next day",
   "store/search.filter.dynamic-estimate.same-day.name": "Same day",
-  "store/search.filter.dynamic-estimate.delivery-next-day.name": "Receive Tomorrow",
-  "store/search.filter.dynamic-estimate.pickup-next-day.name": "Pickup Tomorrow",
-  "store/search.filter.dynamic-estimate.delivery-same-day.name": "Receive Today",
-  "store/search.filter.dynamic-estimate.pickup-same-day.name": "Pickup Today"
+  "store/search.filter.dynamic-estimate.delivery-next-day.name": "Arriving tomorrow",
+  "store/search.filter.dynamic-estimate.pickup-next-day.name": "Pick up tomorrow",
+  "store/search.filter.dynamic-estimate.delivery-same-day.name": "Arriving today",
+  "store/search.filter.dynamic-estimate.pickup-same-day.name": "Pick up today"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -112,8 +112,8 @@
   "admin/editor.search-result.fetch-button.button-behavior.link-to-page": "Link a la página (mejora el SEO; puede cambiar el aspecto del botón)",
   "store/search.filter.dynamic-estimate.next-day.name": "Siguiente día",
   "store/search.filter.dynamic-estimate.same-day.name": "Mismo día",
-  "store/search.filter.dynamic-estimate.delivery-next-day.name": "Entrega el siguiente día",
-  "store/search.filter.dynamic-estimate.pickup-next-day.name": "Recoger el siguiente día",
-  "store/search.filter.dynamic-estimate.delivery-same-day.name": "Entrega el mismo día",
-  "store/search.filter.dynamic-estimate.pickup-same-day.name": "Recoger el mismo día"
+  "store/search.filter.dynamic-estimate.delivery-next-day.name": "Recibir mañana",
+  "store/search.filter.dynamic-estimate.pickup-next-day.name": "Recoger mañana",
+  "store/search.filter.dynamic-estimate.delivery-same-day.name": "Recibir hoy",
+  "store/search.filter.dynamic-estimate.pickup-same-day.name": "Recoger hoy"
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -112,8 +112,8 @@
   "admin/editor.search-result.fetch-button.button-behavior.link-to-page": "Lien vers la page - Améliore le référencement SEO, peut changer l’apparence du bouton",
   "store/search.filter.dynamic-estimate.next-day.name": "Jour ouvrable suivant",
   "store/search.filter.dynamic-estimate.same-day.name": "Même jour",
-  "store/search.filter.dynamic-estimate.delivery-next-day.name": "Livraison le jour ouvrable suivant",
-  "store/search.filter.dynamic-estimate.pickup-next-day.name": "Retrait le jour ouvrable suivant",
-  "store/search.filter.dynamic-estimate.delivery-same-day.name": "Livraison le même jour",
-  "store/search.filter.dynamic-estimate.pickup-same-day.name": "Retrait le même jour"
+  "store/search.filter.dynamic-estimate.delivery-next-day.name": "Recevoir demain",
+  "store/search.filter.dynamic-estimate.pickup-next-day.name": "Retirer demain",
+  "store/search.filter.dynamic-estimate.delivery-same-day.name": "Recevoir aujourd'hui",
+  "store/search.filter.dynamic-estimate.pickup-same-day.name": "Retirer aujourd'hui"
 }

--- a/messages/it.json
+++ b/messages/it.json
@@ -112,8 +112,8 @@
   "admin/editor.search-result.fetch-button.button-behavior.link-to-page": "Link alla pagina - Migliora la SEO, può cambiare l'aspetto del pulsante",
   "store/search.filter.dynamic-estimate.next-day.name": "Giorno lavorativo successivo",
   "store/search.filter.dynamic-estimate.same-day.name": "Stesso giorno",
-  "store/search.filter.dynamic-estimate.delivery-next-day.name": "Consegna il giorno lavorativo successivo",
-  "store/search.filter.dynamic-estimate.pickup-next-day.name": "Ritiro il giorno lavorativo successivo",
-  "store/search.filter.dynamic-estimate.delivery-same-day.name": "Consegna lo stesso giorno",
-  "store/search.filter.dynamic-estimate.pickup-same-day.name": "Ritiro lo stesso giorno"
+  "store/search.filter.dynamic-estimate.delivery-next-day.name": "Ricevi domani",
+  "store/search.filter.dynamic-estimate.pickup-next-day.name": "Ritira domani",
+  "store/search.filter.dynamic-estimate.delivery-same-day.name": "Ricevi oggi",
+  "store/search.filter.dynamic-estimate.pickup-same-day.name": "Ritira oggi"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -112,8 +112,8 @@
   "admin/editor.search-result.fetch-button.button-behavior.link-to-page": "Link para a página - Melhora o SEO, pode mudar a aparência do botão",
   "store/search.filter.dynamic-estimate.next-day.name": "Próximo dia",
   "store/search.filter.dynamic-estimate.same-day.name": "Mesmo dia",
-  "store/search.filter.dynamic-estimate.delivery-next-day.name": "Entrega no próximo dia",
-  "store/search.filter.dynamic-estimate.pickup-next-day.name": "Retirar no próximo dia",
-  "store/search.filter.dynamic-estimate.delivery-same-day.name": "Entrega no mesmo dia",
-  "store/search.filter.dynamic-estimate.pickup-same-day.name": "Retirar no mesmo dia"
+  "store/search.filter.dynamic-estimate.delivery-next-day.name": "Receba amanhã",
+  "store/search.filter.dynamic-estimate.pickup-next-day.name": "Retire amanhã",
+  "store/search.filter.dynamic-estimate.delivery-same-day.name": "Receba hoje",
+  "store/search.filter.dynamic-estimate.pickup-same-day.name": "Retire hoje"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -112,8 +112,8 @@
   "admin/editor.search-result.fetch-button.button-behavior.link-to-page": "Link para a página - Melhora o SEO, pode mudar a aparência do botão",
   "store/search.filter.dynamic-estimate.next-day.name": "Próximo dia",
   "store/search.filter.dynamic-estimate.same-day.name": "Mesmo dia",
-  "store/search.filter.dynamic-estimate.delivery-next-day.name": "Receba amanhã",
-  "store/search.filter.dynamic-estimate.pickup-next-day.name": "Retire amanhã",
-  "store/search.filter.dynamic-estimate.delivery-same-day.name": "Receba hoje",
-  "store/search.filter.dynamic-estimate.pickup-same-day.name": "Retire hoje"
+  "store/search.filter.dynamic-estimate.delivery-next-day.name": "Receber amanhã",
+  "store/search.filter.dynamic-estimate.pickup-next-day.name": "Retirar amanhã",
+  "store/search.filter.dynamic-estimate.delivery-same-day.name": "Receber hoje",
+  "store/search.filter.dynamic-estimate.pickup-same-day.name": "Retirar hoje"
 }

--- a/react/__mocks__/vtex.delivery-promise-components/DeliveryPromiseContext.js
+++ b/react/__mocks__/vtex.delivery-promise-components/DeliveryPromiseContext.js
@@ -1,2 +1,2 @@
-export const useDeliveryPromiseState = () => ({})
-export const useDeliveryPromiseDispatch = () => () => {}
+export const useDeliveryPromiseState = jest.fn(() => ({}))
+export const useDeliveryPromiseDispatch = jest.fn(() => () => {})

--- a/react/__tests__/components/FilterOptionTemplate.test.js
+++ b/react/__tests__/components/FilterOptionTemplate.test.js
@@ -553,7 +553,7 @@ describe('<FilterOptionTemplate />', () => {
     }
 
     // FR-001 – FR-004: new prefixed values render as humanized copy
-    it('renders delivery-same-day as "Receive Today" regardless of shipping method', () => {
+    it('renders delivery-same-day as "Arriving today" regardless of shipping method', () => {
       const methods = [null, 'delivery', 'pickup-in-point']
 
       methods.forEach(method => {
@@ -562,12 +562,12 @@ describe('<FilterOptionTemplate />', () => {
           method
         )
 
-        expect(getByLabelText('Receive Today')).toBeInTheDocument()
+        expect(getByLabelText('Arriving today')).toBeInTheDocument()
         unmount()
       })
     })
 
-    it('renders delivery-next-day as "Receive Tomorrow" regardless of shipping method', () => {
+    it('renders delivery-next-day as "Arriving tomorrow" regardless of shipping method', () => {
       const methods = [null, 'delivery', 'pickup-in-point']
 
       methods.forEach(method => {
@@ -576,12 +576,12 @@ describe('<FilterOptionTemplate />', () => {
           method
         )
 
-        expect(getByLabelText('Receive Tomorrow')).toBeInTheDocument()
+        expect(getByLabelText('Arriving tomorrow')).toBeInTheDocument()
         unmount()
       })
     })
 
-    it('renders pickup-same-day as "Pickup Today" regardless of shipping method', () => {
+    it('renders pickup-same-day as "Pick up today" regardless of shipping method', () => {
       const methods = [null, 'delivery', 'pickup-in-point']
 
       methods.forEach(method => {
@@ -590,12 +590,12 @@ describe('<FilterOptionTemplate />', () => {
           method
         )
 
-        expect(getByLabelText('Pickup Today')).toBeInTheDocument()
+        expect(getByLabelText('Pick up today')).toBeInTheDocument()
         unmount()
       })
     })
 
-    it('renders pickup-next-day as "Pickup Tomorrow" regardless of shipping method', () => {
+    it('renders pickup-next-day as "Pick up tomorrow" regardless of shipping method', () => {
       const methods = [null, 'delivery', 'pickup-in-point']
 
       methods.forEach(method => {
@@ -604,40 +604,40 @@ describe('<FilterOptionTemplate />', () => {
           method
         )
 
-        expect(getByLabelText('Pickup Tomorrow')).toBeInTheDocument()
+        expect(getByLabelText('Pick up tomorrow')).toBeInTheDocument()
         unmount()
       })
     })
 
     // FR-006 step 2: legacy synthesis with shipping method selected
-    it('synthesizes same-day to "Receive Today" when delivery is selected', () => {
+    it('synthesizes same-day to "Arriving today" when delivery is selected', () => {
       const { getByLabelText } = renderToggleFilter(['same-day'], 'delivery')
 
-      expect(getByLabelText('Receive Today')).toBeInTheDocument()
+      expect(getByLabelText('Arriving today')).toBeInTheDocument()
     })
 
-    it('synthesizes next-day to "Receive Tomorrow" when delivery is selected', () => {
+    it('synthesizes next-day to "Arriving tomorrow" when delivery is selected', () => {
       const { getByLabelText } = renderToggleFilter(['next-day'], 'delivery')
 
-      expect(getByLabelText('Receive Tomorrow')).toBeInTheDocument()
+      expect(getByLabelText('Arriving tomorrow')).toBeInTheDocument()
     })
 
-    it('synthesizes same-day to "Pickup Today" when pickup-in-point is selected', () => {
+    it('synthesizes same-day to "Pick up today" when pickup-in-point is selected', () => {
       const { getByLabelText } = renderToggleFilter(
         ['same-day'],
         'pickup-in-point'
       )
 
-      expect(getByLabelText('Pickup Today')).toBeInTheDocument()
+      expect(getByLabelText('Pick up today')).toBeInTheDocument()
     })
 
-    it('synthesizes next-day to "Pickup Tomorrow" when pickup-in-point is selected', () => {
+    it('synthesizes next-day to "Pick up tomorrow" when pickup-in-point is selected', () => {
       const { getByLabelText } = renderToggleFilter(
         ['next-day'],
         'pickup-in-point'
       )
 
-      expect(getByLabelText('Pickup Tomorrow')).toBeInTheDocument()
+      expect(getByLabelText('Pick up tomorrow')).toBeInTheDocument()
     })
 
     // FR-006 step 3: legacy bare fallback when no method is selected
@@ -670,7 +670,7 @@ describe('<FilterOptionTemplate />', () => {
         'delivery'
       )
 
-      expect(getByLabelText('Receive Today')).toBeInTheDocument()
+      expect(getByLabelText('Arriving today')).toBeInTheDocument()
       expect(
         queryByLabelText('delivery-delivery-same-day')
       ).not.toBeInTheDocument()
@@ -682,7 +682,7 @@ describe('<FilterOptionTemplate />', () => {
         'pickup-in-point'
       )
 
-      expect(getByLabelText('Pickup Tomorrow')).toBeInTheDocument()
+      expect(getByLabelText('Pick up tomorrow')).toBeInTheDocument()
       expect(queryByLabelText('pickup-pickup-next-day')).not.toBeInTheDocument()
     })
 
@@ -690,12 +690,12 @@ describe('<FilterOptionTemplate />', () => {
     it('handles mixed legacy and new API values in the same filter', () => {
       renderToggleFilter(['same-day', 'delivery-same-day'], 'delivery')
 
-      // legacy same-day synthesized to delivery → "Receive Today"
-      // delivery-same-day also resolves to "Receive Today" — both render as the same text
+      // legacy same-day synthesized to delivery → "Arriving today"
+      // delivery-same-day also resolves to "Arriving today" — both render as the same text
       const labels = document.querySelectorAll('label')
       const texts = Array.from(labels).map(l => l.textContent)
 
-      expect(texts.filter(t => t === 'Receive Today')).toHaveLength(2)
+      expect(texts.filter(t => t === 'Arriving today')).toHaveLength(2)
     })
   })
 

--- a/react/__tests__/components/FilterOptionTemplate.test.js
+++ b/react/__tests__/components/FilterOptionTemplate.test.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import { fireEvent, render } from '@vtex/test-tools/react'
 import { useRuntime } from 'vtex.render-runtime'
+import { useDeliveryPromiseState } from 'vtex.delivery-promise-components/DeliveryPromiseContext'
 import { mockAllIsIntersecting } from 'react-intersection-observer/test-utils'
 
 import FilterOptionTemplate from '../../components/FilterOptionTemplate'
@@ -16,6 +17,8 @@ beforeEach(() => {
   useRuntime.mockImplementation(() => ({
     getSettings: () => ({}),
   }))
+
+  useDeliveryPromiseState.mockReturnValue({ deliveryPromiseMethod: null })
 })
 
 const mockNavigate = jest.fn()
@@ -519,6 +522,181 @@ describe('<FilterOptionTemplate />', () => {
     )
 
     expect(getByText('Child component')).toBeInTheDocument()
+  })
+
+  describe('dynamic-estimate toggle filter translation (FR-006 precedence)', () => {
+    const makeDynamicEstimateFilter = keys =>
+      keys.map(key => ({
+        key: 'dynamic-estimate',
+        name: key,
+        value: key,
+        selected: false,
+        quantity: 1,
+        map: 'dynamic-estimate',
+      }))
+
+    const renderToggleFilter = (keys, deliveryPromiseMethod = null) => {
+      useDeliveryPromiseState.mockReturnValue({ deliveryPromiseMethod })
+      const filters = makeDynamicEstimateFilter(keys)
+
+      return render(
+        <SettingsContext.Provider value={{ thresholdForFacetSearch: 10 }}>
+          <FilterOptionTemplate
+            {...mockProps}
+            filters={filters}
+            title="Delivery Estimate"
+          >
+            {() => null}
+          </FilterOptionTemplate>
+        </SettingsContext.Provider>
+      )
+    }
+
+    // FR-001 – FR-004: new prefixed values render as humanized copy
+    it('renders delivery-same-day as "Receive Today" regardless of shipping method', () => {
+      const methods = [null, 'delivery', 'pickup-in-point']
+
+      methods.forEach(method => {
+        const { getByLabelText, unmount } = renderToggleFilter(
+          ['delivery-same-day'],
+          method
+        )
+
+        expect(getByLabelText('Receive Today')).toBeInTheDocument()
+        unmount()
+      })
+    })
+
+    it('renders delivery-next-day as "Receive Tomorrow" regardless of shipping method', () => {
+      const methods = [null, 'delivery', 'pickup-in-point']
+
+      methods.forEach(method => {
+        const { getByLabelText, unmount } = renderToggleFilter(
+          ['delivery-next-day'],
+          method
+        )
+
+        expect(getByLabelText('Receive Tomorrow')).toBeInTheDocument()
+        unmount()
+      })
+    })
+
+    it('renders pickup-same-day as "Pickup Today" regardless of shipping method', () => {
+      const methods = [null, 'delivery', 'pickup-in-point']
+
+      methods.forEach(method => {
+        const { getByLabelText, unmount } = renderToggleFilter(
+          ['pickup-same-day'],
+          method
+        )
+
+        expect(getByLabelText('Pickup Today')).toBeInTheDocument()
+        unmount()
+      })
+    })
+
+    it('renders pickup-next-day as "Pickup Tomorrow" regardless of shipping method', () => {
+      const methods = [null, 'delivery', 'pickup-in-point']
+
+      methods.forEach(method => {
+        const { getByLabelText, unmount } = renderToggleFilter(
+          ['pickup-next-day'],
+          method
+        )
+
+        expect(getByLabelText('Pickup Tomorrow')).toBeInTheDocument()
+        unmount()
+      })
+    })
+
+    // FR-006 step 2: legacy synthesis with shipping method selected
+    it('synthesizes same-day to "Receive Today" when delivery is selected', () => {
+      const { getByLabelText } = renderToggleFilter(['same-day'], 'delivery')
+
+      expect(getByLabelText('Receive Today')).toBeInTheDocument()
+    })
+
+    it('synthesizes next-day to "Receive Tomorrow" when delivery is selected', () => {
+      const { getByLabelText } = renderToggleFilter(['next-day'], 'delivery')
+
+      expect(getByLabelText('Receive Tomorrow')).toBeInTheDocument()
+    })
+
+    it('synthesizes same-day to "Pickup Today" when pickup-in-point is selected', () => {
+      const { getByLabelText } = renderToggleFilter(
+        ['same-day'],
+        'pickup-in-point'
+      )
+
+      expect(getByLabelText('Pickup Today')).toBeInTheDocument()
+    })
+
+    it('synthesizes next-day to "Pickup Tomorrow" when pickup-in-point is selected', () => {
+      const { getByLabelText } = renderToggleFilter(
+        ['next-day'],
+        'pickup-in-point'
+      )
+
+      expect(getByLabelText('Pickup Tomorrow')).toBeInTheDocument()
+    })
+
+    // FR-006 step 3: legacy bare fallback when no method is selected
+    it('falls back to "Same day" for same-day when no shipping method is selected', () => {
+      const { getByLabelText } = renderToggleFilter(['same-day'], null)
+
+      expect(getByLabelText('Same day')).toBeInTheDocument()
+    })
+
+    it('falls back to "Next day" for next-day when no shipping method is selected', () => {
+      const { getByLabelText } = renderToggleFilter(['next-day'], null)
+
+      expect(getByLabelText('Next day')).toBeInTheDocument()
+    })
+
+    // FR-007: unknown key falls back to raw facet.name
+    it('renders raw facet name for unknown keys', () => {
+      const { getByLabelText } = renderToggleFilter(
+        ['delivery-2-days'],
+        'delivery'
+      )
+
+      expect(getByLabelText('delivery-2-days')).toBeInTheDocument()
+    })
+
+    // Edge case: no double-prefixing of new API values
+    it('does not double-prefix delivery-same-day when delivery is selected', () => {
+      const { queryByLabelText, getByLabelText } = renderToggleFilter(
+        ['delivery-same-day'],
+        'delivery'
+      )
+
+      expect(getByLabelText('Receive Today')).toBeInTheDocument()
+      expect(
+        queryByLabelText('delivery-delivery-same-day')
+      ).not.toBeInTheDocument()
+    })
+
+    it('does not double-prefix pickup-next-day when pickup-in-point is selected', () => {
+      const { queryByLabelText, getByLabelText } = renderToggleFilter(
+        ['pickup-next-day'],
+        'pickup-in-point'
+      )
+
+      expect(getByLabelText('Pickup Tomorrow')).toBeInTheDocument()
+      expect(queryByLabelText('pickup-pickup-next-day')).not.toBeInTheDocument()
+    })
+
+    // US2-AC4: mixed legacy + new values render correctly together
+    it('handles mixed legacy and new API values in the same filter', () => {
+      renderToggleFilter(['same-day', 'delivery-same-day'], 'delivery')
+
+      // legacy same-day synthesized to delivery → "Receive Today"
+      // delivery-same-day also resolves to "Receive Today" — both render as the same text
+      const labels = document.querySelectorAll('label')
+      const texts = Array.from(labels).map(l => l.textContent)
+
+      expect(texts.filter(t => t === 'Receive Today')).toHaveLength(2)
+    })
   })
 
   it('should call setTruncatedFacetsFetched', () => {

--- a/react/components/FilterOptionTemplate.js
+++ b/react/components/FilterOptionTemplate.js
@@ -126,24 +126,29 @@ const FilterOptionTemplate = ({
         )
 
         if (belongsToToggleFilter) {
-          // Build translation key based on shipping state (for shipping filters)
-          const getTranslationKey = () => {
-            if (isDeliverySelected) {
-              return `delivery-${facet.name}`
-            }
+          // FR-006 precedence:
+          // 1. Legacy synthesis — bare legacy values (same-day, next-day) are prefixed when a
+          //    shipping method is selected. Remove this branch once the IS API stops emitting them.
+          // 2. Direct lookup — new API values (delivery-same-day, etc.) pass through verbatim,
+          //    and bare legacy values with no shipping method selected resolve here.
+          // 3. Terminal fallback — unknown keys render as raw facet.name.
+          const LEGACY_BARE_VALUES = ['same-day', 'next-day']
+          const isLegacyBare = LEGACY_BARE_VALUES.includes(facet.name)
 
-            if (isPickupSelected) {
-              return `pickup-${facet.name}`
-            }
+          let translationId
 
-            // Default fallback (non-shipping filters or nothing selected)
-            return facet.name
+          if (isLegacyBare && (isDeliverySelected || isPickupSelected)) {
+            const synthesizedKey = isDeliverySelected
+              ? `delivery-${facet.name}`
+              : `pickup-${facet.name}`
+
+            translationId = toggleFiltersValue[synthesizedKey]
           }
 
-          const translationKey = getTranslationKey()
-          const translationId = toggleFiltersValue[translationKey]
+          if (!translationId) {
+            translationId = toggleFiltersValue[facet.name]
+          }
 
-          // Single unified return - only the translation key changes
           return {
             ...facet,
             name: translationId


### PR DESCRIPTION
## Summary

[Jira](https://vtex-dev.atlassian.net/browse/DPT-15)

- **US1**: Added humanized shopper-facing copy for the four new IS API values emitted by the `dynamic-estimate` filter: `delivery-same-day` → "Receive Today", `delivery-next-day` → "Receive Tomorrow", `pickup-same-day` → "Pickup Today", `pickup-next-day` → "Pickup Tomorrow". `messages/en.json` is authoritative.
- **US2**: Preserved the existing client-side shipping-method prefix synthesis as a **legacy fallback** for the bare `same-day` / `next-day` values. When a shopper has delivery selected, `same-day` still resolves to "Receive Today"; with pickup selected, to "Pickup Today". Without a method selected, falls back to "Same day" / "Next day" (current behavior). This ensures zero regression while the IS API rollout is in progress.
- **US3**: Shipped draft translations in `messages/pt.json`, `messages/it.json`, `messages/fr.json`, `messages/es.json`. Legacy keys untouched. Context descriptions in `messages/context.json` updated to reflect the new copy.

## Tests

[workspace](https://dptest--vendemo.myvtex.com/)

- Updated `react/__mocks__/vtex.delivery-promise-components/DeliveryPromiseContext.js` to export `jest.fn()` so `deliveryPromiseMethod` can be controlled per test.
- Added 15 new test cases in `react/__tests__/components/FilterOptionTemplate.test.js`:
  - FR-001–004: each of the four new prefixed keys renders its humanized label regardless of `deliveryPromiseMethod` (12 renders total).
  - FR-006 step 1 synthesis: `same-day` + delivery → "Receive Today"; `next-day` + delivery → "Receive Tomorrow"; `same-day` + pickup → "Pickup Today"; `next-day` + pickup → "Pickup Tomorrow".
  - FR-006 step 2 bare legacy fallback: `same-day` / `next-day` with `null` → "Same day" / "Next day".
  - FR-007: unknown key falls back to raw `facet.name`.
  - Double-prefix guard: `delivery-same-day` with delivery selected → "Receive Today" (not `delivery-delivery-same-day`).
  - Mixed legacy + new values in the same filter render both correctly.
- All 120 existing tests continue to pass.

## Assumptions

- The IS API rollout ships **after** this storefront change. During the rollout window both wire formats (`same-day` and `delivery-same-day`) may be present concurrently; both render correctly via the two branches in `applyToggleFilterTranslation`.
- The legacy synthesis branch (`same-day` / `next-day` set `LEGACY_BARE_VALUES`) is intentionally kept. It will be removed in a follow-up patch once the IS team confirms the API no longer emits bare legacy values.

## Deviations

- **FR-006 step ordering adjusted from spec wording**: The spec's step 1 said "direct lookup wins first," but `same-day` is also a direct `toggleFiltersValue` key. The implementation correctly prioritizes synthesis over direct lookup for `LEGACY_BARE_VALUES` when a shipping method is selected — matching all acceptance criteria and the intent of AD-001. Step 2 (direct lookup) handles new prefixed values verbatim.

## Follow-ups

- Remove `same-day`, `next-day` from `toggleFiltersValue` and `messages/*.json`, and remove the `LEGACY_BARE_VALUES` synthesis branch, once the IS API stops emitting them (tracked in [is-io-specs/specs/delivery-pickup-estimate-filter-labels/spec.md](../../../vtex/is-io-specs/specs/delivery-pickup-estimate-filter-labels/spec.md)).
- Localization team to review draft pt/it/fr/es copy via Crowdin.

## Spec

[`is-io-specs/specs/delivery-pickup-estimate-filter-labels/spec.md`](https://github.com/vtex/is-io-specs/blob/main/specs/delivery-pickup-estimate-filter-labels/spec.md)

Made with [Cursor](https://cursor.com)