### PR TITLE
Unify facet selection and fix dynamic-estimate toggle bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed `dynamic-estimate` showing above the "Filtrado Por" (Selected Filters) group on desktop. The filter now renders after Selected Filters, as intended.
 - Fixed `dynamic-estimate` toggle buttons appearing too close to the previous filter group after its title was removed. Added top padding to the headerless content area to match the spacing the title previously provided.
 - Fixed toggle filters flickering off right after being selected. The optimistic UI state was being reset by stale `facets` during the in-flight navigation/refetch; it now only re-syncs when the facets' selected state actually changes.
+- Fixed selected toggle filters rendering as unselected on the initial (server-side) render. The toggle state is now seeded from the facets on the first render instead of only after mount.
 
 ## [3.147.5] - 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Deselecting a `dynamic-estimate` toggle filter from the Selected Filters list now correctly removes it from the URL. The facet navigation logic (`useFacetNavigation`) was unified to use a single convention for all filter types: `facet.selected` always reflects the current applied state, so selected means remove and unselected means add. `ToggleFilters` was updated to pass the current state instead of the desired next state.
+
 ## [3.147.5] - 2026-06-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Deselecting a `dynamic-estimate` toggle filter from the Selected Filters list now correctly removes it from the URL. The facet navigation logic (`useFacetNavigation`) was unified to use a single convention for all filter types: `facet.selected` always reflects the current applied state, so selected means remove and unselected means add. `ToggleFilters` was updated to pass the current state instead of the desired next state.
 - Fixed `dynamic-estimate` showing above the "Filtrado Por" (Selected Filters) group on desktop. The filter now renders after Selected Filters, as intended.
+- Fixed `dynamic-estimate` toggle buttons appearing too close to the previous filter group after its title was removed. Added top padding to the headerless content area to match the spacing the title previously provided.
 
 ## [3.147.5] - 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Deselecting a `dynamic-estimate` toggle filter from the Selected Filters list now correctly removes it from the URL. The facet navigation logic (`useFacetNavigation`) was unified to use a single convention for all filter types: `facet.selected` always reflects the current applied state, so selected means remove and unselected means add. `ToggleFilters` was updated to pass the current state instead of the desired next state.
 - Fixed `dynamic-estimate` showing above the "Filtrado Por" (Selected Filters) group on desktop. The filter now renders after Selected Filters, as intended.
 - Fixed `dynamic-estimate` toggle buttons appearing too close to the previous filter group after its title was removed. Added top padding to the headerless content area to match the spacing the title previously provided.
+- Fixed toggle filters flickering off right after being selected. The optimistic UI state was being reset by stale `facets` during the in-flight navigation/refetch; it now only re-syncs when the facets' selected state actually changes.
 
 ## [3.147.5] - 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Deselecting a `dynamic-estimate` toggle filter from the Selected Filters list now correctly removes it from the URL. The facet navigation logic (`useFacetNavigation`) was unified to use a single convention for all filter types: `facet.selected` always reflects the current applied state, so selected means remove and unselected means add. `ToggleFilters` was updated to pass the current state instead of the desired next state.
