### PR TITLE
fix: use route.params.term as fallback for seller page sponsored products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `SearchResultLayout`: use `route.params.term` as fallback when `searchQuery.variables.fullText` is undefined, ensuring the sponsored products ads request uses `context: "search"` with the correct term on seller pages (`map=sellerName`, `map=seller`). See `specs/seller-page-sponsored-products-term.md` for details.
+
 ## [3.147.2] - 2026-06-05
 
 ### Fixed

--- a/react/SearchResultLayout.js
+++ b/react/SearchResultLayout.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useChildBlock, ExtensionPoint } from 'vtex.render-runtime'
+import { useChildBlock, ExtensionPoint, useRuntime } from 'vtex.render-runtime'
 import { useDevice } from 'vtex.device-detector'
 import { path, compose, equals, pathOr, isEmpty, isNil } from 'ramda'
 import { useAds } from '@vtex/ads-react'
@@ -28,12 +28,13 @@ const SearchResultLayout = props => {
   const hasMobileBlock = !!useChildBlock({ id: 'search-result-layout.mobile' })
   const hasCustomNotFound = !!useChildBlock({ id: 'search-not-found-layout' })
   const { isMobile } = useDevice()
+  const { route } = useRuntime()
 
   const sponsoredSearchResult = useAds({
     placement: 'top_search',
     type: 'product',
     amount: props?.sponsoredCount ?? 3,
-    term: searchQuery?.variables?.fullText,
+    term: searchQuery?.variables?.fullText ?? route?.params?.term,
     selectedFacets: searchQuery?.variables?.selectedFacets ?? [],
   })
 

--- a/react/__mocks__/vtex.render-runtime.js
+++ b/react/__mocks__/vtex.render-runtime.js
@@ -30,6 +30,8 @@ export const setMobileState = isMobile => {
 
 export const useRuntime = jest.fn()
 
+export const useChildBlock = jest.fn(() => null)
+
 export const ExtensionPoint = ({ id }) => <div> Extension Point: {id} </div>
 
 // eslint-disable-next-line jsx-a11y/anchor-is-valid

--- a/react/__tests__/SearchResultLayout.test.js
+++ b/react/__tests__/SearchResultLayout.test.js
@@ -3,6 +3,7 @@ import React from 'react'
 import { render } from '@vtex/test-tools/react'
 import { useDevice } from 'vtex.device-detector'
 import { useRuntime } from 'vtex.render-runtime'
+
 import SearchResultLayout from '../SearchResultLayout'
 
 jest.mock('../index', () => ({

--- a/react/__tests__/SearchResultLayout.test.js
+++ b/react/__tests__/SearchResultLayout.test.js
@@ -1,0 +1,130 @@
+/* eslint-env jest */
+import React from 'react'
+import { render } from '@vtex/test-tools/react'
+import { useDevice } from 'vtex.device-detector'
+import { useRuntime } from 'vtex.render-runtime'
+
+jest.mock('../index', () => ({
+  default: {
+    getSchema: () => ({ properties: {} }),
+  },
+}))
+
+import SearchResultLayout from '../SearchResultLayout'
+
+const mockUseAds = jest.fn(() => ({
+  ads: [],
+  failed: [],
+  isLoading: false,
+  error: undefined,
+  refresh: jest.fn(),
+}))
+
+jest.mock('@vtex/ads-react', () => ({
+  useAds: (...args) => mockUseAds(...args),
+}))
+
+const mockUseRuntime = useRuntime
+
+const baseSearchQuery = {
+  variables: {
+    selectedFacets: [],
+  },
+  data: {
+    productSearch: {
+      products: [{ id: '1' }],
+    },
+  },
+  loading: false,
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+
+  mockUseRuntime.mockImplementation(() => ({
+    route: { params: {}, pageContext: {} },
+    getSettings: () => ({}),
+  }))
+
+  useDevice.mockImplementation(() => ({ isMobile: false }))
+})
+
+describe('SearchResultLayout — sponsored products term', () => {
+  test.each([
+    ['sellerName', 'ofertec'],
+    ['seller', 'shpseller382'],
+  ])(
+    'uses route.params.term when fullText is undefined (map=%s)',
+    (mapValue, term) => {
+      mockUseRuntime.mockImplementation(() => ({
+        route: { params: { term }, pageContext: { type: 'search' } },
+        getSettings: () => ({}),
+      }))
+
+      render(
+        <SearchResultLayout
+          searchQuery={{
+            ...baseSearchQuery,
+            variables: {
+              fullText: undefined,
+              map: mapValue,
+              selectedFacets: [{ key: mapValue, value: term }],
+            },
+          }}
+        />
+      )
+
+      expect(mockUseAds).toHaveBeenCalledWith(
+        expect.objectContaining({ term })
+      )
+    }
+  )
+
+  it('uses fullText over route.params.term on regular search', () => {
+    mockUseRuntime.mockImplementation(() => ({
+      route: { params: { term: 'different-term' }, pageContext: { type: 'search' } },
+      getSettings: () => ({}),
+    }))
+
+    render(
+      <SearchResultLayout
+        searchQuery={{
+          ...baseSearchQuery,
+          variables: {
+            fullText: 'laptop',
+            map: 'ft',
+            selectedFacets: [],
+          },
+        }}
+      />
+    )
+
+    expect(mockUseAds).toHaveBeenCalledWith(
+      expect.objectContaining({ term: 'laptop' })
+    )
+  })
+
+  it('passes undefined term when neither fullText nor route.params.term is available', () => {
+    mockUseRuntime.mockImplementation(() => ({
+      route: { params: {}, pageContext: { type: 'category' } },
+      getSettings: () => ({}),
+    }))
+
+    render(
+      <SearchResultLayout
+        searchQuery={{
+          ...baseSearchQuery,
+          variables: {
+            fullText: undefined,
+            map: 'c',
+            selectedFacets: [{ key: 'c', value: 'eletronicos' }],
+          },
+        }}
+      />
+    )
+
+    expect(mockUseAds).toHaveBeenCalledWith(
+      expect.objectContaining({ term: undefined })
+    )
+  })
+})

--- a/react/__tests__/SearchResultLayout.test.js
+++ b/react/__tests__/SearchResultLayout.test.js
@@ -3,14 +3,13 @@ import React from 'react'
 import { render } from '@vtex/test-tools/react'
 import { useDevice } from 'vtex.device-detector'
 import { useRuntime } from 'vtex.render-runtime'
+import SearchResultLayout from '../SearchResultLayout'
 
 jest.mock('../index', () => ({
   default: {
     getSchema: () => ({ properties: {} }),
   },
 }))
-
-import SearchResultLayout from '../SearchResultLayout'
 
 const mockUseAds = jest.fn(() => ({
   ads: [],
@@ -50,14 +49,17 @@ beforeEach(() => {
 })
 
 describe('SearchResultLayout — sponsored products term', () => {
-  test.each([
+  it.each([
     ['sellerName', 'ofertec'],
     ['seller', 'shpseller382'],
   ])(
     'uses route.params.term when fullText is undefined (map=%s)',
     (mapValue, term) => {
       mockUseRuntime.mockImplementation(() => ({
-        route: { params: { term }, pageContext: { type: 'search' } },
+        route: {
+          params: { term },
+          pageContext: { type: 'search' },
+        },
         getSettings: () => ({}),
       }))
 
@@ -74,15 +76,16 @@ describe('SearchResultLayout — sponsored products term', () => {
         />
       )
 
-      expect(mockUseAds).toHaveBeenCalledWith(
-        expect.objectContaining({ term })
-      )
+      expect(mockUseAds).toHaveBeenCalledWith(expect.objectContaining({ term }))
     }
   )
 
   it('uses fullText over route.params.term on regular search', () => {
     mockUseRuntime.mockImplementation(() => ({
-      route: { params: { term: 'different-term' }, pageContext: { type: 'search' } },
+      route: {
+        params: { term: 'different-term' },
+        pageContext: { type: 'search' },
+      },
       getSettings: () => ({}),
     }))
 

--- a/specs/seller-page-sponsored-products-term.md
+++ b/specs/seller-page-sponsored-products-term.md
@@ -1,0 +1,136 @@
+---
+status: Approved
+---
+
+# Seller Page: Sponsored Products Term Fallback
+
+## Business Context
+
+### Problem
+
+On seller pages (e.g. `/ofertec?map=sellerName` or `/shpseller382?map=seller`), the sponsored products request is sent with `context: "home"` instead of `context: "search"`. This causes the ads system to return unrelated products — not filtered by the seller context.
+
+### Root Cause
+
+`SearchResultLayout` calls `useAds` with `term: searchQuery?.variables?.fullText`. On seller pages, `fullText` is always `undefined` because the seller name is encoded as a facet filter (`map=sellerName` or `map=seller`), not as a full-text search term (`map=ft`). The `@vtex/ads-core` SDK determines context solely from `term` — when it is `undefined`, it defaults to `"home"`.
+
+The correct term (`"ofertec"`, `"shpseller382"`) is available in `route.params.term` from `useRuntime()`, but `SearchResultLayout` does not read it.
+
+### Seller page variants
+
+| URL pattern | map value | params.term | Origin |
+|---|---|---|---|
+| `/ofertec?map=sellerName` | `sellerName` | `ofertec` | IS admin redirect (manual) |
+| `/shpseller382?map=seller` | `seller` | `shpseller382` | Native VTEX seller store URL |
+
+### Goal
+
+Pass the correct search term to `useAds` on seller pages so sponsored products requests use `context: "search"` with the seller name as `term`.
+
+### User Stories
+
+**As a store running ads on seller pages,**  
+I want sponsored product requests to use the correct search context,  
+so that ads are relevant to the seller being browsed.
+
+#### Acceptance Criteria
+
+**Given** a user navigates to a seller page (`map=sellerName` or `map=seller`)  
+**When** `SearchResultLayout` calls `useAds`  
+**Then** `term` is set to `route.params.term` (the seller name/id)  
+**And** the ads request is sent with `context: "search"` and the correct term
+
+**Given** a user navigates to a regular full-text search page (`map=ft`)  
+**When** `SearchResultLayout` calls `useAds`  
+**Then** `term` is set to `searchQuery.variables.fullText` (unchanged behavior)
+
+**Given** neither `fullText` nor `route.params.term` is available  
+**When** `SearchResultLayout` calls `useAds`  
+**Then** `term` is `undefined` (unchanged fallback behavior)
+
+### Key Scenarios
+
+| Scenario | Pre-condition | Steps | Expected result |
+|---|---|---|---|
+| Seller page via IS redirect | `fullText=undefined`, `route.params.term="ofertec"`, `map=sellerName` | Navigate to `/ofertec?map=sellerName` | `useAds` called with `term: "ofertec"` |
+| Seller store page (native) | `fullText=undefined`, `route.params.term="shpseller382"`, `map=seller` | Navigate to `/shpseller382?map=seller` | `useAds` called with `term: "shpseller382"` |
+| Regular search | `fullText="laptop"`, `route.params.term="laptop"`, `map=ft` | Search for "laptop" | `useAds` called with `term: "laptop"` (from fullText) |
+| No term available | `fullText=undefined`, `route.params.term=undefined` | Navigate to category page | `useAds` called with `term: undefined` |
+
+---
+
+## Arch Decisions
+
+### Approach
+
+Add `useRuntime()` to `SearchResultLayout` and use `route.params.term` as a fallback when `searchQuery.variables.fullText` is `undefined`.
+
+```javascript
+const { route } = useRuntime()
+
+useAds({
+  term: searchQuery?.variables?.fullText ?? route?.params?.term,
+  ...
+})
+```
+
+### Alternatives considered
+
+| Alternative | Reason rejected |
+|---|---|
+| Fix in `@vtex/ads-core` facetsAdapter (add `sellerName` extraction) | SDK change requires separate release cycle; doesn't fix the root issue (term not passed) |
+| Fix in `vtex.store/VTEXAdsProvider` (pass pageContext to AdsProvider) | Requires changes in two repos (`ads-js` + `vtex.store`); more invasive for a minimal fix |
+| Fix in `vtex.vtex-ads` usePageContext | Different ads system (banners, not product ads); separate concern |
+
+### Decision
+
+Minimal fix in `SearchResultLayout.js`. `useRuntime` is already a dependency of `vtex.render-runtime` (used by `useChildBlock` and `ExtensionPoint` in the same file). No new dependencies required. The `??` nullish coalescing ensures `fullText` takes precedence — existing behavior for all non-seller pages is unchanged.
+
+---
+
+## Technical Contract
+
+### Changed file
+
+`react/SearchResultLayout.js`
+
+### Change
+
+```diff
+- import { useChildBlock, ExtensionPoint } from 'vtex.render-runtime'
++ import { useChildBlock, ExtensionPoint, useRuntime } from 'vtex.render-runtime'
+
+  const SearchResultLayout = props => {
+    const { searchQuery } = props
+    const hasMobileBlock = !!useChildBlock({ id: 'search-result-layout.mobile' })
+    const hasCustomNotFound = !!useChildBlock({ id: 'search-not-found-layout' })
+    const { isMobile } = useDevice()
++   const { route } = useRuntime()
+
+    const sponsoredSearchResult = useAds({
+      placement: 'top_search',
+      type: 'product',
+      amount: props?.sponsoredCount ?? 3,
+-     term: searchQuery?.variables?.fullText,
++     term: searchQuery?.variables?.fullText ?? route?.params?.term,
+      selectedFacets: searchQuery?.variables?.selectedFacets ?? [],
+    })
+```
+
+### Behavior contract
+
+| Input | `fullText` | `route.params.term` | `term` passed to `useAds` |
+|---|---|---|---|
+| Full-text search | `"laptop"` | `"laptop"` | `"laptop"` |
+| Seller page (sellerName) | `undefined` | `"ofertec"` | `"ofertec"` |
+| Seller page (seller) | `undefined` | `"shpseller382"` | `"shpseller382"` |
+| Category/department page | `undefined` | `undefined` | `undefined` |
+
+### New test
+
+`react/__tests__/SearchResultLayout.test.js`
+
+Covers:
+- `useAds` receives `route.params.term` when `fullText` is undefined (seller page)
+- `useAds` receives `fullText` when both are present (regular search)
+- `useAds` receives `undefined` when neither is present


### PR DESCRIPTION
> **This change only affects the sponsored products ads request context. Search behavior and results are unchanged.**

## Summary

- `SearchResultLayout` now reads `route.params.term` via `useRuntime()` as a fallback when `searchQuery.variables.fullText` is `undefined`
- Fixes sponsored products sending `context: "home"` on seller pages (`map=sellerName`, `map=seller`)
- Adds spec at `specs/seller-page-sponsored-products-term.md`

## Root cause

On seller pages, the seller name is encoded as a facet filter — not a full-text search term — so `fullText` is always `undefined`. The `@vtex/ads-core` SDK defaults to `context: "home"` when no `term` is provided, causing unrelated sponsored products to be returned.

The correct term is already available in `route.params.term` from the runtime, but was not being read.

## Test plan

- [ ] Seller page via IS redirect (`map=sellerName`): sponsored products request sends `context: "search"` + `term: "ofertec"`
- [ ] Seller store page (`map=seller`): sponsored products request sends `context: "search"` + `term: "shpseller382"`
- [ ] Regular full-text search: behavior unchanged — `fullText` takes precedence over `route.params.term`
- [ ] Category/department pages: behavior unchanged — `term` is `undefined` when neither is available
- [ ] All 124 existing tests pass

## Related

ADSUP-295 — [Shopstar] Comportamento de página sem contexto em chamadas

🤖 Generated with [Claude Code](https://claude.com/claude-code)