### PR TITLE
TIS-710 Fix data-af-product-position on paginated PLP loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `data-af-product-position` on gallery items now reflects the product's rank in the search result set (accounting for the current pagination window) instead of restarting from 1 when the PLP is loaded directly at a page greater than 1.
+
 ## [3.147.5] - 2026-06-24
 
 ### Fixed

--- a/react/__tests__/GalleryLayoutRow.test.tsx
+++ b/react/__tests__/GalleryLayoutRow.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react'
+import { render } from '@vtex/test-tools/react'
+
+import GalleryLayoutRow from '../components/GalleryLayoutRow'
+import { ProductsPositionOffsetProvider } from '../components/ProductsPositionOffsetContext'
+
+const mockUseSearchPage = jest.fn()
+
+jest.mock('vtex.search-page-context/SearchPageContext', () => ({
+  useSearchPage: () => mockUseSearchPage(),
+}))
+
+jest.mock('../hooks/useRenderOnView', () => ({
+  useRenderOnView: () => ({ hasBeenViewed: true, dummyElement: null }),
+}))
+
+jest.mock('../components/GalleryLayoutItem', () => {
+  return function MockGalleryLayoutItem() {
+    return null
+  }
+})
+
+const searchQueryMock = {
+  searchQuery: {
+    data: {
+      productSearch: {
+        searchId: 'search-id',
+        redirect: null,
+      },
+    },
+  },
+}
+
+const GalleryItemComponent = () => null
+
+const createProduct = (id: string) => ({
+  cacheId: id,
+  productId: id,
+  productName: `Product ${id}`,
+  description: '',
+  categories: [],
+  linkText: id,
+  items: [],
+  specification: '',
+})
+
+const defaultProps = {
+  products: [createProduct('1'), createProduct('2')],
+  summary: {},
+  displayMode: 'normal',
+  itemsPerRow: 2,
+  rowIndex: 0,
+  listName: 'Search result',
+  currentLayoutName: 'grid',
+  lazyRender: false,
+  GalleryItemComponent,
+}
+
+const renderGalleryLayoutRow = (
+  offset: number,
+  props: Partial<typeof defaultProps> = {}
+) => {
+  mockUseSearchPage.mockReturnValue(searchQueryMock)
+
+  return render(
+    <ProductsPositionOffsetProvider value={offset}>
+      <GalleryLayoutRow {...defaultProps} {...props} />
+    </ProductsPositionOffsetProvider>
+  )
+}
+
+describe('<GalleryLayoutRow /> product position', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('uses DOM index when pagination offset is 0', () => {
+    const { container } = renderGalleryLayoutRow(0)
+
+    const positions = Array.from(
+      container.querySelectorAll('[data-af-product-position]')
+    ).map(el => el.getAttribute('data-af-product-position'))
+
+    expect(positions).toEqual(['1', '2'])
+  })
+
+  it('adds pagination offset for direct page loads', () => {
+    const { container } = renderGalleryLayoutRow(18)
+
+    const positions = Array.from(
+      container.querySelectorAll('[data-af-product-position]')
+    ).map(el => el.getAttribute('data-af-product-position'))
+
+    expect(positions).toEqual(['19', '20'])
+  })
+
+  it('accounts for row index when computing position', () => {
+    const { container } = renderGalleryLayoutRow(18, { rowIndex: 1 })
+
+    const positions = Array.from(
+      container.querySelectorAll('[data-af-product-position]')
+    ).map(el => el.getAttribute('data-af-product-position'))
+
+    expect(positions).toEqual(['21', '22'])
+  })
+})

