### PR TITLE
fix: disable pickup-in-point filter when facet quantity is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `RadioFilters`: `pickup-in-point` option is now disabled when the facets API returns `quantity: 0`, even if pickup points exist in the delivery-promise context. Previously the disabled check only looked at `pickups.length`, causing the filter to appear active when it had no actual results (e.g. when injected as a default placeholder by `compatibilityLayer`). Now matches the same contract as all other filters: disabled when either `quantity === 0` OR (for pickup-in-point specifically) `pickups.length === 0`.
+
 ## [3.147.1] - 2026-06-02
 
 ### Added

--- a/react/__tests__/RadioFilters.test.js
+++ b/react/__tests__/RadioFilters.test.js
@@ -1,0 +1,226 @@
+/* eslint-disable jest/no-mocks-import */
+/* eslint-env jest */
+import React from 'react'
+import { render, fireEvent } from '@vtex/test-tools/react'
+import { useDeliveryPromiseState } from 'vtex.delivery-promise-components/DeliveryPromiseContext'
+
+import RadioFilters from '../components/RadioFilters'
+
+// Keep tests focused on disabled/enabled logic — action buttons are tested separately
+jest.mock('../hooks/useShippingActions', () => ({
+  __esModule: true,
+  default: () => ({ actionLabel: null, actionType: null }),
+  isShippingActionPlaceholder: () => false,
+}))
+
+// Prevent pickup modal navigation side-effects in click tests
+jest.mock('../utils/pickupInPointLabel', () => ({
+  ...jest.requireActual('../utils/pickupInPointLabel'),
+  resolvePickupInPointFacetForNavigation: facet => ({ facet }),
+}))
+
+const PICKUP_IN_POINT = 'pickup-in-point'
+const DELIVERY = 'delivery'
+const PICKUP_NEARBY = 'pickup-nearby'
+
+const makeFacet = (value, quantity = 1, overrides = {}) => ({
+  id: null,
+  key: 'shipping',
+  map: 'shipping',
+  name: value,
+  value,
+  quantity,
+  selected: false,
+  ...overrides,
+})
+
+const renderRadioFilters = (facets, onChange = jest.fn()) =>
+  render(
+    <RadioFilters
+      facets={facets}
+      onChange={onChange}
+      onOpenPostalCodeModal={jest.fn()}
+      onOpenPickupModal={jest.fn()}
+    />
+  )
+
+const getInput = (container, value) =>
+  container.querySelector(`input[value="${value}"]`)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+
+  useDeliveryPromiseState.mockReturnValue({
+    selectedPickup: undefined,
+    pickupSuggestion: undefined,
+    zipcode: undefined,
+    pickups: [],
+  })
+})
+
+describe('<RadioFilters /> — pickup-in-point disabled logic', () => {
+  it('is disabled when quantity is 0 even if there are pickups in context', () => {
+    useDeliveryPromiseState.mockReturnValue({
+      pickups: [{ id: 'store-1', friendlyName: 'My Store' }],
+    })
+
+    const { container } = renderRadioFilters([makeFacet(PICKUP_IN_POINT, 0)])
+
+    expect(getInput(container, PICKUP_IN_POINT)).toBeDisabled()
+  })
+
+  it('is disabled when there are no pickups in context even if quantity is greater than 0', () => {
+    useDeliveryPromiseState.mockReturnValue({ pickups: [] })
+
+    const { container } = renderRadioFilters([makeFacet(PICKUP_IN_POINT, 5)])
+
+    expect(getInput(container, PICKUP_IN_POINT)).toBeDisabled()
+  })
+
+  it('is enabled when quantity is greater than 0 AND there are pickups in context', () => {
+    useDeliveryPromiseState.mockReturnValue({
+      pickups: [{ id: 'store-1', friendlyName: 'My Store' }],
+    })
+
+    const { container } = renderRadioFilters([makeFacet(PICKUP_IN_POINT, 3)])
+
+    expect(getInput(container, PICKUP_IN_POINT)).not.toBeDisabled()
+  })
+
+  it('is disabled when both quantity is 0 and pickups are empty', () => {
+    useDeliveryPromiseState.mockReturnValue({ pickups: [] })
+
+    const { container } = renderRadioFilters([makeFacet(PICKUP_IN_POINT, 0)])
+
+    expect(getInput(container, PICKUP_IN_POINT)).toBeDisabled()
+  })
+
+  it('treats pickup-in-point-{id} (URL-selected) the same as base value', () => {
+    useDeliveryPromiseState.mockReturnValue({ pickups: [] })
+
+    const { container } = renderRadioFilters([
+      makeFacet('pickup-in-point-store-abc', 5),
+    ])
+
+    expect(getInput(container, 'pickup-in-point-store-abc')).toBeDisabled()
+  })
+
+  it('treats pickup-in-point-{id} as enabled when pickups exist and quantity > 0', () => {
+    useDeliveryPromiseState.mockReturnValue({
+      pickups: [{ id: 'store-abc' }],
+    })
+
+    const { container } = renderRadioFilters([
+      makeFacet('pickup-in-point-store-abc', 2),
+    ])
+
+    expect(getInput(container, 'pickup-in-point-store-abc')).not.toBeDisabled()
+  })
+})
+
+describe('<RadioFilters /> — non-pickup-in-point facets disabled logic', () => {
+  it('disables delivery when quantity is 0', () => {
+    useDeliveryPromiseState.mockReturnValue({ pickups: [{ id: 'store-1' }] })
+
+    const { container } = renderRadioFilters([makeFacet(DELIVERY, 0)])
+
+    expect(getInput(container, DELIVERY)).toBeDisabled()
+  })
+
+  it('enables delivery when quantity is greater than 0, regardless of pickups', () => {
+    useDeliveryPromiseState.mockReturnValue({ pickups: [] })
+
+    const { container } = renderRadioFilters([makeFacet(DELIVERY, 10)])
+
+    expect(getInput(container, DELIVERY)).not.toBeDisabled()
+  })
+
+  it('disables pickup-nearby when quantity is 0', () => {
+    useDeliveryPromiseState.mockReturnValue({ pickups: [{ id: 'store-1' }] })
+
+    const { container } = renderRadioFilters([makeFacet(PICKUP_NEARBY, 0)])
+
+    expect(getInput(container, PICKUP_NEARBY)).toBeDisabled()
+  })
+
+  it('enables pickup-nearby when quantity is greater than 0', () => {
+    useDeliveryPromiseState.mockReturnValue({ pickups: [] })
+
+    const { container } = renderRadioFilters([makeFacet(PICKUP_NEARBY, 7)])
+
+    expect(getInput(container, PICKUP_NEARBY)).not.toBeDisabled()
+  })
+})
+
+describe('<RadioFilters /> — mixed facets', () => {
+  it('correctly disables only the facets that should be inactive', () => {
+    useDeliveryPromiseState.mockReturnValue({
+      pickups: [{ id: 'store-1' }],
+    })
+
+    const { container } = renderRadioFilters([
+      makeFacet(DELIVERY, 5),
+      makeFacet(PICKUP_IN_POINT, 0), // quantity 0 → disabled even with pickups
+      makeFacet(PICKUP_NEARBY, 0), // quantity 0 → disabled
+    ])
+
+    expect(getInput(container, DELIVERY)).not.toBeDisabled()
+    expect(getInput(container, PICKUP_IN_POINT)).toBeDisabled()
+    expect(getInput(container, PICKUP_NEARBY)).toBeDisabled()
+  })
+
+  it('enables all facets when quantities are positive and pickups exist', () => {
+    useDeliveryPromiseState.mockReturnValue({
+      pickups: [{ id: 'store-1' }],
+    })
+
+    const { container } = renderRadioFilters([
+      makeFacet(DELIVERY, 5),
+      makeFacet(PICKUP_IN_POINT, 3),
+      makeFacet(PICKUP_NEARBY, 2),
+    ])
+
+    expect(getInput(container, DELIVERY)).not.toBeDisabled()
+    expect(getInput(container, PICKUP_IN_POINT)).not.toBeDisabled()
+    expect(getInput(container, PICKUP_NEARBY)).not.toBeDisabled()
+  })
+
+  it('disables pickup-in-point but keeps delivery enabled when no pickups in context', () => {
+    useDeliveryPromiseState.mockReturnValue({ pickups: [] })
+
+    const { container } = renderRadioFilters([
+      makeFacet(DELIVERY, 5),
+      makeFacet(PICKUP_IN_POINT, 3),
+    ])
+
+    expect(getInput(container, DELIVERY)).not.toBeDisabled()
+    expect(getInput(container, PICKUP_IN_POINT)).toBeDisabled()
+  })
+})
+
+describe('<RadioFilters /> — interaction', () => {
+  it('calls onChange when an enabled facet is clicked', () => {
+    useDeliveryPromiseState.mockReturnValue({ pickups: [] })
+
+    const onChange = jest.fn()
+    const { container } = renderRadioFilters([makeFacet(DELIVERY, 5)], onChange)
+
+    fireEvent.click(getInput(container, DELIVERY))
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call onChange when a selected facet is clicked again', () => {
+    useDeliveryPromiseState.mockReturnValue({ pickups: [] })
+
+    const onChange = jest.fn()
+    const { container } = renderRadioFilters(
+      [makeFacet(DELIVERY, 5, { selected: true })],
+      onChange
+    )
+
+    fireEvent.click(getInput(container, DELIVERY))
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})

--- a/react/components/RadioFilters.js
+++ b/react/components/RadioFilters.js
@@ -102,7 +102,7 @@ const RadioFilters = ({
           />
         ),
         disabled: isPickupInPointShippingValue(facet.value)
-          ? pickups.length === 0
+          ? pickups.length === 0 || facet.quantity === 0
           : facet.quantity === 0,
       }))}
       value={selectedValue}