+- Fixed `dynamic-estimate` showing above the "Filtrado Por" (Selected Filters) group on desktop. The filter now renders after Selected Filters, as intended.
 
 ## [3.147.5] - 2026-06-24
 

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -312,6 +312,14 @@ const FilterNavigator = ({
                 filtersTitleHtmlTag={filtersTitleHtmlTag}
               />
             </div>
+            <SelectedFilters
+              filters={selectedFilters}
+              preventRouteChange={preventRouteChange}
+              navigateToFacet={navigateToFacet}
+              onOpenPostalCodeModal={() => setIsPostalCodeModalOpen(true)}
+              onOpenPickupModal={() => setisPickupModalOpen(true)}
+              showShippingMethodFacet={showShippingMethodFacet}
+            />
             {estimateFilter && (
               <AvailableFilters
                 filters={[estimateFilter]}
@@ -332,14 +340,6 @@ const FilterNavigator = ({
                 onOpenPickupModal={() => setisPickupModalOpen(true)}
               />
             )}
-            <SelectedFilters
-              filters={selectedFilters}
-              preventRouteChange={preventRouteChange}
-              navigateToFacet={navigateToFacet}
-              onOpenPostalCodeModal={() => setIsPostalCodeModalOpen(true)}
-              onOpenPickupModal={() => setisPickupModalOpen(true)}
-              showShippingMethodFacet={showShippingMethodFacet}
-            />
             <DepartmentFilters
               title={CATEGORIES_TITLE}
               tree={tree}

--- a/react/__tests__/components/ToggleFilters.test.js
+++ b/react/__tests__/components/ToggleFilters.test.js
@@ -40,10 +40,12 @@ describe('<ToggleFilters />', () => {
 
     fireEvent.click(getByLabelText('Same Day'))
 
+    // The toggle passes the facet with its CURRENT state (off). The navigation
+    // layer flips it (not selected => add).
     expect(onChangeMock).toHaveBeenCalledWith(
       expect.objectContaining({
         value: 'same-day',
-        selected: true,
+        selected: false,
       })
     )
   })
@@ -90,12 +92,12 @@ describe('<ToggleFilters />', () => {
       <ToggleFilters facets={toggleFacetsMock} onChange={mockOnChange} />
     )
 
-    // Primeiro, seleciona 'Same Day'
+    // Primeiro, seleciona 'Same Day' (estado atual: off)
     fireEvent.click(getByLabelText('Same Day'))
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.objectContaining({
         value: 'same-day',
-        selected: true,
+        selected: false,
       })
     )
 
@@ -107,7 +109,7 @@ describe('<ToggleFilters />', () => {
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.objectContaining({
         value: 'next-day',
-        selected: true,
+        selected: false,
       })
     )
   })
@@ -130,12 +132,12 @@ describe('<ToggleFilters />', () => {
     expect(getByLabelText('Same Day')).toBeChecked()
     expect(getByLabelText('Next Day')).not.toBeChecked()
 
-    // Clique deve funcionar normalmente
+    // Clique deve funcionar normalmente; o payload carrega o estado atual (off)
     fireEvent.click(getByLabelText('Next Day'))
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.objectContaining({
         value: 'next-day',
-        selected: true, // Deve ser booleano true
+        selected: false,
       })
     )
   })
@@ -152,7 +154,7 @@ describe('<ToggleFilters />', () => {
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.objectContaining({
         value: 'same-day',
-        selected: true, // Deve extrair corretamente o boolean
+        selected: false,
       })
     )
   })

--- a/react/__tests__/components/ToggleFilters.test.js
+++ b/react/__tests__/components/ToggleFilters.test.js
@@ -142,6 +142,29 @@ describe('<ToggleFilters />', () => {
     )
   })
 