--- a/react/__tests__/GalleryRow.test.tsx
+++ b/react/__tests__/GalleryRow.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react'
+import { render } from '@vtex/test-tools/react'
+
+import GalleryRow from '../components/GalleryRow'
+import { ProductsPositionOffsetProvider } from '../components/ProductsPositionOffsetContext'
+
+const mockUseSearchPage = jest.fn()
+
+jest.mock('vtex.search-page-context/SearchPageContext', () => ({
+  useSearchPage: () => mockUseSearchPage(),
+}))
+
+jest.mock('../hooks/useRenderOnView', () => ({
+  useRenderOnView: () => ({ hasBeenViewed: true, dummyElement: null }),
+}))
+
+jest.mock('../components/GalleryItem', () => {
+  return function MockGalleryItem() {
+    return null
+  }
+})
+
+const searchQueryMock = {
+  searchQuery: {
+    data: {
+      productSearch: {
+        searchId: 'search-id',
+        redirect: null,
+      },
+    },
+  },
+}
+
+const createProduct = (id: string) => ({
+  cacheId: id,
+  productId: id,
+  productName: `Product ${id}`,
+  description: '',
+  categories: [],
+  linkText: id,
+  items: [],
+  specification: '',
+})
+
+const defaultProps = {
+  products: [createProduct('1'), createProduct('2')],
+  summary: {},
+  displayMode: 'normal' as const,
+  itemsPerRow: 2,
+  rowIndex: 0,
+  listName: 'Search result',
+}
+
+const renderGalleryRow = (
+  offset: number,
+  props: Partial<typeof defaultProps> = {}
+) => {
+  mockUseSearchPage.mockReturnValue(searchQueryMock)
+
+  return render(
+    <ProductsPositionOffsetProvider value={offset}>
+      <GalleryRow {...defaultProps} {...props} />
+    </ProductsPositionOffsetProvider>
+  )
+}
+
+describe('<GalleryRow /> product position', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('uses DOM index when pagination offset is 0', () => {
+    const { container } = renderGalleryRow(0)
+
+    const positions = Array.from(
+      container.querySelectorAll('[data-af-product-position]')
+    ).map(el => el.getAttribute('data-af-product-position'))
+
+    expect(positions).toEqual(['1', '2'])
+  })
+
+  it('adds pagination offset for direct page loads', () => {
+    const { container } = renderGalleryRow(18)
+
+    const positions = Array.from(
+      container.querySelectorAll('[data-af-product-position]')
+    ).map(el => el.getAttribute('data-af-product-position'))
+
+    expect(positions).toEqual(['19', '20'])
+  })
+
+  it('accounts for row index when computing position', () => {
+    const { container } = renderGalleryRow(18, { rowIndex: 1 })
+
+    const positions = Array.from(
+      container.querySelectorAll('[data-af-product-position]')
+    ).map(el => el.getAttribute('data-af-product-position'))
+
+    expect(positions).toEqual(['21', '22'])
+  })
+})

--- a/react/components/GalleryLayoutRow.tsx
+++ b/react/components/GalleryLayoutRow.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
 
 import { useRenderOnView } from '../hooks/useRenderOnView'
+import { useProductsPositionOffset } from './ProductsPositionOffsetContext'
 import GalleryItem from './GalleryLayoutItem'
 import type { Product } from '../Gallery'
 import type { PreferredSKU } from '../GalleryLayout'
