### PR TITLE
Always render delivery facets at the top in a fixed order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- The three delivery-promise filter groups now always render at the top of the `filter-navigator.v2` / `.v3` in a fixed sequence: **Dynamic Estimate → Shipping Method → Delivery Option**. Ordering is enforced once in `getFilters` (`sortDeliveryGroups`) regardless of the order returned by the Intelligent Search API, so the flat filter list leads with the delivery groups on both desktop and mobile; unknown delivery groups keep their API-relative order after the three known ones. `dynamic-estimate` still renders headerless on desktop, and the title's bottom border is dropped while it is the first group. (Accounts that surface delivery filters do not surface a category tree, so `DepartmentFilters` renders null and the delivery groups stay at the top; the previous desktop-only hoist was removed as redundant.)
+
 ## [3.148.0] - 2026-06-30
 
 ### Added

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -226,21 +226,15 @@ const FilterNavigator = ({
     [visibleDeliveries, intl]
   )
 
-  // On desktop the dynamic-estimate filter renders headerless as the first
-  // filter, right below the "Filters" title. The title's bottom border is
-  // dropped while it is present, so the estimate shows no divider at its top.
-  const estimateFilter = useMemo(
-    () => filters.find(filter => filter.name === DYNAMIC_ESTIMATE_KEY),
-    [filters]
-  )
-
-  const availableFilters = useMemo(
-    () =>
-      estimateFilter
-        ? filters.filter(filter => filter !== estimateFilter)
-        : filters,
-    [filters, estimateFilter]
-  )
+  // The delivery-promise groups are already ordered first (Dynamic Estimate →
+  // Shipping Method → Delivery Option) by `getFilters` (`sortDeliveryGroups`),
+  // so the flat `filters` list renders them at the top on both desktop and
+  // mobile. On desktop `dynamic-estimate` renders headerless; when it is the
+  // first group the title's bottom border is dropped so no divider shows at
+  // its top. Accounts that surface delivery filters do not surface a category
+  // tree, so `DepartmentFilters` renders null and does not sit between the
+  // title and the estimate.
+  const hasEstimateAtTop = filters[0]?.name === DYNAMIC_ESTIMATE_KEY
 
   const { pickupModal } = useSearchPickupModal({
     navigateToFacet,
@@ -312,7 +306,7 @@ const FilterNavigator = ({
               className={`${applyModifiers(
                 handles.filter__container,
                 'title'
-              )}${estimateFilter ? '' : ' bb b--muted-4'}`}
+              )}${hasEstimateAtTop ? '' : ' bb b--muted-4'}`}
             >
               <FilterNavigatorTitleTag
                 filtersTitleHtmlTag={filtersTitleHtmlTag}
@@ -326,26 +320,6 @@ const FilterNavigator = ({
               onOpenPickupModal={() => setisPickupModalOpen(true)}
               showShippingMethodFacet={showShippingMethodFacet}
             />
-            {estimateFilter && (
-              <AvailableFilters
-                filters={[estimateFilter]}
-                priceRange={priceRange}
-                preventRouteChange={preventRouteChange}
-                initiallyCollapsed={initiallyCollapsed}
-                navigateToFacet={navigateToFacet}
-                truncatedFacetsFetched={truncatedFacetsFetched}
-                setTruncatedFacetsFetched={setTruncatedFacetsFetched}
-                truncateFilters={truncateFilters}
-                openFiltersMode={openFiltersMode}
-                closeOnOutsideClick={closeOnOutsideClick}
-                appliedFiltersOverview={appliedFiltersOverview}
-                showClearByFilter={showClearByFilter}
-                priceRangeLayout={priceRangeLayout}
-                scrollToTop={scrollToTop}
-                onOpenPostalCodeModal={() => setIsPostalCodeModalOpen(true)}
-                onOpenPickupModal={() => setisPickupModalOpen(true)}
-              />
-            )}
             <DepartmentFilters
               title={CATEGORIES_TITLE}
               tree={tree}
@@ -357,7 +331,7 @@ const FilterNavigator = ({
               categoryFiltersMode={categoryFiltersMode}
             />
             <AvailableFilters
-              filters={availableFilters}
+              filters={filters}
               priceRange={priceRange}
               preventRouteChange={preventRouteChange}
               initiallyCollapsed={initiallyCollapsed}

--- a/react/__tests__/utils/getFilters.test.js
+++ b/react/__tests__/utils/getFilters.test.js
@@ -6,6 +6,8 @@ import getFilters, {
   getDeliveryGroupTitle,
   shouldHideDeliveryGroupHeader,
   filterHiddenDeliveryGroups,
+  sortDeliveryGroups,
+  DELIVERY_GROUP_ORDER,
   SHIPPING_TITLE,
   DELIVERY_OPTION_TITLE,
   DYNAMIC_ESTIMATE_TITLE,
@@ -80,9 +82,7 @@ describe('getFilters delivery group titles', () => {
     expect(deliveryOption.title).not.toBe('Default Title')
   })
 
-  it('includes the dynamic-estimate group in filters without reordering it', () => {
-    // getFilters no longer hoists dynamic-estimate to position 0;
-    // the FilterNavigator renders it after SelectedFilters ("Filtrado Por").
+  it('includes the dynamic-estimate group in filters', () => {
     const filters = renderGetFilters({
       deliveries: [
         makeGroup('delivery-options'),
@@ -100,6 +100,40 @@ describe('getFilters delivery group titles', () => {
     })
 
     expect(filters.some(f => f.name === 'dynamic-estimate')).toBe(true)
+  })
+
+  it('sorts the delivery groups as Dynamic Estimate → Shipping Method → Delivery Option regardless of API order, keeping them ahead of specs / brands / price', () => {
+    const filters = renderGetFilters({
+      deliveries: [
+        makeGroup('delivery-options'),
+        makeGroup('shipping'),
+        makeGroup('dynamic-estimate'),
+      ],
+      showShippingMethodFacet: true,
+      brands: [{ name: 'Samsung', value: 'samsung', selected: false }],
+      brandsQuantity: 1,
+      specificationFilters: [
+        {
+          name: 'Color',
+          quantity: 1,
+          facets: [{ key: 'color', name: 'Blue', value: 'blue' }],
+        },
+      ],
+    })
+
+    const deliveryNames = filters
+      .filter(f => DELIVERY_GROUP_ORDER.includes(f.name))
+      .map(f => f.name)
+
+    expect(deliveryNames).toEqual([
+      'dynamic-estimate',
+      'shipping',
+      'delivery-options',
+    ])
+
+    expect(filters[0].name).toBe('dynamic-estimate')
+    expect(filters[1].name).toBe('shipping')
+    expect(filters[2].name).toBe('delivery-options')
   })
 
   it('titles the shipping group with the shipping title id and keeps its header', () => {
@@ -138,6 +172,47 @@ describe('getFilters delivery group titles', () => {
     expect(unknown.title).toBe('delivery-window')
     expect(unknown.title).not.toBe('Default Title')
     expect(unknown.hideHeader).toBe(false)
+  })
+})
+
+describe('sortDeliveryGroups', () => {
+  it('orders known groups as dynamic-estimate → shipping → delivery-options', () => {
+    const sorted = sortDeliveryGroups([
+      { name: 'delivery-options', facets: [] },
+      { name: 'shipping', facets: [] },
+      { name: 'dynamic-estimate', facets: [] },
+    ])
+
+    expect(sorted.map(group => group.name)).toEqual([
+      'dynamic-estimate',
+      'shipping',
+      'delivery-options',
+    ])
+  })
+
+  it('keeps unknown delivery groups after the known ones, preserving their input order (stable)', () => {
+    const sorted = sortDeliveryGroups([
+      { name: 'delivery-window-b', facets: [] },
+      { name: 'delivery-options', facets: [] },
+      { name: 'delivery-window-a', facets: [] },
+      { name: 'dynamic-estimate', facets: [] },
+    ])
+
+    expect(sorted.map(group => group.name)).toEqual([
+      'dynamic-estimate',
+      'delivery-options',
+      'delivery-window-b',
+      'delivery-window-a',
+    ])
+  })
+
+  it('handles empty / single-item / missing inputs without throwing', () => {
+    expect(sortDeliveryGroups(undefined)).toEqual([])
+    expect(sortDeliveryGroups([])).toEqual([])
+
+    const single = [{ name: 'shipping', facets: [] }]
+
+    expect(sortDeliveryGroups(single)).toEqual(single)
   })
 })
 

--- a/react/utils/getFilters.js
+++ b/react/utils/getFilters.js
@@ -19,11 +19,43 @@ export const shippingOptions = {
 
 export const SHIPPING_KEY = 'shipping'
 export const DYNAMIC_ESTIMATE_KEY = 'dynamic-estimate'
+export const DELIVERY_OPTIONS_KEY = 'delivery-options'
 
 const DELIVERY_GROUP_TITLES = {
   [SHIPPING_KEY]: SHIPPING_TITLE,
-  'delivery-options': DELIVERY_OPTION_TITLE,
+  [DELIVERY_OPTIONS_KEY]: DELIVERY_OPTION_TITLE,
   [DYNAMIC_ESTIMATE_KEY]: DYNAMIC_ESTIMATE_TITLE,
+}
+
+/**
+ * Required render order for the delivery-promise groups. Kept in sync with the
+ * top-of-navigator hoist in `FilterNavigator.js` so mobile (flat list) and
+ * desktop (hoist above the categories tree) agree on the sequence:
+ * Dynamic Estimate → Shipping Method → Delivery Option.
+ * Unknown delivery groups keep their API-relative order after the three known
+ * ones (sort is stable).
+ */
+export const DELIVERY_GROUP_ORDER = [
+  DYNAMIC_ESTIMATE_KEY,
+  SHIPPING_KEY,
+  DELIVERY_OPTIONS_KEY,
+]
+
+export const sortDeliveryGroups = deliveries => {
+  if (!deliveries || deliveries.length <= 1) {
+    return deliveries || []
+  }
+
+  const indexByName = new Map(
+    DELIVERY_GROUP_ORDER.map((name, index) => [name, index])
+  )
+
+  const priority = group =>
+    indexByName.has(group.name)
+      ? indexByName.get(group.name)
+      : Number.MAX_SAFE_INTEGER
+
+  return [...deliveries].sort((a, b) => priority(a) - priority(b))
 }
 
 /** Maps a delivery group name to its heading message id; unknown groups fall back to the raw name. */
@@ -136,7 +168,9 @@ const getDeliveriesFormatted = (
     ? allowedDeliveries
     : allowedDeliveries.filter(d => d.name !== SHIPPING_KEY)
 
-  return visibleDeliveries.map(group =>
+  const orderedDeliveries = sortDeliveryGroups(visibleDeliveries)
+
+  return orderedDeliveries.map(group =>
     formatDeliveryGroup(group, intl, availableShippingValues)
   )
 }


### PR DESCRIPTION
## Summary

Delivery-promise filter groups now **always render at the top** of `filter-navigator.v2` / `.v3`, in a fixed sequence:

**Dynamic Estimate → Shipping Method → Delivery Option**

The order is enforced **once**, in `getFilters` (`sortDeliveryGroups`), regardless of the order the Intelligent Search API returns the facets. Unknown delivery groups keep their API-relative order after the three known ones (stable sort).

Before:
<img width="299" height="485" alt="Screenshot 2026-07-02 at 00 36 15" src="https://github.com/user-attachments/assets/49334205-f3ac-45e5-93b0-bdedf0061032" />

After:
<img width="316" height="495" alt="Screenshot 2026-07-02 at 00 36 31" src="https://github.com/user-attachments/assets/62f32bf1-d562-457b-84f2-03ae9f23c5b7" />


## Why we removed the desktop hoist

Previously `FilterNavigator.js` did a desktop-only "hoist": it pulled the delivery groups out of the flat `filters` list and rendered them in a separate `AvailableFilters` block **above** the categories tree (`DepartmentFilters`), because `DepartmentFilters` is rendered from a different prop (`tree`) and sits between the selected filters and the main filter list.

That hoist is now **redundant and removable** for two reasons:

1. **`getFilters` already guarantees the order.** Since ordering is enforced in `sortDeliveryGroups`, the single flat `filters` list already leads with the delivery groups on both desktop and mobile. A second, desktop-only ordering mechanism is duplicated logic.

2. **`DepartmentFilters` is practically deprecated.** With the migration from **catalog search** to **Intelligent Search**, the category tree (`CATEGORYTREE` facet) is no longer surfaced for accounts that use delivery facets. `DepartmentFilters` renders `null` (`tree.length === 0`), so there is nothing between the title and the delivery groups — the hoist was solving a positioning problem that no longer occurs.

Net effect: a **single `AvailableFilters` render path** instead of two, less branching, and one source of truth for facet order. `dynamic-estimate` still renders headerless on desktop, and the title's bottom border is still dropped while it is the first group (`hasEstimateAtTop`).

> Note (tradeoff, on record): this now relies on the "delivery accounts don't surface a `CATEGORYTREE`" property. If an account ever surfaced both, the delivery groups would render below the category tree on desktop.

## Changes

- `react/utils/getFilters.js` — add `DELIVERY_OPTIONS_KEY`, `DELIVERY_GROUP_ORDER`, and `sortDeliveryGroups`; apply the sort in `getDeliveriesFormatted`.
- `react/FilterNavigator.js` — remove the `topDeliveryFilters` / `availableFilters` split and the extra hoisted `AvailableFilters`; render the full `filters` list; reduce `hasEstimateAtTop` to `filters[0]?.name === DYNAMIC_ESTIMATE_KEY`.
- `react/__tests__/utils/getFilters.test.js` — tests for `sortDeliveryGroups` (order + stability + empty inputs) and an end-to-end order assertion.
- `CHANGELOG.md` — `[Unreleased]` entry.

## Test plan

- [x] `yarn test __tests__/utils/getFilters.test.js` — passes (order, stability, empty-input cases)
- [x] `yarn test __tests__/FilterNavigator` — passes (no regression in category/spec navigation)
- [x] `yarn lint` — no errors
- [x] Desktop: verify Dynamic Estimate (headerless) → Shipping Method → Delivery Option at the top of the navigator
- [x] Mobile: verify the same order leads the flat filter list

Made with [Cursor](https://cursor.com)