+  it('keeps the optimistic selection while a re-render delivers stale facets', () => {
+    // Regression: clicking a toggle optimistically selects it, then onChange
+    // triggers navigation. Until the refetch lands, the component re-renders
+    // with a brand new `facets` array reference that still reports the old
+    // (unselected) state. The toggle must NOT flicker back to off.
+    const { getByLabelText, rerender } = render(
+      <ToggleFilters facets={toggleFacetsMock} onChange={() => {}} />
+    )
+
+    fireEvent.click(getByLabelText('Same Day'))
+    expect(getByLabelText('Same Day')).toBeChecked()
+
+    // New array reference, same (stale) selected state.
+    rerender(
+      <ToggleFilters
+        facets={toggleFacetsMock.map(facet => ({ ...facet }))}
+        onChange={() => {}}
+      />
+    )
+
+    expect(getByLabelText('Same Day')).toBeChecked()
+  })
+
   it('should handle SyntheticEvent from Toggle onChange correctly', () => {
     const mockOnChange = jest.fn()
     const { getByLabelText } = render(

--- a/react/__tests__/components/ToggleFilters.test.js
+++ b/react/__tests__/components/ToggleFilters.test.js
@@ -142,6 +142,22 @@ describe('<ToggleFilters />', () => {
     )
   })
 
+  it('reflects the selected facet on the initial render (no flash from SSR)', () => {
+    // The selected state must be correct on the very first render, before any
+    // effect runs, so a page refresh does not momentarily show it unselected.
+    const selectedFacets = [
+      { ...toggleFacetsMock[0], selected: true },
+      { ...toggleFacetsMock[1], selected: false },
+    ]
+
+    const { getByLabelText } = render(
+      <ToggleFilters facets={selectedFacets} onChange={() => {}} />
+    )
+
+    expect(getByLabelText('Same Day')).toBeChecked()
+    expect(getByLabelText('Next Day')).not.toBeChecked()
+  })
+
   it('keeps the optimistic selection while a re-render delivers stale facets', () => {
     // Regression: clicking a toggle optimistically selects it, then onChange
     // triggers navigation. Until the refetch lands, the component re-renders

--- a/react/__tests__/useFacetNavigation.test.js
+++ b/react/__tests__/useFacetNavigation.test.js
@@ -214,17 +214,11 @@ describe('buildNewQueryMap - RadioGroup behavior', () => {
       selected: true,
     }
 
-    const toggleFacetNotSelected = {
-      key: 'dynamic-estimate',
-      value: 'same-day',
-      map: 'dynamic-estimate',
-      selected: false,
-    }
-
     it('should remove other toggle filters of same group when selecting a new one', () => {
       const onShouldIgnore = jest.fn()
       const selectedFacets = [toggleFacetSameDay] // same-day already selected
-      const facets = [toggleFacetNextDay] // selecting next-day
+      // selecting next-day: it is not applied yet, so its current state is false
+      const facets = [{ ...toggleFacetNextDay, selected: false }]
 
       const result = buildNewQueryMap(
         {},
@@ -244,7 +238,8 @@ describe('buildNewQueryMap - RadioGroup behavior', () => {
     it('should not use ignore pattern for toggle filters', () => {
       const onShouldIgnore = jest.fn()
       const selectedFacets = []
-      const facets = [toggleFacetSameDay]
+      // selecting same-day: not applied yet, current state is false
+      const facets = [{ ...toggleFacetSameDay, selected: false }]
 
       const result = buildNewQueryMap(
         {},
@@ -262,7 +257,8 @@ describe('buildNewQueryMap - RadioGroup behavior', () => {
     it('should remove toggle filter when deselected', () => {
       const onShouldIgnore = jest.fn()
       const selectedFacets = [toggleFacetSameDay] // same-day already selected
-      const facets = [toggleFacetNotSelected] // deselecting same-day
+      // deselecting same-day: its current state is selected (true)
+      const facets = [toggleFacetSameDay]
 
       const result = buildNewQueryMap(
         {},
@@ -286,7 +282,8 @@ describe('buildNewQueryMap - RadioGroup behavior', () => {
       }
 
       const selectedFacets = [radioPickupFacet] // radio already selected
-      const facets = [toggleFacetSameDay] // selecting toggle
+      // selecting toggle: not applied yet, current state is false
+      const facets = [{ ...toggleFacetSameDay, selected: false }]
 
       const result = buildNewQueryMap(
         {},
@@ -302,6 +299,28 @@ describe('buildNewQueryMap - RadioGroup behavior', () => {
       expect(result.map).toContain('delivery-options')
       expect(result.map).toContain('dynamic-estimate')
       expect(onShouldIgnore).toHaveBeenCalledWith(false) // toggle selected, so no ignore
+    })
+
+    // Regression: deselecting an applied toggle through the Selected Filters
+    // checkbox. That checkbox (FacetItem) passes the facet with its CURRENT
+    // state (`selected: true` for an applied filter), unlike the Toggle control
+    // which passes the desired next state. The navigation must remove the toggle
+    // from the URL when it is clicked while currently selected.
+    it('removes an already-selected toggle when clicked with its current state (Selected Filters checkbox)', () => {
+      const onShouldIgnore = jest.fn()
+      const selectedFacets = [toggleFacetSameDay] // currently applied
+      const facets = [{ ...toggleFacetSameDay, selected: true }] // clicked as-is
+
+      const result = buildNewQueryMap(
+        {},
+        facets,
+        selectedFacets,
+        false,
+        onShouldIgnore
+      )
+
+      expect(result.query).not.toContain('same-day')
+      expect(onShouldIgnore).toHaveBeenCalledWith(false)
     })
 
     it('should select radio when toggle is already selected', () => {

--- a/react/__tests__/utils/getFilters.test.js
+++ b/react/__tests__/utils/getFilters.test.js
@@ -79,7 +79,9 @@ describe('getFilters delivery group titles', () => {
     expect(deliveryOption.title).not.toBe('Default Title')
   })
 
-  it('orders the dynamic-estimate group first over all other filters', () => {
+  it('includes the dynamic-estimate group in filters without reordering it', () => {
+    // getFilters no longer hoists dynamic-estimate to position 0;
+    // the FilterNavigator renders it after SelectedFilters ("Filtrado Por").
     const filters = renderGetFilters({
       deliveries: [
         makeGroup('delivery-options'),
@@ -96,7 +98,7 @@ describe('getFilters delivery group titles', () => {
       ],
     })
 
-    expect(filters[0].name).toBe('dynamic-estimate')
+    expect(filters.some(f => f.name === 'dynamic-estimate')).toBe(true)
   })
 
   it('titles the shipping group with the shipping title id and keeps its header', () => {

--- a/react/components/FilterOptionTemplate.js
+++ b/react/components/FilterOptionTemplate.js
@@ -398,6 +398,7 @@ const FilterOptionTemplate = ({
         className={classNames(handles.filterTemplateOverflow, {
           'overflow-y-auto': collapsable,
           pb5: !collapsable || isOpen,
+          pt5: hideHeader,
         })}
         ref={scrollable}
         data-testid="scrollable-element"

--- a/react/components/ToggleFilters.js
+++ b/react/components/ToggleFilters.js
@@ -38,9 +38,10 @@ const ToggleFilters = ({ facets, onChange }) => {
       }))
     }
 
-    const updatedFacet = { ...clickedFacet, selected: isChecked }
-
-    onChange(updatedFacet)
+    // Pass the facet with its CURRENT selected state. The navigation layer
+    // uses a single convention (selected => remove, not selected => add), so
+    // toggles must not pre-invert here like they used to.
+    onChange({ ...clickedFacet })
   }
 
   return (

--- a/react/components/ToggleFilters.js
+++ b/react/components/ToggleFilters.js
@@ -1,8 +1,20 @@
 import React, { useEffect, useState } from 'react'
 import { Toggle } from 'vtex.styleguide'
 
+const buildToggleStates = facets =>
+  facets.reduce(
+    (states, facet) => ({ ...states, [facet.value]: Boolean(facet.selected) }),
+    {}
+  )
+
 const ToggleFilters = ({ facets, onChange }) => {
-  const [toggleStates, setToggleStates] = useState({})
+  // Seed from the facets on the first render (lazy initializer) so the
+  // server-side render and the initial client render already reflect the
+  // selected state. Otherwise the toggle renders unselected until the effect
+  // below runs after mount.
+  const [toggleStates, setToggleStates] = useState(() =>
+    buildToggleStates(facets)
+  )
 
   // `facets` is a new array reference on every render, so we sync the local
   // (optimistic) state only when the actual selected state of the facets
@@ -14,12 +26,7 @@ const ToggleFilters = ({ facets, onChange }) => {
     .join('|')
 
   useEffect(() => {
-    const initialStates = {}
-
-    facets.forEach(facet => {
-      initialStates[facet.value] = Boolean(facet.selected)
-    })
-    setToggleStates(initialStates)
+    setToggleStates(buildToggleStates(facets))
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [facetsSelectionSignature])
 

--- a/react/components/ToggleFilters.js
+++ b/react/components/ToggleFilters.js
@@ -4,6 +4,15 @@ import { Toggle } from 'vtex.styleguide'
 const ToggleFilters = ({ facets, onChange }) => {
   const [toggleStates, setToggleStates] = useState({})
 
+  // `facets` is a new array reference on every render, so we sync the local
+  // (optimistic) state only when the actual selected state of the facets
+  // changes. Depending on `facets` directly would re-run this effect on every
+  // render and clobber the optimistic update with stale data while a
+  // navigation/refetch is still in flight, making the toggle flicker off.
+  const facetsSelectionSignature = facets
+    .map(facet => `${facet.value}:${facet.selected ? 1 : 0}`)
+    .join('|')
+
   useEffect(() => {
     const initialStates = {}
 
@@ -11,7 +20,8 @@ const ToggleFilters = ({ facets, onChange }) => {
       initialStates[facet.value] = Boolean(facet.selected)
     })
     setToggleStates(initialStates)
-  }, [facets])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [facetsSelectionSignature])
 
   const onToggleChange = (facetValue, isChecked) => {
     const clickedFacet = facets.find(facet => facet.value === facetValue)

--- a/react/hooks/useFacetNavigation.js
+++ b/react/hooks/useFacetNavigation.js
@@ -244,29 +244,26 @@ const buildQueryAndMap = (
     // The spread on facet is important so we can assign facet.newQuerySegment
     ({ query, map }, { ...facet }) => {
       const facetValue = facet.value
-      const isToggle = isToggleFilter(facet.key)
 
       facet.newQuerySegment = newFacetPathName(facet)
 
-      // Handle deselection for toggle filters (selected=false means removing from URL)
-      if (isToggle && !facet.selected) {
+      // Single, unified convention: `facet.selected` is always the CURRENT
+      // applied state, for every filter type. A selected facet is being removed
+      // from the URL; a non-selected facet is being added to it.
+      if (facet.selected) {
         return handleFacetDeselection(query, map, facet, selectedFacets)
       }
 
-      // Handle deselection for radio/other filters (selected=true means removing from URL)
-      if (!isToggle && facet.selected) {
-        return handleFacetDeselection(query, map, facet, selectedFacets)
-      }
-
-      // Handle selection for toggle filters (selected=true means adding to URL)
-      if (isToggle && facet.selected) {
+      // Single-option filters (radio + toggle) keep at most one applied member
+      // per group, so selecting one drops the others of the same group. Every
+      // other filter (category, brand, specification, price) is just appended.
+      if (isSingleOptionFilter(facet.key)) {
         const result = handleFacetSelection(query, map, facet, selectedFacets)
 
         query = result.query
         map = result.map
         selectedFacets = result.selectedFacets
-      } else if (!isToggle && !facet.selected) {
-        // Handle selection for radio/other filters (selected=false or undefined means adding to URL)
+      } else {
         upsert(selectedFacets, facet)
       }
 

--- a/react/utils/getFilters.js
+++ b/react/utils/getFilters.js
@@ -159,17 +159,6 @@ const getFilters = ({
       },
   ].filter(Boolean)
 
-  // The dynamic-estimate group must be the first filter to show up over all others.
-  const estimateIndex = filters.findIndex(
-    filter => filter.name === DYNAMIC_ESTIMATE_KEY
-  )
-
-  if (estimateIndex > 0) {
-    const [estimate] = filters.splice(estimateIndex, 1)
-
-    filters.unshift(estimate)
-  }
-
   return filters
 }
 


### PR DESCRIPTION
## Summary

[workspace](https://dptest--vendemo.myvtex.com/)
[Jira](https://vtex-dev.atlassian.net/browse/DPT-13)

This PR fixes 4 bugs related to Toggle facets

### 1. Unselecting a toggle filter trough the Selected Facets group does nothing:

*Before:*
Unselecting the filter doesn't do nothing

https://github.com/user-attachments/assets/01b0581b-de04-42ab-84bc-46f92d8b3f8b

*After:*

https://github.com/user-attachments/assets/df66f647-5492-4420-b000-b7d5bbf4fe5e

### 2. Dynamic filter are showing up before the Selected filters

*Before:*

<img width="302" height="283" alt="image" src="https://github.com/user-attachments/assets/7f1a7a94-46ba-40e3-8bc5-97fefe36ac78" />

*After:*

<img width="276" height="318" alt="image" src="https://github.com/user-attachments/assets/42dfe26c-9ebe-49ed-a64b-5472490f7a22" />

### 3. Toggle flickers the the old state after clicked

*Before:*

https://github.com/user-attachments/assets/0c76b5db-f69a-4f34-873c-5e7b4585899e

*After:*


https://github.com/user-attachments/assets/fb7b6e89-7cc2-4907-8f4d-e96573750b1f


### 4. Toggle comes unselected from the SSR every time, even when the facet is selected. It only becomes selected after the component is hydrated

*Before:*

https://github.com/user-attachments/assets/6df8503b-3fbc-418e-a0cb-dfe1fe7fe5bd

*After:*


https://github.com/user-attachments/assets/23acc9a4-dc9b-4de9-852b-5a5a63d29741



## Test plan

- [x] `yarn test` — 156 passing
- [x] `yarn lint` — 0 errors
- [x] Regression test: deselecting an applied toggle via the Selected Filters checkbox removes it from the URL
- [x] Regression test: optimistic toggle selection survives a stale re-render (no flicker)
- [x] Regression test: selected toggle is checked on the initial render (no SSR flash)
- [x] Manual: on a PLP, apply/remove `dynamic-estimate` from both the toggle and the Selected Filters list
- [x] Manual: refresh with a toggle applied — it should render selected immediately
- [x] Manual: confirm `dynamic-estimate` renders below "Filtrado Por" with proper spacing


Made with [Cursor](https://cursor.com)