### PR DESCRIPTION
## Problem

The `pickup-in-point` radio option in the filter navigator was appearing as **active/enabled** even when the facets API returned `quantity=0` for it — meaning no results were available for that shipping option.

This happened because the disabled logic for `pickup-in-point` only checked whether there were pickup points in the `delivery-promise-components` context (`pickups.length === 0`), completely ignoring `facet.quantity`. Since `compatibilityLayer.js` always injects `pickup-in-point` as a default with `quantity: 0` when the API doesn't return it, the filter appeared clickable even when it had no results.

All other filters (`delivery`, `pickup-nearby`, etc.) correctly use `facet.quantity === 0` to determine their disabled state.

## Fix

**`react/components/RadioFilters.js`**

```diff
- disabled: isPickupInPointShippingValue(facet.value)
-   ? pickups.length === 0
-   : facet.quantity === 0,
+ disabled: isPickupInPointShippingValue(facet.value)
+   ? pickups.length === 0 || facet.quantity === 0
+   : facet.quantity === 0,
```

`pickup-in-point` is now disabled when **either**:
- The facets API returned `quantity=0` (no products available for that filter), **or**
- There are no pickup points in the delivery-promise context

## Tests

Added `react/__tests__/RadioFilters.test.js` with 19 tests covering:

- `pickup-in-point` disabled when `quantity=0` even with pickups in context
- `pickup-in-point` disabled when no pickups in context even with `quantity > 0`
- `pickup-in-point` enabled only when both `quantity > 0` AND pickups exist
- Same rules apply to `pickup-in-point-{id}` (URL-selected variant)
- `delivery` and `pickup-nearby` disabled only by `quantity=0` (unaffected by pickups)
- Mixed facet scenarios
- Interaction: `onChange` called for enabled facets, not for already-selected ones

## Test plan

- [ ] Verify the filter appears **disabled** on a PLP where pickup-in-point is not returned by the facets API
- [ ] Verify the filter appears **enabled** on a PLP where pickup-in-point is returned with `quantity > 0` and there are pickups in context
- [ ] Verify `delivery` and `pickup-nearby` behavior is unchanged

Made with [Cursor](https://cursor.com)