@@ -38,6 +39,7 @@ const GalleryLayoutRow: React.FC<GalleryLayoutRowProps> = ({
   preferredSKU,
 }) => {
   const { searchQuery } = useSearchPage()
+  const productsPositionOffset = useProductsPositionOffset()
   const handles = useCssHandles(CSS_HANDLES)
 
   const style = {
@@ -59,7 +61,9 @@ const GalleryLayoutRow: React.FC<GalleryLayoutRowProps> = ({
   return (
     <>
       {products.map((product, index) => {
-        const absoluteProductIndex = rowIndex * itemsPerRow + index + 1
+        const absoluteProductIndex =
+          productsPositionOffset + rowIndex * itemsPerRow + index + 1
+
         const shouldAddAFAttr = searchId && !redirect && product.productId
 
         return (

--- a/react/components/GalleryRow.tsx
+++ b/react/components/GalleryRow.tsx
@@ -5,6 +5,7 @@ import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
 import classNames from 'classnames'
 
 import { useRenderOnView } from '../hooks/useRenderOnView'
+import { useProductsPositionOffset } from './ProductsPositionOffsetContext'
 import GalleryItem from './GalleryItem'
 import type { Product } from '../Gallery'
 import type { MobileLayoutMode } from '../GalleryLegacy'
@@ -43,6 +44,7 @@ function GalleryRow({
   preferredSKU,
 }: GalleryRowProps) {
   const { searchQuery } = useSearchPage()
+  const productsPositionOffset = useProductsPositionOffset()
   const handles = useCssHandles(CSS_HANDLES)
 
   const style = {
@@ -64,7 +66,8 @@ function GalleryRow({
   return (
     <>
       {products.map((product, index) => {
-        const absoluteProductIndex = rowIndex * itemsPerRow + index + 1
+        const absoluteProductIndex =
+          productsPositionOffset + rowIndex * itemsPerRow + index + 1
 
         const shouldRenderCustom = !!(
           CustomSummary &&

--- a/react/components/ProductsPositionOffsetContext.tsx
+++ b/react/components/ProductsPositionOffsetContext.tsx
@@ -1,0 +1,12 @@
+import { createContext, useContext } from 'react'
+
+const ProductsPositionOffsetContext = createContext(0)
+
+export const ProductsPositionOffsetProvider =
+  ProductsPositionOffsetContext.Provider
+
+export function useProductsPositionOffset(): number {
+  return useContext(ProductsPositionOffsetContext)
+}
+
+export default ProductsPositionOffsetContext

--- a/react/components/SearchResultContainer.js
+++ b/react/components/SearchResultContainer.js
@@ -4,6 +4,7 @@ import { Container } from 'vtex.store-components'
 import { useCssHandles } from 'vtex.css-handles'
 
 import { PopupProvider } from './Popup'
+import { ProductsPositionOffsetProvider } from './ProductsPositionOffsetContext'
 import SearchResult from './SearchResult'
 import { searchResultContainerPropTypes } from '../constants/propTypes'
 import { useFetchMore } from '../hooks/useFetchMore'
@@ -108,8 +109,10 @@ const SearchResultContainer = props => {
   return (
     <Container className={`${handles.searchResultContainer} pt3-m pt5-l`}>
       <PopupProvider>
-        <div id="search-result-anchor" />
-        {isInfiniteScroll ? infiniteScrollComponent : resultComponent}
+        <ProductsPositionOffsetProvider value={from}>
+          <div id="search-result-anchor" />
+          {isInfiniteScroll ? infiniteScrollComponent : resultComponent}
+        </ProductsPositionOffsetProvider>
       </PopupProvider>
     </Container>
   )


### PR DESCRIPTION
## Summary

- Fix `data-af-product-position` so gallery items report their true rank in the search result set, not just their index within the currently rendered DOM
- Introduce `ProductsPositionOffsetContext` fed by `useFetchMore`'s live `from` offset, covering direct page loads (`?page=2`) and fetch-previous scenarios
- Apply the corrected position in both `GalleryRow` and `GalleryLayoutRow`, including pixel `productClick` events via the `position` prop

Closes [TIS-710](https://vtex-dev.atlassian.net/browse/TIS-710)

## Test plan

- [x] `make check` (lint + 159 unit tests)
- [x] Search on a store with show-more pagination (e.g. Intelbras, 18 items/page)
- [x] Verify positions 1–18 on page 1
- [x] Click "Load more" → positions 1–36
- [x] Reload at `?page=2` → first product shows `data-af-product-position="19"`
- [x] From page 2, click "Fetch previous" → positions 1–36 with correct sequence
- [ ] Repeat on flexible layout (`search-result-layout` + gallery layout options)

[TIS-710]: https://vtex-dev.atlassian.net/browse/TIS-710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